### PR TITLE
Update docker compose file and instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,11 +27,30 @@ Copy `config.dev.php` to `config.php`. Make sure to change the admin email to yo
 You can now view the site at http://servername/ork/orkui/.
 
 ### Using Docker
-A docker-compose file is setup for quickly getting the environment running locally. With an up to date version of docker you can run
+A docker-compose file is setup for quickly getting the environment running locally. If there are other environments using port 80 change the exposed port in the docker-compose file to keep from conflicting. Same goes for 3306 for the database. Run the following Docker command from the cloned directory.
 ```
 docker-compose up
 ```
+Once this completes and MySql is waiting on a socket there are some setup tasks required. In another window issue the following commands:
+```
+mysql -P 3306 --protocol=tcp -h localhost -u ork  -p ork < ork.sql
+```
+This will setup the database.  The default password for the user 'ork' is 'secret'.
 
-You will still need to hydrate the database from a backup. If you have other environments using port 80 you may need to change the exposed port in the docker-compose file to keep from conflicting. Same goes for 3306 for the database. Out of the box and without port conflicts you should be able to run the command above, import the DB to the 'ork' database, and begin work. You may want to adjust the error reporting in config.dev.php as the codebase is old and uses deprecated methods and throws notices/deprecation messages
+Download and extract a recent Ork backup from https://amtgard.com/ork/assets/backups/
 
-A .dev.env is setup to set the database credentials. Currently this is set to what is currently in the default config.dev.php file.
+```
+mysql -P 3306 --protocol=tcp -h localhost -u ork  -p ork < ~/Downloads/2019.02.28.02.00.amtgard_ork3production.sql
+```
+This will take a while but will hydrate the database with the backup that was downloaded and extracted above.
+```
+mysql -P 3306 --protocol=tcp -h localhost -u root  -p ork 
+```
+Use the root password of root. Once the SQL prompt appears enter:
+```
+SET GLOBAL sql_mode = '';
+exit
+```
+This was needed to allow the database to accept certain values sent by the PHP APIs.
+
+Navigate to http://localhost/ork/orkui and see the contents of the backup that was restored.  Login with your ORK accound and password provided you have recently setup your password before the backup database was created on the production server.

--- a/README.md
+++ b/README.md
@@ -33,18 +33,18 @@ docker-compose up
 ```
 Once this completes and MySql is waiting on a socket there are some setup tasks required. In another window issue the following commands:
 ```
-mysql -P 3306 --protocol=tcp -h localhost -u ork  -p ork < ork.sql
+mysql -P 3306 --protocol=tcp -h localhost -u ork  -psecret < ork.sql
 ```
 This will setup the database.  The default password for the user 'ork' is 'secret'.
 
 Download and extract a recent Ork backup from https://amtgard.com/ork/assets/backups/
 
 ```
-mysql -P 3306 --protocol=tcp -h localhost -u ork  -p ork < ~/Downloads/2019.02.28.02.00.amtgard_ork3production.sql
+mysql -P 3306 --protocol=tcp -h localhost -u ork  -psecret < ~/Downloads/2019.02.28.02.00.amtgard_ork3production.sql
 ```
 This will take a while but will hydrate the database with the backup that was downloaded and extracted above.
 ```
-mysql -P 3306 --protocol=tcp -h localhost -u root  -p ork 
+mysql -P 3306 --protocol=tcp -h localhost -u root  -proot 
 ```
 Use the root password of root. Once the SQL prompt appears enter:
 ```

--- a/README.md
+++ b/README.md
@@ -33,24 +33,24 @@ docker-compose up
 ```
 Once this completes and MySql is waiting on a socket there are some setup tasks required. In another window issue the following commands:
 ```
-mysql -P 3306 --protocol=tcp -h localhost -u ork  -psecret < ork.sql
+mysql -P 3306 --protocol=tcp -h localhost -u root -proot ork < ork.sql
 ```
-This will setup the database.  The default password for the user 'ork' is 'secret'.
+This will setup the database.
 
 Download and extract a recent Ork backup from https://amtgard.com/ork/assets/backups/
 
 ```
-mysql -P 3306 --protocol=tcp -h localhost -u ork  -psecret < ~/Downloads/2019.02.28.02.00.amtgard_ork3production.sql
+mysql -P 3306 --protocol=tcp -h localhost -u root -proot ork < ~/Downloads/2019.02.28.02.00.amtgard_ork3production.sql
 ```
 This will take a while but will hydrate the database with the backup that was downloaded and extracted above.
 ```
-mysql -P 3306 --protocol=tcp -h localhost -u root  -proot 
+mysql -P 3306 --protocol=tcp -h localhost -u root -proot 
 ```
-Use the root password of root. Once the SQL prompt appears enter:
+Once the SQL prompt appears enter:
 ```
 SET GLOBAL sql_mode = '';
 exit
 ```
 This was needed to allow the database to accept certain values sent by the PHP APIs.
 
-Navigate to http://localhost/ork/orkui and see the contents of the backup that was restored.  Login with your ORK accound and password provided you have recently setup your password before the backup database was created on the production server.
+Navigate to http://localhost/ork/orkui and see the contents of the backup that was restored.  Login with your ORK account and password provided you have recently setup your password before the backup database was created on the production server.

--- a/config.dev.php
+++ b/config.dev.php
@@ -4,14 +4,15 @@ date_default_timezone_set( 'America/Chicago' );
 define( 'CONFIG', true );
 
 error_reporting( E_ALL );
-ini_set( 'display_errors', 'true' );
+ini_set( 'display_errors', 'false' );
 
 // HTTP
-define( 'HTTP_SERVICE', 'http://' . $_SERVER[ 'HTTP_HOST' ] . '/orkservice/' );
-define( 'HTTP_UI', 'http://' . $_SERVER[ 'HTTP_HOST' ] . '/orkui/' );
-define( 'HTTP_UI_REMOTE', 'http://' . $_SERVER[ 'HTTP_HOST' ] . '/orkui/' );
+define( 'ORK_DIST_NAME', 'ork');
+define( 'HTTP_SERVICE', 'http://' . $_SERVER['HTTP_HOST'] . '/' . ORK_DIST_NAME . '/orkservice/'); 
+define( 'HTTP_UI', 'http://' . $_SERVER['HTTP_HOST'] . '/' . ORK_DIST_NAME . '/orkui/'); 
+define( 'HTTP_UI_REMOTE', 'http://' . $_SERVER['HTTP_HOST'] . '/' . ORK_DIST_NAME . '/orkui/'); 
 define( 'HTTP_TEMPLATE', HTTP_UI . 'template/' );
-define( 'HTTP_ASSETS', 'http://' . $_SERVER[ 'HTTP_HOST' ] . '/assets/' );
+define( 'HTTP_ASSETS', 'http://' . $_SERVER['HTTP_HOST']. '/' . ORK_DIST_NAME . '/assets/');
 define( 'HTTP_WAIVERS', 'http://amtgard.com/ork/assets/waivers/' );
 define( 'HTTP_HERALDRY', 'http://amtgard.com/ork/assets/heraldry/' );
 define( 'HTTP_PLAYER_IMAGE', 'http://amtgard.com/ork/assets/players/' );

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,18 +8,31 @@ services:
      - 80:80
     working_dir: /var/www
     volumes:
-      - ./:/var/www/html
+      - ./:/var/www/html/ork/
     env_file: .dev.env
     container_name: ork-app
     networks:
       - orknet
   mysql:
-    image: mariadb
+    image: mysql:5.6.35
+    restart: always
+    environment:
+      MYSQL_DATABASE: 'ork'
+      # So you don't have to use root, but you can if you like
+      MYSQL_USER: 'ork'
+      # You can use whatever password you like
+      MYSQL_PASSWORD: 'secret'
+      # Password for root access
+      MYSQL_ROOT_PASSWORD: 'root'
     ports:
-     - 3306:3306
-    env_file: .dev.env
+      # <Port exposed> : < MySQL Port running inside container>
+      - '3306:3306'
+    expose:
+      # Opens port 3306 on the container
+      - '3306'
+      # Where our data will be persisted
     volumes:
-     - data-db:/var/lib/mysql
+      - data-db:/var/lib/mysql
     container_name: mysql
     networks:
       - orknet

--- a/orkservice/Json/index.php
+++ b/orkservice/Json/index.php
@@ -4,7 +4,7 @@
 			
 *******************************************************************************/
 
-	if(empty($_SERVER['HTTPS']) || $_SERVER['HTTPS'] == "off"){
+  if(getenv('ENVIRONMENT') != 'DEV' && (empty($_SERVER['HTTPS']) || $_SERVER['HTTPS'] == "off")){
 			$redirect = 'https://' . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'];
 			header('HTTP/1.1 301 Moved Permanently');
 			header('Location: ' . $redirect);

--- a/php.Dockerfile
+++ b/php.Dockerfile
@@ -1,4 +1,6 @@
 FROM php:5.6-apache
+RUN a2enmod headers
+RUN a2enmod rewrite
 
 RUN apt-get update && apt-get install -y \
 && docker-php-ext-install mysql


### PR DESCRIPTION
These changes allowed me to be able to run the Ork within a Docker container.  I switched to MySql from MariaDb since that seems to be what is on production.  This includes logging in, updating or creating new entities.  I also tried the Ork Mobile against it and you'll see the small change in the index.php file for the service to allow it to work on dev http.

The only odd thing was that I had to set the following mode in SQL otherwise there are several places where time() values are sent and rejected, and all creates attempt to set the AUTO_INCREMENT field to "".  Also rejected.

`SET GLOBAL sql_mode = '';`