### PR TITLE
Waiver is always marked false

### DIFF
--- a/system/lib/ork3/class.Player.php
+++ b/system/lib/ork3/class.Player.php
@@ -418,8 +418,6 @@ class Player extends Ork3 {
 						$this->mundane->waivered = 1;
 						$this->mundane->waiver_ext = 'pdf';
 					}
-				} else {
-					$this->mundane->waivered = 0;
 				}
 				if ($request['HasImage'] && strlen($request['Image']) > 0 && strlen($request['Image']) < 465000 && Common::supported_mime_types($request['ImageMimeType']) && !Common::is_pdf_mime_type($request['ImageMimeType'])) {
 					$playerimage = @imagecreatefromstring(base64_decode($request['Image']));


### PR DESCRIPTION
Closes amtgard/ORK3#29 

Code checked if there was a waiver and an image and if not, set it to zero. But could be waivered AND no image.  In that case, set to 1.

Moved the code that set depending on **Waivered** being set to the last **else**