### PR TITLE
SQL is pulling mundane_id from authorization db which Champion is not in

### DIFF
--- a/system/lib/ork3/class.Kingdom.php
+++ b/system/lib/ork3/class.Kingdom.php
@@ -495,7 +495,7 @@ class Kingdom  extends Ork3 {
 	}
 
 	public function GetOfficers($request) {
-		$sql = "select a.*, p.name as park_name, k.name as kingdom_name, e.name as event_name, u.name as unit_name, m.username, m.given_name, m.surname, m.persona, m.restricted, o.role as officer_role, o.officer_id
+		$sql = "select a.*, p.name as park_name, k.name as kingdom_name, e.name as event_name, u.name as unit_name, m.mundane_id as m_mundane_id, m.username, m.given_name, m.surname, m.persona, m.restricted, o.role as officer_role, o.officer_id
 					from " . DB_PREFIX . "officer o
 						left join " . DB_PREFIX . "mundane m on o.mundane_id = m.mundane_id
 						left join " . DB_PREFIX . "authorization a on a.authorization_id = o.authorization_id
@@ -513,7 +513,7 @@ class Kingdom  extends Ork3 {
 			do {
 				$response['Officers'][] = array(
 							'AuthorizationId' => $r->authorization_id,
-							'MundaneId' => $r->mundane_id,
+							'MundaneId' => $r->m_mundane_id,
 							'ParkId' => $r->park_id,
 							'KingdomId' => $r->kingdom_id,
 							'EventId' => $r->event_id,

--- a/system/lib/ork3/class.Park.php
+++ b/system/lib/ork3/class.Park.php
@@ -211,7 +211,7 @@ class Park extends Ork3
 
 	public function GetOfficers( $request )
 	{
-		$sql = "select a.*, p.name as park_name, k.name as kingdom_name, e.name as event_name, u.name as unit_name, m.username, m.given_name, m.surname, m.persona, m.restricted, o.role as officer_role, o.officer_id
+		$sql = "select a.*, p.name as park_name, k.name as kingdom_name, e.name as event_name, u.name as unit_name, m.mundane_id as m_mundane_id, m.username, m.given_name, m.surname, m.persona, m.restricted, o.role as officer_role, o.officer_id
 					from " . DB_PREFIX . "officer o
 						left join " . DB_PREFIX . "mundane m on o.mundane_id = m.mundane_id
 						left join " . DB_PREFIX . "authorization a on a.authorization_id = o.authorization_id
@@ -229,7 +229,7 @@ class Park extends Ork3
 			do {
 				$response[ 'Officers' ][] = [
 					'AuthorizationId' => $r->authorization_id,
-					'MundaneId'       => $r->mundane_id,
+					'MundaneId'       => $r->m_mundane_id,
 					'ParkId'          => $r->park_id,
 					'KingdomId'       => $r->kingdom_id,
 					'EventId'         => $r->event_id,


### PR DESCRIPTION
Fixes #295 The mundane_id was being pulled from the join with the authorization DB which the Champion is not in so many fields were set to null including mundane_id. Set an additional field in the sql results to be the mundane_id and used that in the results. 

@jrtaylor-com you can make a branch for a release soon and change the merge destination if you want.

<img width="830" alt="image" src="https://user-images.githubusercontent.com/1138820/128645674-5d760198-9edb-4681-b273-4b58d6bd4af4.png">

<img width="181" alt="image" src="https://user-images.githubusercontent.com/1138820/128645699-217f028d-d39d-4fc6-bf29-4d8bd16bcc89.png">
