### PR TITLE
Remove Default Awards for Parks/Kingdoms

### DIFF
--- a/orkui/template/default/Award_addawards.tpl
+++ b/orkui/template/default/Award_addawards.tpl
@@ -184,6 +184,7 @@
 			<span>Award:</span>
 			<span>
 				<select name='AwardId' id='AwardId'>
+					<option value=''></option>
 <?=$AwardOptions ?>
 				</select>
 			</span>


### PR DESCRIPTION
The Add Award dialogue for Parks and Kingdoms still had "Archduchess" as the default, whereas the Add Award dialogue for Players defaults to blank (to avoid accidentally awarding the first award alphabetically). This should fix that issue, by adding a blank entry to the top of the list, the same way the Player dialogue was changed.