### PR TITLE
Enhancement to return entered_at to attendance

### DIFF
--- a/system/lib/ork3/class.Player.php
+++ b/system/lib/ork3/class.Player.php
@@ -282,7 +282,9 @@ class Player extends Ork3 {
 		} else if ($r->size() > 0) {
 			do {
 				$response['Attendance'][] = array(
-						'AttendanceId' => $r->attenance_id,
+						'AttendanceId' => $r->attendance_id,
+						'EnteredById' => $r->by_whom_id,
+						'EnteredAt' => $r->entered_at,
 						'MundaneId' => $r->mundane_id,
 						'ClassId' => $r->class_id,
 						'Date' => $r->date,

--- a/system/lib/ork3/class.Report.php
+++ b/system/lib/ork3/class.Report.php
@@ -578,6 +578,7 @@ class Report  extends Ork3 {
 			do {
 				$response['Attendance'][] = array(
 						'AttendanceId' => $r->attendance_id,
+						'EnteredAt' => $r->entered_at,
 						'MundaneId' => $r->mundane_id,
 						'ClassId' => $r->class_id,
 						'Date' => $r->date,
@@ -667,6 +668,7 @@ class Report  extends Ork3 {
 						'UnitName' => $r->unit_name,
 						'EnteredBy' => $r->by_whom_persona,
 						'EnteredById' => $r->by_whom_id,
+						'EnteredAt' => $r->entered_at,
 						'Persona' => $r->persona,
 						'ClassName' => $r->class_name,
         				'AttendancePersona' => $r->attendance_persona,

--- a/system/lib/ork3/class.Report.php
+++ b/system/lib/ork3/class.Report.php
@@ -579,6 +579,7 @@ class Report  extends Ork3 {
 				$response['Attendance'][] = array(
 						'AttendanceId' => $r->attendance_id,
 						'EnteredAt' => $r->entered_at,
+						'EnteredById' => $r->by_whom_id,
 						'MundaneId' => $r->mundane_id,
 						'ClassId' => $r->class_id,
 						'Date' => $r->date,


### PR DESCRIPTION
Fixes #310 

Added **entered_at** to attendance call results. Also fixed a typo which was preventing **Attendance_Id** from being returned in player attendance record. 

**Park getAttendance now**
<img width="804" alt="Park getAttendance" src="https://user-images.githubusercontent.com/1138820/151031909-1ececc3d-f1fe-421b-a2ea-4d26f12ae812.png">

**Event getAttendance now**
<img width="703" alt="Event getAttendance" src="https://user-images.githubusercontent.com/1138820/151031913-e4a5047d-99bb-4173-96c9-5c715d564ff4.png">

**Player getAttendance now**
<img width="633" alt="Player getAttendance" src="https://user-images.githubusercontent.com/1138820/151031915-fc4fdf73-9c23-4bbe-936d-f2c2272552f5.png">

