### PR TITLE
Fix for Unnecessary exposure of names #345

### DIFF
--- a/orkui/controller/controller.Admin.php
+++ b/orkui/controller/controller.Admin.php
@@ -368,7 +368,7 @@ class Controller_Admin extends Controller {
 			}
 		}
 		$this->template = 'Admin_setofficers.tpl';
-		if (($officers = $this->Kingdom->get_officers($this->request->KingdomId))) {
+		if (($officers = $this->Kingdom->get_officers($this->request->KingdomId, $this->session->token))) {
 			$this->data['Officers'] = $officers;
 		} else {
 			$this->data['Officers'] = array();
@@ -416,7 +416,7 @@ class Controller_Admin extends Controller {
 			}
 		}
 		$this->template = 'Admin_setofficers.tpl';
-		if (($officers = $this->Park->get_officers($this->request->ParkId))) {
+		if (($officers = $this->Park->get_officers($this->request->ParkId, $this->session->token))) {
 			$this->data['Officers'] = $officers;
 		} else {
 			$this->data['Officers'] = array();

--- a/orkui/controller/controller.Kingdom.php
+++ b/orkui/controller/controller.Kingdom.php
@@ -39,7 +39,7 @@ class Controller_Kingdom extends Controller {
 		$this->data['principalities'] = $this->Kingdom->get_principalities($kingdom_id);
 		$this->data['event_summary'] = $this->Kingdom->get_kingdom_events($kingdom_id);
 		$this->data['kingdom_info'] = $this->Kingdom->get_kingdom_shortinfo($kingdom_id);
-		$this->data['kingdom_officers'] = $this->Kingdom->GetOfficers(['KingdomId' => $kingdom_id]);
+		$this->data['kingdom_officers'] = $this->Kingdom->GetOfficers(['KingdomId' => $kingdom_id, 'Token' => $this->session->token]);
 		$this->data['IsPrinz'] = $this->data['kingdom_info']['Info']['KingdomInfo']['IsPrincipality'];
 		$this->data['kingdom_tournaments'] = $this->Reports->get_tournaments(null, $kingdom_id);
 		logtrace("index($kingdom_id = null)", $this->data['kingdom_tournaments']);

--- a/orkui/controller/controller.Park.php
+++ b/orkui/controller/controller.Park.php
@@ -46,7 +46,7 @@ class Controller_Park extends Controller
 		$this->data[ 'event_summary' ] = $this->Park->get_park_events( $park_id );
 		$this->data[ 'park_days' ] = $this->Park->get_park_parkdays( $park_id );
 		$this->data[ 'park_info' ] = $this->Park->get_park_details( $park_id );
-		$this->data[ 'park_officers' ] = $this->Park->GetOfficers(['ParkId' => $park_id]);
+		$this->data[ 'park_officers' ] = $this->Park->GetOfficers(['ParkId' => $park_id, 'Token' => $this->session->token]);
 		$this->data[ 'park_tournaments' ] = $this->Reports->get_tournaments( null, null, $park_id );
 	}
 }

--- a/orkui/model/model.Kingdom.php
+++ b/orkui/model/model.Kingdom.php
@@ -40,8 +40,8 @@ class Model_Kingdom extends Model {
 		return array();
 	}
 	
-	function get_officers($kingdom_id) {
-		$r = $this->Kingdom->GetOfficers(array( 'KingdomId' => $kingdom_id ));
+	function get_officers($kingdom_id, $token) {
+		$r = $this->Kingdom->GetOfficers(array('KingdomId' => $kingdom_id, 'Token' => $token ));
 		logtrace("get_officers($kingdom_id)", $r);
 		if ($r['Status']['Status'] == 0)
 			return $r['Officers'];

--- a/orkui/model/model.Login.php
+++ b/orkui/model/model.Login.php
@@ -12,6 +12,11 @@ class Model_Login extends Model {
 		unset($this->session->user_name);
 		unset($this->session->token);
 		unset($this->session->timeout);
+		unset($this->session->kingdom_id);
+		unset($this->session->kingdom_name);
+		if (isset($_SESSION['is_authorized_mundane_id'])) {
+			unset($_SESSION['is_authorized_mundane_id']);
+		}
 	}
 	
 	function login($username, $password) {

--- a/orkui/model/model.Park.php
+++ b/orkui/model/model.Park.php
@@ -31,8 +31,8 @@ class Model_Park extends Model {
 						'Heraldry' => $this->Heraldry->GetHeraldryUrl(array('Type' => 'Park', 'Id' => $park_id )));
 	}
 	
-	function get_officers($park_id) {
-		$r = $this->Park->GetOfficers(array( 'ParkId' => $park_id ));
+	function get_officers($park_id, $token) {
+		$r = $this->Park->GetOfficers(array( 'ParkId' => $park_id, 'Token' => $token ));
 		logtrace("get_officers($park_id)", $r);
 		if ($r['Status']['Status'] == 0)
 			return $r['Officers'];

--- a/orkui/template/default/Admin_setofficers.tpl
+++ b/orkui/template/default/Admin_setofficers.tpl
@@ -61,7 +61,7 @@
 	<?php 	foreach ($Officers as $k => $auth): ?>
 				<tr>
 					<td><?=$auth['UserName'] ?></td>
-					<td><a href='<?=UIR.'Player/index/'.$auth['MundaneId'] ?>'><?=$auth['Persona'] . ' (' . ($auth['Restricted']?'<span class="restricted-player-display">Restricted</span>':$auth['Surname'].', '.$auth['GivenName']) ?>)</a></td>
+					<td><a href='<?=UIR.'Player/index/'.$auth['MundaneId'] ?>'><?=$auth['Persona'] . (($auth['Surname'] || $auth['GivenName']) ? ' (' . $auth['Surname'] . ', ' . $auth['GivenName'] . ')':'') ?></a></td>
 					<td><?=$auth['Role'] ?></td>
 <?php if ($Type == 'KingdomId' && $Id == 34) : ?>
 					<td>Champion</td>


### PR DESCRIPTION
The API call to GetOfficers has been modified to respect the authorization level of the token being used to invoke the call. So a park officer with edit rights may see the additional information in the edit officers page or if they pass a valid token to the API they will get the additional information, same for kingdom, same for admin.