### PR TITLE
#353 Suspensions Overwrite Existing Players

### DIFF
--- a/orkui/template/default/Player_index.tpl
+++ b/orkui/template/default/Player_index.tpl
@@ -70,11 +70,11 @@
 			<span class='form-informational-field'><?=$Player['SuspendedAt'] ?></span>
 		</div>
 		<div>
-			<span>Suspended At:</span>
+			<span>Suspended Until:</span>
 			<span class='form-informational-field'><?=$Player['SuspendedUntil'] ?></span>
 		</div>
 		<div>
-			<span>Suspended At:</span>
+			<span>Suspension:</span>
 			<span class='form-informational-field'><?=$Player['Suspension'] ?></span>
 		</div>
 	<?php endif; ?>

--- a/system/lib/ork3/class.Player.php
+++ b/system/lib/ork3/class.Player.php
@@ -706,7 +706,7 @@ class Player extends Ork3 {
 	}
 
 	public function _ClearSuspensions() {
-		$sql = "update " . DB_PREFIX . "mundane set suspended = 0, suspended_by_id = null, suspended_at = null, suspended_until = null, suspension = null where suspended_until < curdate() and suspended_until is not null";
+		$sql = "update " . DB_PREFIX . "mundane set suspended = 0, suspended_by_id = null, suspended_at = null, suspended_until = null, suspension = null where suspended_until < curdate() and suspended_until is not null and suspended_until != '0000-00-00'";
 		$this->db->query($sql);
 	}
 

--- a/system/lib/ork3/class.Report.php
+++ b/system/lib/ork3/class.Report.php
@@ -793,6 +793,11 @@ class Report  extends Ork3 {
 		$select_list = array();
 		$order_by = "k.name, p.name";
 		$restrict_clause = array();
+		if (true == $request['Suspended']) {
+			/* Borrowed from Player class to clear the suspensions past their suspended_until date before running the report */
+			$sql = "update " . DB_PREFIX . "mundane set suspended = 0, suspended_by_id = null, suspended_at = null, suspended_until = null, suspension = null where suspended_until < curdate() and suspended_until is not null and suspended_until != '0000-00-00'";
+			$this->db->query($sql);
+		}
 		switch ($request['Type']) {
 			case AUTH_PARK:
 				    $kdid  = Ork3::$Lib->park->GetParkKingdomId($request['Id']);


### PR DESCRIPTION
Fix for #353 - I think database changes resulted in a '0000-00-00' being assigned instead of null and thus when the time came to clear expired suspensions it compares today greater than '0000-00-00' which it is so it clears it.  I also fixed the naming in the display of the suspension for the 3 fields shown on a player. Additionally, when you get a report for suspensions, the clear suspensions code is first run so that any suspensions that should be removed, are.