### PR TITLE
349 Cannot save kingdom config

### DIFF
--- a/system/lib/ork3/common.php
+++ b/system/lib/ork3/common.php
@@ -514,7 +514,9 @@ class Common
 		// Ditto, above
 		$this->config->type = strlen( $type ) > 0 ? $type : $this->config->type;
 		$this->config->id = strlen( $id ) > 0 ? $id : $this->config->id;
-		$this->config->key = strlen( $key ) > 0 ? $key : $this->config->key;
+		if (strlen( $key ) > 0) {
+			$this->config->key = $key;
+		}
 		if ( $this->config->find() ) {
 			if ( $value != null ) {
 				$allowed = json_decode( $this->config->allowed_values );


### PR DESCRIPTION
Fix for #349 

If the `$this->config->key `is called before the find, it generates a 

`PHP Fatal error:  Uncaught Exception: There is no active record set. in /var/www/ork.amtgard.com/system/lib/Yapo2/class.YapoCore.php:117`

And it seems it's always null. 