### PR TITLE
Fixed player search to allow '-' and spaces. Plus support for full name search (like "Jane Doe")

### DIFF
--- a/system/lib/ork3/class.SearchService.php
+++ b/system/lib/ork3/class.SearchService.php
@@ -317,7 +317,6 @@ class SearchService extends Ork3 {
 					limit $limit";
 		$i = 0;
 		$this->db->clear();
-		error_log("olgafix: " . $sql, 0);
 		$q = $this->db->query($sql);
 		if ($q !== false && $q->size() > 0) {
 			$r = array();


### PR DESCRIPTION
As per reported issue https://github.com/amtgard/ORK3/issues/206 '-' character break the player search as it is a dedicated operator in MATCH AGAINST search clause. However, many usernames include '-'

To keep the search fast and solve this issue: 
1) made MATCH AGAINST clause focus only on the first word entered into the search field. 
2) added a set of LIKE clauses to catch everything after that: with dasher, spaces, etc. 
3) included a concat(`given_name`,' ',`surname`) to support full name search.