### PR TITLE
Bugfix: Knights and Masters Dues Issue

### DIFF
--- a/orkui/controller/controller.Reports.php
+++ b/orkui/controller/controller.Reports.php
@@ -215,13 +215,13 @@ class Controller_Reports extends Controller {
 	}
 
     public function knights($type=null) {
-        $this->_peerage_waivered_duespaid('Knight', $type, false, null);
+        $this->_peerage_waivered_duespaid('Knight', $type, true, null);
     	$this->template = 'Reports_knights.tpl';
 		$this->data['page_title'] = "Active Knights";
 	}
 
     public function masters($type=null) {
-        $this->_peerage_waivered_duespaid('Master', $type, false, null);
+        $this->_peerage_waivered_duespaid('Master', $type, true, null);
     	$this->template = 'Reports_masters.tpl';
 		$this->data['page_title'] ="Active Masters";
 	}

--- a/orkui/template/default/Reports_knights.tpl
+++ b/orkui/template/default/Reports_knights.tpl
@@ -9,6 +9,24 @@
 <?php else: ?>
 	<h3>Active Players</h3>
 <?php endif; ?>
+	<details style="margin-bottom: 12px; border: 1px solid #ccc; border-radius: 4px; padding: 0;">
+		<summary style="cursor: pointer; padding: 8px 12px; background: #f0f0f0; font-weight: bold; list-style: none;">
+			<i class="fas fa-info-circle"></i> Report Explanation <span style="font-weight: normal; font-size: 0.85em; color: #666;">(click to expand)</span>
+		</summary>
+		<div style="padding: 10px 14px; font-size: 0.9em; line-height: 1.5;">
+			<p>This report lists all players who hold a <strong>Knight</strong> peerage award and meet the kingdom's minimum activity requirements within the <strong>last 6 months</strong>.</p>
+			<p><strong>How players qualify:</strong> A player must be a non-suspended member of this kingdom with at least one Knight-level award. They must also meet the kingdom's configured attendance and credit minimums during the lookback period.</p>
+			<p><strong>Column definitions:</strong></p>
+			<ul style="margin: 4px 0 8px 20px;">
+				<li><strong>Weeks</strong> &ndash; Number of distinct weeks in which the player had at least one attendance record.</li>
+				<li><strong>Park Weeks</strong> &ndash; Number of weeks the player attended at a park (park-level attendance count).</li>
+				<li><strong>Attendances</strong> &ndash; Total individual attendance records during the period.</li>
+				<li><strong>Credits</strong> &ndash; Total credits earned, with each month capped at the kingdom's configured monthly credit maximum.</li>
+				<li><strong>Dues Paid</strong> &ndash; Shows "Dues Paid" if the player has a current, non-revoked dues record on file (either active dues or dues for life).</li>
+			</ul>
+			<p style="margin-bottom: 0;"><strong>Note:</strong> Only attendance from the last 6 months is considered. Players who do not meet the minimum weekly attendance, daily attendance, or credit thresholds configured for this kingdom will not appear.</p>
+		</div>
+	</details>
 	<div class="actions"><button class="print button">Print</button> <button class="download button">Download CSV</button></div>
 	<table class='information-table'>
 		<thead>

--- a/orkui/template/default/Reports_masters.tpl
+++ b/orkui/template/default/Reports_masters.tpl
@@ -8,6 +8,24 @@
 <?php else: ?>
 	<h3>Active Players</h3>
 <?php endif; ?>
+	<details style="margin-bottom: 12px; border: 1px solid #ccc; border-radius: 4px; padding: 0;">
+		<summary style="cursor: pointer; padding: 8px 12px; background: #f0f0f0; font-weight: bold; list-style: none;">
+			<i class="fas fa-info-circle"></i> Report Explanation <span style="font-weight: normal; font-size: 0.85em; color: #666;">(click to expand)</span>
+		</summary>
+		<div style="padding: 10px 14px; font-size: 0.9em; line-height: 1.5;">
+			<p>This report lists all players who hold a <strong>Master</strong> peerage award and meet the kingdom's minimum activity requirements within the <strong>last 6 months</strong>.</p>
+			<p><strong>How players qualify:</strong> A player must be a non-suspended member of this kingdom with at least one Master-level award. They must also meet the kingdom's configured attendance and credit minimums during the lookback period.</p>
+			<p><strong>Column definitions:</strong></p>
+			<ul style="margin: 4px 0 8px 20px;">
+				<li><strong>Weeks</strong> &ndash; Number of distinct weeks in which the player had at least one attendance record.</li>
+				<li><strong>Park Weeks</strong> &ndash; Number of weeks the player attended at a park (park-level attendance count).</li>
+				<li><strong>Attendances</strong> &ndash; Total individual attendance records during the period.</li>
+				<li><strong>Credits</strong> &ndash; Total credits earned, with each month capped at the kingdom's configured monthly credit maximum.</li>
+				<li><strong>Dues Paid</strong> &ndash; Shows "Dues Paid" if the player has a current, non-revoked dues record on file (either active dues or dues for life).</li>
+			</ul>
+			<p style="margin-bottom: 0;"><strong>Note:</strong> Only attendance from the last 6 months is considered. Players who do not meet the minimum weekly attendance, daily attendance, or credit thresholds configured for this kingdom will not appear.</p>
+		</div>
+	</details>
 	<div class="actions"><button class="print button">Print</button> <button class="download button">Download CSV</button></div>
 	<table class='information-table'>
 		<thead>


### PR DESCRIPTION
## Summary
- Fixes the Active Knights and Active Masters reports where the **Dues Paid** column always showed blank/empty for all players, even those with active dues.
- The root cause was that `knights()` and `masters()` in `controller.Reports.php` were calling `_peerage_waivered_duespaid()` with the `$dues` parameter set to `false`, which caused the SQL query to skip the dues subquery entirely. The `DuesPaid` field was therefore always null in the result set, despite the report templates expecting and rendering it.
- Changed the `$dues` parameter from `false` to `true` in both methods so the dues subquery is included, correctly checking for non-revoked, current dues (or dues-for-life) records.
- Added a report explanation panel at the top of each report to provide details on how they are calculated.

Fixes #381

## Files Changed
- `orkui/controller/controller.Reports.php` — Set `$dues=true` in `knights()` and `masters()` method calls

## Test Plan
- [ ] Navigate to a Kingdom Admin page and open the **Active Knights** report
- [ ] Verify the **Dues Paid** column correctly displays "Dues Paid" for players with active, non-revoked dues
- [ ] Repeat for the **Active Masters** report
- [ ] Confirm the total "Dues Paid" count at the bottom of the table reflects the correct number

🤖 Generated with [Claude Code](https://claude.com/claude-code)