### PR TITLE
Enhancement: Allow offices to be set to vacant

### DIFF
--- a/orkui/controller/controller.Admin.php
+++ b/orkui/controller/controller.Admin.php
@@ -438,6 +438,56 @@ class Controller_Admin extends Controller {
 		}
 	}
 
+	public function vacatekingdomofficer() {
+		$this->load_model('Kingdom');
+		$kingdom_id = $this->request->KingdomId;
+		if (!isset($this->session->user_id)) {
+			header('Location: ' . UIR . 'Login/login/Admin/setkingdomofficers');
+		} else {
+			$role = $this->request->Role;
+			$r = $this->Kingdom->vacate_officer($kingdom_id, $role, $this->session->token);
+			if (isset($r['Status']) && $r['Status'] != 0) {
+				$this->data['Error'] = 'Could not vacate officer: ' . $r['Detail'];
+			} else {
+				$this->data['Message'] = "The $role position has been vacated.";
+			}
+		}
+		$this->template = 'Admin_setofficers.tpl';
+		if (($officers = $this->Kingdom->get_officers($kingdom_id, $this->session->token))) {
+			$this->data['Officers'] = $officers;
+		} else {
+			$this->data['Officers'] = array();
+		}
+		$this->data['Type'] = 'KingdomId';
+		$this->data['Id'] = $kingdom_id;
+		$this->data['Call'] = 'setkingdomofficers';
+	}
+
+	public function vacateparkofficer() {
+		$this->load_model('Park');
+		$park_id = $this->request->ParkId;
+		if (!isset($this->session->user_id)) {
+			header('Location: ' . UIR . 'Login/login/Admin/setparkofficers');
+		} else {
+			$role = $this->request->Role;
+			$r = $this->Park->vacate_officer($park_id, $role, $this->session->token);
+			if (isset($r['Status']) && $r['Status'] != 0) {
+				$this->data['Error'] = 'Could not vacate officer: ' . $r['Detail'];
+			} else {
+				$this->data['Message'] = "The $role position has been vacated.";
+			}
+		}
+		$this->template = 'Admin_setofficers.tpl';
+		if (($officers = $this->Park->get_officers($park_id, $this->session->token))) {
+			$this->data['Officers'] = $officers;
+		} else {
+			$this->data['Officers'] = array();
+		}
+		$this->data['Type'] = 'ParkId';
+		$this->data['Id'] = $park_id;
+		$this->data['Call'] = 'setparkofficers';
+	}
+
 	public function event($p) {
 		$params = explode('/',$p);
 		$event_id = $params[0];

--- a/orkui/model/model.Kingdom.php
+++ b/orkui/model/model.Kingdom.php
@@ -57,6 +57,10 @@ class Model_Kingdom extends Model {
 		}
 		return $r;
 	}
+
+	function vacate_officer($kingdom_id, $role, $token) {
+		return $this->Kingdom->VacateOfficer(array('KingdomId' => $kingdom_id, 'Role' => $role, 'Token' => $token));
+	}
 	
 	function create_kingdom($request) {
 		logtrace("create_kingdom", $request);

--- a/orkui/model/model.Park.php
+++ b/orkui/model/model.Park.php
@@ -48,6 +48,10 @@ class Model_Park extends Model {
 		}
 		return $r;
 	}
+
+	function vacate_officer($park_id, $role, $token) {
+		return $this->Park->VacateOfficer(array('ParkId' => $park_id, 'Role' => $role, 'Token' => $token));
+	}
 	
 	function create_park($request) {
 		logtrace("create_park", $request);

--- a/orkui/template/default/Admin_setofficers.tpl
+++ b/orkui/template/default/Admin_setofficers.tpl
@@ -44,6 +44,12 @@
 	});
 </script>
 
+<?php if (!empty($Error)) : ?>
+	<div class='error-message'><?=$Error ?></div>
+<?php endif; ?>
+<?php if (!empty($Message)) : ?>
+	<div class='success-message'><?=$Message ?></div>
+<?php endif; ?>
 <div class='info-container'>
 	<h3>Officers</h3>
 	<form class='form-container' method='post' action='<?=UIR ?>Admin/<?=$Call ?>/post&<?=$Type ?>=<?=$Id ?>'>
@@ -55,6 +61,7 @@
 					<th>Role</th>
 					<th>Officer</th>
 					<th>Set To</th>
+					<th>Vacate</th>
 				</tr>
 			</thead>
 			<tbody>
@@ -70,10 +77,16 @@
 <?php endif; ?>
 					<td><input type='text' class='officer-input' value='<?=$Award_setofficers[str_replace(' ', '_',$auth['OfficerRole'])] ?>' name='<?=str_replace(' ', '_',$auth['OfficerRole']) ?>' value='<?=str_replace(' ', '_',$auth['OfficerRole']) ?>'></td>
 					<input type='hidden' id='<?=str_replace(' ', '_',$auth['OfficerRole']) ?>Id' name='<?=str_replace(' ', '_',$auth['OfficerRole']) ?>Id' value='<?=$Award_setofficers[str_replace(' ', '_',$auth['OfficerRole']).'Id'] ?>' />
+					<td>
+<?php if (!empty($auth['MundaneId']) && $auth['MundaneId'] > 0): ?>
+						<?php $vacateAction = ($Type == 'KingdomId') ? 'vacatekingdomofficer' : 'vacateparkofficer'; ?>
+						<a href='<?=UIR ?>Admin/<?=$vacateAction ?>&<?=$Type ?>=<?=$Id ?>&Role=<?=urlencode($auth['OfficerRole']) ?>' onclick="return confirm('Are you sure you want to vacate the <?=$auth['OfficerRole'] ?> position?');">Set Vacant</a>
+<?php endif; ?>
+					</td>
 				</tr>
 	<?php 	endforeach; ?>
 				<tr>
-					<td colspan='5'><input type='submit' value='Update' /></td>
+					<td colspan='6'><input type='submit' value='Update' /></td>
 				</tr>
 			</tbody>
 		</table>

--- a/orkui/template/default/Kingdom_index.tpl
+++ b/orkui/template/default/Kingdom_index.tpl
@@ -14,7 +14,7 @@
 	<h4>Monarchy</h4>
 		<ul>
 			<?php foreach ($kingdom_officers['Officers'] as $key => $officer): ?>
-				<li><?= $officer['OfficerRole']; ?>: <a href="<?=UIR.'Player/index/'.$officer['MundaneId'] ?>"><?= $officer['Persona']; ?></a></li>
+				<li><?= $officer['OfficerRole']; ?>: <?php if (!empty($officer['MundaneId']) && $officer['MundaneId'] > 0): ?><a href="<?=UIR.'Player/index/'.$officer['MundaneId'] ?>"><?= $officer['Persona']; ?></a><?php else: ?>(Vacant)<?php endif; ?></li>
 			<?php endforeach; ?>
 		</ul>
 	<?php endif; ?>

--- a/orkui/template/default/Park_index.tpl
+++ b/orkui/template/default/Park_index.tpl
@@ -22,7 +22,7 @@
 	<h4>Park Monarchy</h4>
 		<ul>
 			<?php foreach ($park_officers['Officers'] as $key => $officer): ?>
-				<li><?= $officer['OfficerRole']; ?>: <a href="<?=UIR.'Player/index/'.$officer['MundaneId'] ?>"><?= $officer['Persona']; ?></a></li>
+				<li><?= $officer['OfficerRole']; ?>: <?php if (!empty($officer['MundaneId']) && $officer['MundaneId'] > 0): ?><a href="<?=UIR.'Player/index/'.$officer['MundaneId'] ?>"><?= $officer['Persona']; ?></a><?php else: ?>(Vacant)<?php endif; ?></li>
 			<?php endforeach; ?>
 		</ul>
 	<?php endif; ?>	

--- a/system/lib/ork3/class.Kingdom.php
+++ b/system/lib/ork3/class.Kingdom.php
@@ -566,6 +566,22 @@ class Kingdom  extends Ork3 {
 		return $response;
 	}
 	
+	public function VacateOfficer($request) {
+		$response = array();
+		$mundane_id = Ork3::$Lib->authorization->IsAuthorized($request['Token']);
+		if ($mundane_id > 0) {
+			if (Ork3::$Lib->authorization->HasAuthority($mundane_id, AUTH_KINGDOM, $request['KingdomId'], AUTH_EDIT)) {
+				$c = new Common();
+				$c->set_officer($request['KingdomId'], 0, 0, $request['Role']);
+			} else {
+				$response = NoAuthorization();
+			}
+		} else {
+			$response = NoAuthorization();
+		}
+		return $response;
+	}
+
 	public function RetireKingdom($request) {
 		return $this->WaffleKingdom($request, 'Retired');
 	}

--- a/system/lib/ork3/class.Park.php
+++ b/system/lib/ork3/class.Park.php
@@ -690,6 +690,21 @@ class Park extends Ork3
 		return $response;
 	}
 
+	public function VacateOfficer( $request )
+	{
+		$response = [ ];
+		if ( ( $mundane_id = Ork3::$Lib->authorization->IsAuthorized( $request[ 'Token' ] ) ) > 0
+			&& Ork3::$Lib->authorization->HasAuthority( $mundane_id, AUTH_PARK, $request[ 'ParkId' ], AUTH_EDIT )
+		) {
+			$kingdomId = $this->GetParkKingdomId( $request[ 'ParkId' ] );
+			$c = new Common();
+			$c->set_officer( $kingdomId, $request[ 'ParkId' ], 0, $request[ 'Role' ] );
+		} else {
+			$response = NoAuthorization();
+		}
+		return $response;
+	}
+
 	public function RetirePark( $request )
 	{
 		return $this->WafflePark( $request, 'Retired' );


### PR DESCRIPTION
## Summary
- Adds `VacateOfficer` API endpoints for both Kingdom and Park levels
- Admin officer management page now includes a "Vacate" column with confirmation dialog
- Kingdom and Park detail pages display "(Vacant)" when an officer position is unassigned

## Details

**Backend** (`class.Kingdom.php`, `class.Park.php`):
- New `VacateOfficer()` methods that use `Common::set_officer()` to set the mundane_id to 0 for a given role
- Proper authorization checks (Kingdom edit / Park edit) before allowing vacate

**UI Models** (`model.Kingdom.php`, `model.Park.php`):
- Added `vacate_officer()` wrapper methods to call the new API endpoints

**Controller** (`controller.Admin.php`):
- New `vacatekingdomofficer()` and `vacateparkofficer()` actions with auth checks, error/success messaging, and page re-render

**Templates**:
- `Admin_setofficers.tpl` — Added "Vacate" column with "Set Vacant" links (only shown when a position is currently filled) and a confirmation dialog
- `Kingdom_index.tpl` / `Park_index.tpl` — Officer lists now show "(Vacant)" instead of a broken player link when `MundaneId` is 0 or empty

## Files Changed
- `system/lib/ork3/class.Kingdom.php` — VacateOfficer API
- `system/lib/ork3/class.Park.php` — VacateOfficer API
- `orkui/model/model.Kingdom.php` — Model wrapper
- `orkui/model/model.Park.php` — Model wrapper
- `orkui/controller/controller.Admin.php` — Controller actions
- `orkui/template/default/Admin_setofficers.tpl` — Vacate UI column
- `orkui/template/default/Kingdom_index.tpl` — Vacant display
- `orkui/template/default/Park_index.tpl` — Vacant display

## Test plan
- [ ] As a kingdom admin, navigate to Admin > Set Kingdom Officers — confirm "Vacate" column appears with "Set Vacant" links for filled positions
- [ ] Click "Set Vacant" on a filled role — confirm the confirmation dialog appears, and on confirm the role is vacated with a success message
- [ ] View the kingdom detail page — confirm the vacated role shows "(Vacant)" instead of a broken link
- [ ] Repeat for park-level officers
- [ ] As an unauthorized user, attempt to vacate — confirm authorization is denied

Closes #376

🤖 Generated with [Claude Code](https://claude.com/claude-code)