### PR TITLE
Enhancement: Search outside of park

### DIFF
--- a/orkui/template/default/Attendance_park.tpl
+++ b/orkui/template/default/Attendance_park.tpl
@@ -1,7 +1,7 @@
 <?php global $Session ?>
 
 <style>
-.ui-autocomplete-separator { border-top: 1px solid #ccc; margin: 4px 0; height: 0; padding: 0; cursor: default; pointer-events: none; }
+.ui-autocomplete-separator { padding: 2px 12px; cursor: default; pointer-events: none; color: #999; font-size: 11px; }
 </style>
 
 <script type='text/javascript'>
@@ -160,7 +160,7 @@
 		});
 		playerAC.data('autocomplete')._renderItem = function(ul, item) {
 			if (item.separator) {
-				return $('<li class="ui-autocomplete-separator">').appendTo(ul);
+				return $('<li class="ui-autocomplete-separator">').text('── Kingdom ──').appendTo(ul);
 			}
 			return $('<li></li>').data('item.autocomplete', item).append($('<a>').text(item.label)).appendTo(ul);
 		};


### PR DESCRIPTION
## Summary

- When entering attendance, the player autocomplete now searches the full kingdom rather than just the selected park
- Local park players appear first in the dropdown with no annotation
- Players from other parks in the kingdom appear below a separator line, labeled with their kingdom and park abbreviations (e.g. `Binky (KCG:RSS)`)

## Test plan

- [ ] Type a player name in the Player field on the attendance entry page
- [ ] Confirm local park players appear at the top without any label
- [ ] Confirm a separator line appears between local and kingdom results
- [ ] Confirm kingdom players from other parks appear below the separator with `KAbbr:PAbbr` labels
- [ ] Select a kingdom player from below the separator and confirm attendance submits correctly
- [ ] Confirm the separator itself is not selectable

🤖 Generated with [Claude Code](https://claude.com/claude-code)