### PR TITLE
Enhancement: Allow line breaks in Unit text boxes

### DIFF
--- a/orkui/template/default/Unit_index.tpl
+++ b/orkui/template/default/Unit_index.tpl
@@ -21,11 +21,11 @@
 		</div>
 		<div>
 			<span>Description:</span>
-			<span class='form-informational-field' style='white-space: normal'><?=$Unit['Details']['Unit']['Description'] ?></span>
+			<span class='form-informational-field' style='white-space: normal'><?=nl2br($Unit['Details']['Unit']['Description']) ?></span>
 		</div>
 		<div>
 			<span>History:</span>
-			<span class='form-informational-field' style='white-space: normal'><?=$Unit['Details']['Unit']['History'] ?></span>
+			<span class='form-informational-field' style='white-space: normal'><?=nl2br($Unit['Details']['Unit']['History']) ?></span>
 		</div>
 	</form>
 </div>


### PR DESCRIPTION
## Summary

Closes #221

- Apply `nl2br()` to the Description and History fields on the public unit display page (`Unit_index.tpl`), so newlines entered in the admin textarea are rendered as `<br>` tags in the browser.

## Details

The `strip_tags()` call on save already whitelists `<br>`, `<p>`, `<ul>`, `<li>`, `<b>`, and `<i>`, so the fields support basic formatting. However, plain newlines from the textarea were not converted to HTML line breaks on display, making multi-line text appear as a single block.

This matches how chapter/park descriptions are already handled elsewhere in the app (e.g. `nl2br()` in `class.Park.php` and in event display templates).

The admin edit textareas are unchanged — they continue to show the raw stored text for editing.

## Test plan

- [ ] Open an existing unit (e.g. Admin/unit/346), add line breaks to the Description and/or History fields, and save.
- [ ] Visit the public unit page and confirm the line breaks are rendered correctly.
- [ ] Confirm the admin edit form still shows the raw text (no `<br />` tags visible in the textarea).

🤖 Generated with [Claude Code](https://claude.com/claude-code)