### PR TITLE
Enhancement: Updates to image upload and view

### DIFF
--- a/orkui/template/default/Admin_editkingdom.tpl
+++ b/orkui/template/default/Admin_editkingdom.tpl
@@ -7,7 +7,7 @@
 		<div>
 			<span>Heraldry:</span>
 			<span>
-				<img class='heraldry-img' src='<?=$Kingdom_heraldryurl['Url'] ?>' />
+				<img class='heraldry-img' src='<?=$Kingdom_heraldryurl['Url'] . '?t=' . time() ?>' />
 				<input type='file' name='Heraldry' id='Heraldry' />
 			</span>
 		</div>

--- a/orkui/template/default/Admin_editpark.tpl
+++ b/orkui/template/default/Admin_editpark.tpl
@@ -11,7 +11,7 @@
 		<div>
 			<span>Heraldry:</span>
 			<span>
-				<img class='heraldry-img' src='<?=$Park_data['HasHeraldry']?$Park_heraldry['Url']:HTTP_PLAYER_HERALDRY . '000000.jpg' ?>' />
+				<img class='heraldry-img' src='<?=($Park_data['HasHeraldry']?$Park_heraldry['Url']:HTTP_PLAYER_HERALDRY . '000000.jpg') . '?t=' . time() ?>' />
 				<input type='file' name='Heraldry' class='restricted-image-type' id='Heraldry' />
 			</span>
 		</div>	

--- a/orkui/template/default/Admin_event.tpl
+++ b/orkui/template/default/Admin_event.tpl
@@ -212,7 +212,7 @@
 		<div>
 			<span>Heraldry:</span>
 			<span>
-				<img class='heraldry-img' src='<?=$EventDetails['HeraldryUrl']['Url'] ?>' />
+				<img class='heraldry-img' src='<?=$EventDetails['HeraldryUrl']['Url'] . '?t=' . time() ?>' />
 				<input type='file' class='restricted-image-type' name='Heraldry' id='Heraldry' />
 			</span>
 		</div>

--- a/orkui/template/default/Admin_player.tpl
+++ b/orkui/template/default/Admin_player.tpl
@@ -4,14 +4,14 @@
 		<div>
 			<span>Heraldry:</span>
 			<span>
-				<img class='heraldry-img' src='<?=$Player['HasHeraldry']>0?$Player['Heraldry']:HTTP_PLAYER_HERALDRY . '000000.jpg' ?>' />
+				<img class='heraldry-img' src='<?=($Player['HasHeraldry']>0?$Player['Heraldry']:HTTP_PLAYER_HERALDRY . '000000.jpg') . '?t=' . time() ?>' />
 				<input type='file' class='restricted-image-type' name='Heraldry' id='Heraldry' />
 			</span>
 		</div>
 		<div>
 			<span>Image:</span>
 			<span>
-				<img class='heraldry-img' src='<?=$Player['HasImage']>0?$Player['Image']:HTTP_PLAYER_HERALDRY . '000000.jpg' ?>' />
+				<img class='heraldry-img' src='<?=($Player['HasImage']>0?$Player['Image']:HTTP_PLAYER_HERALDRY . '000000.jpg') . '?t=' . time() ?>' />
 				<input type='file' class='restricted-image-type' name='PlayerImage' id='PlayerImage' />
 			</span>
 		</div>

--- a/orkui/template/default/Admin_unit.tpl
+++ b/orkui/template/default/Admin_unit.tpl
@@ -93,7 +93,7 @@
 		<div>
 			<span>Heraldry:</span>
 			<span>
-				<img class='heraldry-img' src='<?=$Unit['Details']['Unit']['HasHeraldry']?$Unit_heraldryurl['Url']:(HTTP_UNIT_HERALDRY.'00000.jpg') ?>' />
+				<img class='heraldry-img' src='<?=($Unit['Details']['Unit']['HasHeraldry']?$Unit_heraldryurl['Url']:(HTTP_UNIT_HERALDRY.'00000.jpg')) . '?t=' . time() ?>' />
 				<input type='file' class='restricted-image-type' name='Heraldry' id='Heraldry' />
 			</span>
 		</div>

--- a/orkui/template/default/script/default.js
+++ b/orkui/template/default/script/default.js
@@ -137,6 +137,42 @@ function expandUrl() {
 		return document.URL;
 }
 
+function resizeImageToLimit(file, maxBytes, onSuccess, onError) {
+	var MAX_ITERATIONS = 5;
+	var targetBytes = maxBytes - 100;
+
+	function attempt(sourceBlob, remainingTries) {
+		var img = new Image();
+		var url = URL.createObjectURL(sourceBlob);
+		img.onload = function() {
+			URL.revokeObjectURL(url);
+			var scale = Math.sqrt(targetBytes / sourceBlob.size) * 0.9;
+			scale = Math.min(scale, 1);
+			var canvas = document.createElement('canvas');
+			canvas.width  = Math.max(1, Math.floor(img.width  * scale));
+			canvas.height = Math.max(1, Math.floor(img.height * scale));
+			var ctx = canvas.getContext('2d');
+			ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
+			canvas.toBlob(function(blob) {
+				if (blob.size <= maxBytes) {
+					onSuccess(blob, canvas.width, canvas.height);
+				} else if (remainingTries > 1) {
+					attempt(blob, remainingTries - 1);
+				} else {
+					onError('Could not resize image to fit within 340 KB. Please choose a smaller image.');
+				}
+			}, 'image/jpeg', 0.85);
+		};
+		img.onerror = function() {
+			URL.revokeObjectURL(url);
+			onError('Could not load image for resizing.');
+		};
+		img.src = url;
+	}
+
+	attempt(file, MAX_ITERATIONS);
+}
+
 $(function() {
 	$('.info-container').each(function(k, container) {
 		setExpandMode(container, expandUrl(), k, getExpandMode(container, expandUrl(), k));
@@ -146,10 +182,36 @@ $(function() {
 	});
 	$( '.hasDatePicker' ).datetimepicker({ dateFormat: "yy-mm-dd", showMinute: false });
 	$( '.restricted-image-type' ).change(function() {
-		if (!extension_check( $( this ), ['gif','png','jpg','jpeg'])) {
-			$( this ).effect("shake",{ times: 5 }, 50, 
-				function () { replaceWith( $( this ).val('').clone( true ) ) } );
+		var $input = $(this);
+		var generation = ($input.data('resize-gen') || 0) + 1;
+		$input.data('resize-gen', generation);
+		$input.siblings('.image-resize-notice').remove();
+		if (!extension_check($input, ['gif','png','jpg','jpeg'])) {
+			$input.effect("shake", {times: 5}, 50,
+				function() { replaceWith($input.val('').clone(true)); });
+			return;
 		}
+		var file = this.files && this.files[0];
+		if (!file || file.size <= 348836) return;
+		var originalKB = Math.round(file.size / 1024);
+		$input.after('<span class="image-resize-notice" style="font-size:10px;color:#888;margin-left:6px;">Resizing\u2026</span>');
+		resizeImageToLimit(file, 348836,
+			function(blob, newW, newH) {
+				if ($input.data('resize-gen') !== generation) return;
+				var resizedKB = Math.round(blob.size / 1024);
+				var dt = new DataTransfer();
+				dt.items.add(new File([blob], 'resized.jpg', {type: 'image/jpeg'}));
+				$input[0].files = dt.files;
+				$input.siblings('.image-resize-notice')
+					.css('color', '#555')
+					.text('Resized ' + originalKB + ' KB \u2192 ' + resizedKB + ' KB (' + newW + '\xd7' + newH + ')');
+			},
+			function(errMsg) {
+				if ($input.data('resize-gen') !== generation) return;
+				$input.siblings('.image-resize-notice').css('color', 'red').text(errMsg);
+				$input.val('');
+			}
+		);
 	});
 	$( '.restricted-document-type' ).change(function() {
 		if (!extension_check( $( this ), ['gif','png','jpg','jpeg','pdf'])) {
@@ -316,4 +378,17 @@ $(function() {
 	$( "#ParkSearch" ).keydown( function () {
         $('#ParkSearch').autocomplete('option', 'delay', Math.max(100, 900 / ($('#ParkSearch').val().length + 1)) );
     });
+	// Heraldry image lightbox
+	$('body').append('<div id="ork-lightbox"><img /></div>');
+	$(document).on('click', '.heraldry-img', function() {
+		if ($(this).closest('a').length) return;
+		$('#ork-lightbox img').attr('src', this.src);
+		$('#ork-lightbox').fadeIn(150);
+	});
+	$('#ork-lightbox').on('click', function() {
+		$(this).fadeOut(150);
+	});
+	$(document).on('keydown', function(e) {
+		if (e.key === 'Escape') $('#ork-lightbox').fadeOut(150);
+	});
 });

--- a/orkui/template/default/script/orkui.js
+++ b/orkui/template/default/script/orkui.js
@@ -13963,6 +13963,42 @@ function expandUrl() {
 		return document.URL;
 }
 
+function resizeImageToLimit(file, maxBytes, onSuccess, onError) {
+	var MAX_ITERATIONS = 5;
+	var targetBytes = maxBytes - 100;
+
+	function attempt(sourceBlob, remainingTries) {
+		var img = new Image();
+		var url = URL.createObjectURL(sourceBlob);
+		img.onload = function() {
+			URL.revokeObjectURL(url);
+			var scale = Math.sqrt(targetBytes / sourceBlob.size) * 0.9;
+			scale = Math.min(scale, 1);
+			var canvas = document.createElement('canvas');
+			canvas.width  = Math.max(1, Math.floor(img.width  * scale));
+			canvas.height = Math.max(1, Math.floor(img.height * scale));
+			var ctx = canvas.getContext('2d');
+			ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
+			canvas.toBlob(function(blob) {
+				if (blob.size <= maxBytes) {
+					onSuccess(blob, canvas.width, canvas.height);
+				} else if (remainingTries > 1) {
+					attempt(blob, remainingTries - 1);
+				} else {
+					onError('Could not resize image to fit within 340 KB. Please choose a smaller image.');
+				}
+			}, 'image/jpeg', 0.85);
+		};
+		img.onerror = function() {
+			URL.revokeObjectURL(url);
+			onError('Could not load image for resizing.');
+		};
+		img.src = url;
+	}
+
+	attempt(file, MAX_ITERATIONS);
+}
+
 $(function() {
 	$('.info-container').each(function(k, container) {
 		setExpandMode(container, expandUrl(), k, getExpandMode(container, expandUrl(), k));
@@ -13972,10 +14008,36 @@ $(function() {
 	});
 	$( '.hasDatePicker' ).datetimepicker({ dateFormat: "yy-mm-dd", showMinute: false });
 	$( '.restricted-image-type' ).change(function() {
-		if (!extension_check( $( this ), ['gif','png','jpg','jpeg'])) {
-			$( this ).effect("shake",{ times: 5 }, 50,
-				function () { replaceWith( $( this ).val('').clone( true ) ) } );
+		var $input = $(this);
+		var generation = ($input.data('resize-gen') || 0) + 1;
+		$input.data('resize-gen', generation);
+		$input.siblings('.image-resize-notice').remove();
+		if (!extension_check($input, ['gif','png','jpg','jpeg'])) {
+			$input.effect("shake", {times: 5}, 50,
+				function() { replaceWith($input.val('').clone(true)); });
+			return;
 		}
+		var file = this.files && this.files[0];
+		if (!file || file.size <= 348836) return;
+		var originalKB = Math.round(file.size / 1024);
+		$input.after('<span class="image-resize-notice" style="font-size:10px;color:#888;margin-left:6px;">Resizing\u2026</span>');
+		resizeImageToLimit(file, 348836,
+			function(blob, newW, newH) {
+				if ($input.data('resize-gen') !== generation) return;
+				var resizedKB = Math.round(blob.size / 1024);
+				var dt = new DataTransfer();
+				dt.items.add(new File([blob], 'resized.jpg', {type: 'image/jpeg'}));
+				$input[0].files = dt.files;
+				$input.siblings('.image-resize-notice')
+					.css('color', '#555')
+					.text('Resized ' + originalKB + ' KB \u2192 ' + resizedKB + ' KB (' + newW + '\xd7' + newH + ')');
+			},
+			function(errMsg) {
+				if ($input.data('resize-gen') !== generation) return;
+				$input.siblings('.image-resize-notice').css('color', 'red').text(errMsg);
+				$input.val('');
+			}
+		);
 	});
 	$( '.restricted-document-type' ).change(function() {
 		if (!extension_check( $( this ), ['gif','png','jpg','jpeg','pdf'])) {
@@ -14142,6 +14204,19 @@ $(function() {
 	$( "#ParkSearch" ).keydown( function () {
         $('#ParkSearch').autocomplete('option', 'delay', Math.max(100, 900 / ($('#ParkSearch').val().length + 1)) );
     });
+	// Heraldry image lightbox
+	$('body').append('<div id="ork-lightbox"><img /></div>');
+	$(document).on('click', '.heraldry-img', function() {
+		if ($(this).closest('a').length) return;
+		$('#ork-lightbox img').attr('src', this.src);
+		$('#ork-lightbox').fadeIn(150);
+	});
+	$('#ork-lightbox').on('click', function() {
+		$(this).fadeOut(150);
+	});
+	$(document).on('keydown', function(e) {
+		if (e.key === 'Escape') $('#ork-lightbox').fadeOut(150);
+	});
 });
 
 /*!

--- a/orkui/template/default/style/orkui.css
+++ b/orkui/template/default/style/orkui.css
@@ -7079,3 +7079,26 @@ table.tablesorter tbody tr.normal-row td {
 	background-color: #e6bf99;
 }
 
+
+/* Heraldry image lightbox */
+.heraldry-img { cursor: pointer; }
+#ork-lightbox {
+	display: none;
+	position: fixed;
+	inset: 0;
+	background: rgba(0,0,0,0.78);
+	z-index: 9999;
+	cursor: zoom-out;
+}
+#ork-lightbox img {
+	position: absolute;
+	top: 50%;
+	left: 50%;
+	transform: translate(-50%, -50%);
+	max-width: 90vw;
+	max-height: 90vh;
+	border: 3px solid #fff;
+	border-radius: 4px;
+	box-shadow: 0 4px 32px rgba(0,0,0,0.7);
+	cursor: default;
+}


### PR DESCRIPTION
## Summary

- **Auto-resize oversized images before upload** — When a user selects an image that exceeds the 340 KB limit, the browser uses the Canvas API to proportionally scale it down (up to 5 passes at JPEG quality 0.85) and replaces the file input's value via `DataTransfer` so the form submits the resized version transparently. An inline notice appears next to the file input showing the original and final size plus new dimensions (e.g. _Resized 850 KB → 298 KB (640×480)_). A generation counter prevents a race condition where a stale async resize callback could overwrite a replacement file the user selected while the first resize was still running.

- **Cache-bust heraldry thumbnails on admin edit pages** — All heraldry/image `<img>` tags in the five admin edit templates (`Admin_player.tpl`, `Admin_editpark.tpl`, `Admin_editkingdom.tpl`, `Admin_unit.tpl`, `Admin_event.tpl`) now append `?t=<?=time()?>` to their `src`. This ensures the browser always fetches the latest file after an upload instead of serving a stale cached copy.

- **Click-to-expand lightbox for heraldry thumbnails** — Clicking any `.heraldry-img` thumbnail opens a full-viewport dark overlay showing the image at up to 90vw/90vh. Click the overlay or press Escape to dismiss. Images that are already wrapped in `<a>` links (e.g. the heraldry report, where clicking navigates to the player page) are excluded from the lightbox so their existing navigation behaviour is preserved.

## Files changed

| File | Change |
|---|---|
| `orkui/template/default/script/default.js` | Auto-resize helper + enhanced file input handler + lightbox JS |
| `orkui/template/default/script/orkui.js` | Same changes mirrored into the production bundle |
| `orkui/template/default/style/orkui.css` | Lightbox overlay + `cursor: pointer` on `.heraldry-img` |
| `Admin_player.tpl` | Cache-bust heraldry + player image src |
| `Admin_editpark.tpl` | Cache-bust park heraldry src |
| `Admin_editkingdom.tpl` | Cache-bust kingdom heraldry src |
| `Admin_unit.tpl` | Cache-bust unit heraldry src |
| `Admin_event.tpl` | Cache-bust event heraldry src |

## Test plan

- [ ] Select an image **under 340 KB** on an admin edit page → uploads normally, no resize notice shown
- [ ] Select an image **over 340 KB** → inline notice appears, form submits successfully with the resized image visible in the heraldry slot
- [ ] After selecting a large image (resize in flight), quickly replace with a small image → small image is what actually uploads (generation counter prevents the stale resize from overwriting it)
- [ ] After uploading a new heraldry image, reload the admin edit page → new image is shown immediately (no stale cache)
- [ ] Click a heraldry thumbnail on any non-report page → lightbox overlay opens showing the full image; click overlay or press Escape to dismiss
- [ ] Click a heraldry thumbnail in the heraldry report → navigates to player page as before (lightbox does not intercept)

🤖 Generated with [Claude Code](https://claude.com/claude-code)