### PR TITLE
Bugfix: Add button unavailable for Player Award

### DIFF
--- a/orkui/controller/controller.Admin.php
+++ b/orkui/controller/controller.Admin.php
@@ -819,7 +819,7 @@ class Controller_Admin extends Controller {
                         if (!valid_id($this->request->Admin_player->KingdomAwardId)) {
                             $this->data['Error'] = 'You must choose an award. Award not added!'; break;
                         }
-                        if (!valid_id($this->request->Admin_player->MundaneId)) {
+                        if (!valid_id($this->request->Admin_player->GivenById)) {
                             $this->data['Error'] = 'Who gave this award? Award not added!'; break;
                         }
 						$r = $this->Player->add_player_award(array(
@@ -829,7 +829,7 @@ class Controller_Admin extends Controller {
 								'CustomName' => $this->request->Admin_player->AwardName,
 								'Rank' => $this->request->Admin_player->Rank,
 								'Date' => $this->request->Admin_player->Date,
-								'GivenById' => $this->request->Admin_player->MundaneId,
+								'GivenById' => $this->request->Admin_player->GivenById,
 								'Note' => $this->request->Admin_player->Note,
 								'ParkId' => valid_id($this->request->Admin_player->ParkId)?$this->request->Admin_player->ParkId:0,
 								'KingdomId' => valid_id($this->request->Admin_player->KingdomId)?$this->request->Admin_player->KingdomId:0,
@@ -864,7 +864,7 @@ class Controller_Admin extends Controller {
 								'AwardId' => $this->request->Admin_player->AwardId,
 								'Rank' => $this->request->Admin_player->Rank,
 								'Date' => $this->request->Admin_player->Date,
-								'GivenById' => $this->request->Admin_player->MundaneId,
+								'GivenById' => $this->request->Admin_player->GivenById,
 								'Note' => $this->request->Admin_player->Note,
 								'ParkId' => valid_id($this->request->Admin_player->ParkId)?$this->request->Admin_player->ParkId:0,
 								'KingdomId' => valid_id($this->request->Admin_player->KingdomId)?$this->request->Admin_player->KingdomId:0,

--- a/orkui/template/default/Admin_player.tpl
+++ b/orkui/template/default/Admin_player.tpl
@@ -478,7 +478,7 @@
 			change: function (e, ui) {
 				if (ui.item == null) {
 					showLabel('#GivenBy',null);
-					$('#MundaneId').val(null);
+					$('#GivenById').val('');
 				}
 				return false;
 			}
@@ -486,6 +486,7 @@
 			if (this.value == "")
 				$(this).trigger('keydown.autocomplete');
 		});
+		var givenBySelected = false;
 		$( "#GivenBy" ).autocomplete({
 			source: function( request, response ) {
 				park_id = $('#ParkId').val();
@@ -513,15 +514,17 @@
 			delay: 250,
 			select: function (e, ui) {
 				showLabel('#GivenBy', ui);
-				$('input[name=MundaneId]').val(ui.item.value);
+				$('#GivenById').val(ui.item.value);
+				givenBySelected = true;
 				checkRequiredFields();
 				return false;
 			},
 			change: function (e, ui) {
-				if (ui.item == null) {
+				if (!givenBySelected) {
 					showLabel('#GivenBy',null);
-					$('input[name=MundaneId]').val(null);
+					$('#GivenById').val('');
 				}
+				givenBySelected = false;
 				checkRequiredFields();
 				return false;
 			}
@@ -539,8 +542,8 @@
 	}
 	function checkRequiredFields() {
 		var hasAward = $('#AwardId').val() !== '' && $('#AwardId').val() !== null;
-		var hasGivenBy = $('#MundaneId').val() !== '' && $('#MundaneId').val() !== null && $('#MundaneId').val() > 0;
-		$('#Add').prop('disabled', !(hasAward && hasGivenBy));
+		var hasGivenBy = $('#GivenById').val() !== '' && $('#GivenById').val() !== null && $('#GivenById').val() > 0;
+		$('#AddAward').prop('disabled', !(hasAward && hasGivenBy));
 	}
 </script>
 
@@ -624,9 +627,10 @@
 		</div>
 		<div>
 			<span></span>
-			<span><input type='submit' id='Add' value='Add' disabled /><button type='button' id='Cancel' value='Cancel'>Cancel</button></span>
+			<span><input type='submit' id='AddAward' value='Add' disabled /><button type='button' id='Cancel' value='Cancel'>Cancel</button></span>
 		</div>
-		<input type='hidden' id='MundaneId' name='MundaneId' value='<?=isset($Admin_player)?$Admin_player['MundaneId']:0 ?>' />
+		<input type='hidden' id='MundaneId' name='MundaneId' value='<?=$Player['MundaneId'] ?>' />
+		<input type='hidden' id='GivenById' name='GivenById' value='<?=isset($Admin_player)?$Admin_player['GivenById']:'' ?>' />
 		<input type='hidden' id='ParkId' name='ParkId' value='<?=isset($Admin_player)?$Admin_player['ParkId']:$Player['ParkId'] ?>' />
 		<input type='hidden' id='KingdomId' name='KingdomId' value='<?=isset($Admin_player)?$Admin_player['KingdomId']:$Player['KingdomId'] ?>' />
 		<input type='hidden' id='EventId' name='EventId' value='<?=isset($Admin_player)?$Admin_player['EventId']:$Player['EventId'] ?>' />
@@ -677,7 +681,7 @@
 	function Reset() {
 		$( '#award-editor h3' ).text('Add Award');
 		$( '#award-editor form' ).attr('action', '<?=UIR ?>Admin/player/<?=$Player['MundaneId'] ?>/addaward' );
-		$( '#Add' ).val('Add');
+		$( '#AddAward' ).val('Add');
 		$( '#Cancel' ).hide();
 		$( '#AwardId' ).val('');
 		$( '#Rank' ).val('');
@@ -685,7 +689,8 @@
 		$( '#GivenBy' ).val('');
 		$( '#GivenAt' ).val('');
 		$( '#Note' ).val('');
-		$( '#MundaneId' ).val('');
+		$( '#MundaneId' ).val('<?=$Player['MundaneId'] ?>');
+		$( '#GivenById' ).val('');
 		$( '#ParkId' ).val('');
 		$( '#KingdomId' ).val('');
 		$( '#EventId' ).val('');
@@ -698,7 +703,7 @@
 		$( '#award-editor h3' ).text('Update Award');
 		$( '#award-editor form' ).attr('action', '<?=UIR ?>Admin/player/<?=$Player['MundaneId'] ?>/updateaward/' + id.toString() );
 		$( '#Cancel' ).show();
-		$( '#Add' ).val('Update');
+		$( '#AddAward' ).val('Update');
 		$.getJSON(
 			"<?=HTTP_SERVICE ?>Search/SearchService.php",
 			{
@@ -712,7 +717,7 @@
 				$( '#GivenBy' ).val(data['GivenBy']);
 				$( '#GivenAt' ).val((data['AtEventId'] > 0)?(data['EventName']):((data['AtParkId']>0)?data['ParkName']:data['KingdomName']));
 				$( '#Note' ).val(data['Note']);
-				$( '#MundaneId' ).val(data['GivenById']);
+				$( '#GivenById' ).val(data['GivenById']);
 				$( '#ParkId' ).val(data['ParkId']);
 				$( '#KingdomId' ).val(data['KingdomId']);
 				$( '#EventId' ).val(data['EventId']);


### PR DESCRIPTION
## Summary

Fixes #403 — the **Add** button in the Add Award form on the Admin Player page was permanently disabled and could never be enabled.

Two bugs combined to cause this:

### Bug 1: Duplicate element ID `id='Add'`

The page had two elements with `id='Add'` — the Dues form's submit button and the Award form's submit button. jQuery's `$('#Add')` matched only the **first** match (the Dues button), so `checkRequiredFields()` was toggling the wrong button. The Award form's Add button was never enabled.

**Fix:** Renamed the Award form's submit button to `id='AddAward'` and updated all JS references accordingly.

### Bug 2: Wrong hidden field used for giver vs. recipient

The form used a single `MundaneId` hidden field for both the award **recipient** and the "Given By" player. The `GivenBy` autocomplete's `select`/`change` handlers were overwriting `MundaneId` (the recipient), and `checkRequiredFields()` was checking `MundaneId` for the giver — making validation logic incorrect.

There was also a jQuery UI timing issue: when the `select` handler returns `false` (to prevent the raw ID from appearing in the text field), jQuery UI fires `change` with `ui.item == null` on blur, which immediately cleared the giver value and re-disabled the button.

**Fix:**
- Pre-fill `MundaneId` with the current player's ID (so recipient is always satisfied)
- Add a dedicated `GivenById` hidden field for the giver
- Update `checkRequiredFields()` to require `GivenById > 0`
- Add a `givenBySelected` flag to suppress the spurious `change` clear after `select` returns `false`
- Update `controller.Admin.php` to read `GivenById` (not `MundaneId`) for the giver in both `addaward` and `updateaward` cases

## Test plan

- [ ] Navigate to Admin → Player page for any player
- [ ] In the Add Award section, select an award from the dropdown
- [ ] Search for and select a "Given By" player via autocomplete — **Add button should enable**
- [ ] Submit the award and confirm it saves correctly with the right giver
- [ ] Edit an existing award — confirm it pre-fills correctly and saves with the right giver
- [ ] Confirm the Dues form's Add button still works independently

🤖 Generated with [Claude Code](https://claude.com/claude-code)