### PR TITLE
Feature: Quick access to monarch/regent for award given

### DIFF
--- a/orkui/controller/controller.Award.php
+++ b/orkui/controller/controller.Award.php
@@ -137,5 +137,27 @@ class Controller_Award extends Controller
 		$this->data['AwardOptions'] = $this->Award->fetch_award_option_list($this->session->kingdom_id, 'Awards');
 		$this->data['OfficerOptions'] = $this->Award->fetch_award_option_list($this->session->kingdom_id, 'Officers');
 		$this->data['Id'] = $id;
+
+		// Preload Kingdom and Park Monarch/Regent for GivenBy autocomplete
+		$preloadOfficers = array();
+		$kingdomOfficers = $this->Kingdom->get_officers($this->session->kingdom_id, $this->session->token);
+		if (is_array($kingdomOfficers)) {
+			foreach ($kingdomOfficers as $officer) {
+				if (in_array($officer['OfficerRole'], array('Monarch', 'Regent')) && $officer['MundaneId'] > 0) {
+					$preloadOfficers[] = array('MundaneId' => $officer['MundaneId'], 'Persona' => $officer['Persona'], 'Role' => 'Kingdom ' . $officer['OfficerRole']);
+				}
+			}
+		}
+		if (valid_id($this->session->park_id)) {
+			$parkOfficers = $this->Park->get_officers($this->session->park_id, $this->session->token);
+			if (is_array($parkOfficers)) {
+				foreach ($parkOfficers as $officer) {
+					if (in_array($officer['OfficerRole'], array('Monarch', 'Regent')) && $officer['MundaneId'] > 0) {
+						$preloadOfficers[] = array('MundaneId' => $officer['MundaneId'], 'Persona' => $officer['Persona'], 'Role' => 'Park ' . $officer['OfficerRole']);
+					}
+				}
+			}
+		}
+		$this->data['PreloadOfficers'] = $preloadOfficers;
 	}
 }

--- a/orkui/controller/controller.Player.php
+++ b/orkui/controller/controller.Player.php
@@ -189,7 +189,31 @@ class Controller_Player extends Controller {
 		}
 		$this->data['menu']['player'] = array( 'url' => UIR."Player/index/$id", 'display' => $this->data['Player']['Persona'] );
 		$this->data['AwardRecommendations'] = $this->Reports->recommended_awards(array('PlayerId'=>$id, 'KingdomId'=>0, 'ParkId'=>0, 'IncludeKnights' => 1, 'IncludeMasters' => 1, 'IncludeLadder' => 1, 'LadderMinimum' => $ladder));
-		
+
+		// Preload Kingdom and Park Monarch/Regent for GivenBy autocomplete
+		$this->load_model('Kingdom');
+		$preloadOfficers = array();
+		$kingdomOfficers = $this->Kingdom->get_officers($this->session->kingdom_id, $this->session->token);
+		if (is_array($kingdomOfficers)) {
+			foreach ($kingdomOfficers as $officer) {
+				if (in_array($officer['OfficerRole'], array('Monarch', 'Regent')) && $officer['MundaneId'] > 0) {
+					$preloadOfficers[] = array('MundaneId' => $officer['MundaneId'], 'Persona' => $officer['Persona'], 'Role' => 'Kingdom ' . $officer['OfficerRole']);
+				}
+			}
+		}
+		$parkId = $this->data['Player']['ParkId'];
+		if (valid_id($parkId)) {
+			$parkOfficers = $this->Park->get_officers($parkId, $this->session->token);
+			if (is_array($parkOfficers)) {
+				foreach ($parkOfficers as $officer) {
+					if (in_array($officer['OfficerRole'], array('Monarch', 'Regent')) && $officer['MundaneId'] > 0) {
+						$preloadOfficers[] = array('MundaneId' => $officer['MundaneId'], 'Persona' => $officer['Persona'], 'Role' => 'Park ' . $officer['OfficerRole']);
+					}
+				}
+			}
+		}
+		$this->data['PreloadOfficers'] = $preloadOfficers;
+
 	}
 	
 }

--- a/orkui/template/default/Admin_player.tpl
+++ b/orkui/template/default/Admin_player.tpl
@@ -487,8 +487,18 @@
 				$(this).trigger('keydown.autocomplete');
 		});
 		var givenBySelected = false;
+		var preloadedOfficers = [
+<?php if (is_array($PreloadOfficers)) foreach ($PreloadOfficers as $officer) : ?>
+			{label: <?=json_encode($officer['Persona'] . ' (' . $officer['Role'] . ')') ?>, value: <?=intval($officer['MundaneId']) ?>},
+<?php endforeach; ?>
+		];
 		$( "#GivenBy" ).autocomplete({
+			minLength: 0,
 			source: function( request, response ) {
+				if (request.term === '') {
+					response(preloadedOfficers.concat([{label: '...or start typing to search.', value: -1}]));
+					return;
+				}
 				park_id = $('#ParkId').val();
 				$.getJSON(
 					"<?=HTTP_SERVICE ?>Search/SearchService.php",
@@ -509,10 +519,12 @@
 				);
 			},
 			focus: function( event, ui ) {
+				if (ui.item.value === -1) return false;
 				return showLabel('#GivenBy', ui);
-			}, 
+			},
 			delay: 250,
 			select: function (e, ui) {
+				if (ui.item.value === -1) return false;
 				showLabel('#GivenBy', ui);
 				$('#GivenById').val(ui.item.value);
 				givenBySelected = true;

--- a/orkui/template/default/Award_addawards.tpl
+++ b/orkui/template/default/Award_addawards.tpl
@@ -93,8 +93,18 @@
 			if (this.value == "")
 				$(this).trigger('keydown.autocomplete');
 		});
+		var preloadedGivenByOfficers = [
+<?php if (is_array($PreloadOfficers)) foreach ($PreloadOfficers as $officer) : ?>
+			{label: <?=json_encode($officer['Persona'] . ' (' . $officer['Role'] . ')') ?>, value: <?=intval($officer['MundaneId']) ?>},
+<?php endforeach; ?>
+		];
 		$( "#GivenBy" ).autocomplete({
+			minLength: 0,
 			source: function( request, response ) {
+				if (request.term === '') {
+					response(preloadedGivenByOfficers.concat([{label: '...or start typing to search.', value: -1}]));
+					return;
+				}
 				park_id = $('#ParkId').val();
 				$.getJSON(
 					"<?=HTTP_SERVICE ?>Search/SearchService.php",
@@ -115,10 +125,12 @@
 				);
 			},
 			focus: function( event, ui ) {
+				if (ui.item.value === -1) return false;
 				return showLabel('#GivenBy', ui);
-			}, 
+			},
 			delay: 250,
 			select: function (e, ui) {
+				if (ui.item.value === -1) return false;
 				showLabel('#GivenBy', ui);
 				$('#GivenById').val(ui.item.value);
 				checkRequiredFields();


### PR DESCRIPTION
## Summary
- Preloads the player's Kingdom Monarch, Kingdom Regent, Park Monarch, and Park Regent as default suggestions in the "Given By" autocomplete field when adding awards
- Officers appear immediately when the field is focused (before typing); normal player search takes over once the user starts typing
- Applies to the Admin player page, Player public page, and Award (park/kingdom) pages
- Includes a "...or start typing to search." hint at the bottom of the preloaded list

## Test plan
- [ ] Navigate to Admin > Player page, click "Given By" field — verify up to 4 officers appear immediately
- [ ] Select a preloaded officer — verify GivenById is set and Add button enables
- [ ] Start typing in the field — verify normal AJAX search takes over
- [ ] Verify the "...or start typing to search." hint is not selectable
- [ ] Repeat on the Player public page award form
- [ ] Repeat on Park/Kingdom-level award pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)