### PR TITLE
Bugfix: Pagination issues on reports (#398)

### DIFF
--- a/orkui/template/default/Reports_customawards.tpl
+++ b/orkui/template/default/Reports_customawards.tpl
@@ -43,7 +43,7 @@
 			<option value="25">25</option>
 			<option value="50">50</option>
 			<option value="100">100</option>
-			<option value="all">All</option>
+			<option value="<?=is_array($Awards)?count($Awards):9999 ?>">All</option>
 		</select>
 	</div>
 </div>
@@ -85,7 +85,11 @@
 
 		$('.download.button').click(function(e) {
 			e.preventDefault();
-			$("table.information-table").table2csv({"filename":"Custom Awards", "excludeRows":".tablesorter-filter-row"});
+			var $table = $("table.information-table");
+			var $hiddenRows = $table.find('tbody tr:hidden');
+			$hiddenRows.show();
+			$table.table2csv({"filename":"Custom Awards", "excludeRows":".tablesorter-filter-row"});
+			$hiddenRows.hide();
 		});
 	});
 </script>

--- a/orkui/template/default/Reports_playerawards.tpl
+++ b/orkui/template/default/Reports_playerawards.tpl
@@ -53,7 +53,7 @@
 			<option value="25">25</option>
 			<option value="50">50</option>
 			<option value="100">100</option>
-			<option value="all">All</option>
+			<option value="<?=is_array($Awards)?count($Awards):9999 ?>">All</option>
 		</select>
 	</div>
 </div>
@@ -95,7 +95,11 @@
 
 		$('.download.button').click(function(e) {
 			e.preventDefault();
-			$("table.information-table").table2csv({"filename":"Player Awards", "excludeRows":".tablesorter-filter-row"});
+			var $table = $("table.information-table");
+			var $hiddenRows = $table.find('tbody tr:hidden');
+			$hiddenRows.show();
+			$table.table2csv({"filename":"Player Awards", "excludeRows":".tablesorter-filter-row"});
+			$hiddenRows.hide();
 		});
 	});
 </script>


### PR DESCRIPTION
## Summary
- **CSV Download** now exports all rows, not just the current page. Before exporting, hidden (paginated) rows are temporarily shown so `table2csv` captures the full dataset.
- **"All" page size option** now works. Changed the option value from the string `"all"` (which `parseInt()` can't parse) to the actual row count via PHP.

Fixes #398

## Test plan
- [ ] Navigate to Reports > Custom Awards for a kingdom with 25+ custom awards
- [ ] Select page size "All" — verify all rows display
- [ ] Go back to page size 25, stay on page 1, click Download CSV — verify CSV contains all rows
- [ ] Repeat on Reports > Player Awards

🤖 Generated with [Claude Code](https://claude.com/claude-code)