### PR TITLE
Enhancement: Allow PNG uploads and images with transparency

### DIFF
--- a/orkui/template/default/Atlas_index.tpl
+++ b/orkui/template/default/Atlas_index.tpl
@@ -43,7 +43,7 @@
 			$location = ((isset($location->location))?$location->location:$location->bounds->northeast);
 			if (is_numeric($location->lat) && is_numeric($location->lng)) :
 	?>
-  	locations.push(["<?=ucwords($Details['Name']) ?>", <?=$location->lat ?>, <?=$location->lng ?>, <?=$Details['ParkId'] ?>, "<?=($Details['HasHeraldry']?"<img src='" . HTTP_PARK_HERALDRY . sprintf("%05d", $Details['ParkId']) . ".jpg' />":'') . urlencode($Details['Directions'] . "<h4>Description</h4>" . $Details['Description']) ?>", <?=$Details['KingdomId'] ?>, "<?=$Details['KingdomColor'] ?>" ]);
+  	locations.push(["<?=ucwords($Details['Name']) ?>", <?=$location->lat ?>, <?=$location->lng ?>, <?=$Details['ParkId'] ?>, "<?=($Details['HasHeraldry']?"<img src='" . HTTP_PARK_HERALDRY . Common::resolve_image_ext(DIR_PARK_HERALDRY, sprintf("%05d", $Details['ParkId'])) . "' />":'') . urlencode($Details['Directions'] . "<h4>Description</h4>" . $Details['Description']) ?>", <?=$Details['KingdomId'] ?>, "<?=$Details['KingdomColor'] ?>" ]);
 		LatLngList.push(new google.maps.LatLng (<?=$location->lat ?>, <?=$location->lng ?>));
 	<?php endif ; ?>
 	<?php endforeach ; ?>

--- a/orkui/template/default/Atlas_map.tpl
+++ b/orkui/template/default/Atlas_map.tpl
@@ -29,7 +29,7 @@
 			$location = ((isset($location->location))?$location->location:$location->bounds->northeast);
 			if (is_numeric($location->lat) && is_numeric($location->lng)) :
 	?>
-  	locations.push(["<?=ucwords($Details['Name']) ?>", <?=$location->lat ?>, <?=$location->lng ?>, <?=$Details['ParkId'] ?>, "<?=($Details['HasHeraldry']?"<img src='" . HTTP_PARK_HERALDRY . sprintf("%05d", $Details['ParkId']) . ".jpg' />":'') . urlencode($Details['Directions'] . "<h4>Description</h4>" . $Details['Description']) ?>", <?=$Details['KingdomId'] ?>, "<?=$Details['KingdomColor'] ?>" ]);
+  	locations.push(["<?=ucwords($Details['Name']) ?>", <?=$location->lat ?>, <?=$location->lng ?>, <?=$Details['ParkId'] ?>, "<?=($Details['HasHeraldry']?"<img src='" . HTTP_PARK_HERALDRY . Common::resolve_image_ext(DIR_PARK_HERALDRY, sprintf("%05d", $Details['ParkId'])) . "' />":'') . urlencode($Details['Directions'] . "<h4>Description</h4>" . $Details['Description']) ?>", <?=$Details['KingdomId'] ?>, "<?=$Details['KingdomColor'] ?>" ]);
 		LatLngList.push(new google.maps.LatLng (<?=$location->lat ?>, <?=$location->lng ?>));
 	<?php endif ; ?>
 	<?php endforeach ; ?>

--- a/orkui/template/default/Kingdom_index.tpl
+++ b/orkui/template/default/Kingdom_index.tpl
@@ -42,7 +42,7 @@
 				<td>
 					<div class='tiny-heraldry'>
 						<?php if ($park['HasHeraldry']==1): ?>
-							<img src="<?=HTTP_PARK_HERALDRY . sprintf("%05d", $park['ParkId']) ?>.jpg" onerror="this.src='<?=HTTP_PARK_HERALDRY ?>00000.jpg';">
+							<img src="<?=HTTP_PARK_HERALDRY . Common::resolve_image_ext(DIR_PARK_HERALDRY, sprintf("%05d", $park['ParkId'])) ?>" onerror="this.src='<?=HTTP_PARK_HERALDRY ?>00000.jpg';">
 						<?php else: ?>
 							<img src="<?=HTTP_PARK_HERALDRY ?>00000.jpg">
 						<?php endif; ?>
@@ -79,7 +79,7 @@
 			<tr onclick='javascript:window.location.href="<?=UIR;?>Kingdom/index/<?=$prinz['KingdomId'];?>&kingdom_name=<?=$prinz['Name'];?>"'>
 				<td>
 					<div class='tiny-heraldry'>
-						<img src="<?=HTTP_KINGDOM_HERALDRY . sprintf("%04d", $prinz['KingdomId']) ?>.jpg" onerror="this.src='<?=HTTP_KINGDOM_HERALDRY ?>0000.jpg';">
+						<img src="<?=HTTP_KINGDOM_HERALDRY . Common::resolve_image_ext(DIR_KINGDOM_HERALDRY, sprintf("%04d", $prinz['KingdomId'])) ?>" onerror="this.src='<?=HTTP_KINGDOM_HERALDRY ?>0000.jpg';">
 					</div>
 					<?=$prinz['Name'] ?>
 				</td>
@@ -163,7 +163,7 @@
 				<td>
 					<div class='tiny-heraldry'>
 						<?php if ($event['HasHeraldry']==1): ?>
-							<img src="<?=HTTP_EVENT_HERALDRY . sprintf("%05d", $event['EventId']) ?>.jpg" onerror="this.src='<?=HTTP_EVENT_HERALDRY ?>00000.jpg';">
+							<img src="<?=HTTP_EVENT_HERALDRY . Common::resolve_image_ext(DIR_EVENT_HERALDRY, sprintf("%05d", $event['EventId'])) ?>" onerror="this.src='<?=HTTP_EVENT_HERALDRY ?>00000.jpg';">
 						<?php else: ?>
 							<img src="<?=HTTP_EVENT_HERALDRY ?>00000.jpg">
 						<?php endif; ?>

--- a/orkui/template/default/Kingdom_map.tpl
+++ b/orkui/template/default/Kingdom_map.tpl
@@ -31,7 +31,7 @@
 			$location = ((isset($location->location))?$location->location:$location->bounds->northeast);
 			if (is_numeric($location->lat) && is_numeric($location->lng)) :
 	?>
-  	locations.push(["<?=ucwords($Details['Name']) ?>", <?=$location->lat ?>, <?=$location->lng ?>, <?=$Details['ParkId'] ?>, "<?=($Details['HasHeraldry']?"<img src='" . HTTP_PARK_HERALDRY . sprintf("%05d", $Details['ParkId']) . ".jpg' />":'') . urlencode($Details['Directions'] . "<h4>Description</h4>" . $Details['Description']) ?>", <?=$Details['KingdomId'] ?>, "<?=$Details['KingdomColor'] ?>" ]);
+  	locations.push(["<?=ucwords($Details['Name']) ?>", <?=$location->lat ?>, <?=$location->lng ?>, <?=$Details['ParkId'] ?>, "<?=($Details['HasHeraldry']?"<img src='" . HTTP_PARK_HERALDRY . Common::resolve_image_ext(DIR_PARK_HERALDRY, sprintf("%05d", $Details['ParkId'])) . "' />":'') . urlencode($Details['Directions'] . "<h4>Description</h4>" . $Details['Description']) ?>", <?=$Details['KingdomId'] ?>, "<?=$Details['KingdomColor'] ?>" ]);
 		LatLngList.push(new google.maps.LatLng (<?=$location->lat ?>, <?=$location->lng ?>));
 	<?php endif ; ?>
 	<?php endforeach ; ?>

--- a/orkui/template/default/Park_index.tpl
+++ b/orkui/template/default/Park_index.tpl
@@ -168,7 +168,7 @@
 				<td>
 					<div class='tiny-heraldry'>
 						<?php if ($event['HasHeraldry']==1): ?>
-							<img src="<?=HTTP_EVENT_HERALDRY . sprintf("%05d", $event['EventId']) ?>.jpg" onerror="this.src='<?=HTTP_EVENT_HERALDRY ?>00000.jpg';">
+							<img src="<?=HTTP_EVENT_HERALDRY . Common::resolve_image_ext(DIR_EVENT_HERALDRY, sprintf("%05d", $event['EventId'])) ?>" onerror="this.src='<?=HTTP_EVENT_HERALDRY ?>00000.jpg';">
 						<?php else: ?>
 							<img src="<?=HTTP_EVENT_HERALDRY ?>00000.jpg">
 						<?php endif; ?>

--- a/orkui/template/default/default.tpl
+++ b/orkui/template/default/default.tpl
@@ -42,7 +42,7 @@
             <?php $parks += $report['ParkCount']; $part += $report['Participation']; $ave += $report['Attendance']/26.0; $total += $report['Attendance'];  $month_total += $report['Monthly'];?>
 			<tr onclick='javascript:window.location.href="<?=UIR;?>Kingdom/index/<?=$report['KingdomId']; ?>&kingdom_name=<?=$report['KingdomName']; ?>";'>
 				<td>
-				    <div class='tiny-heraldry'><img src='<?=HTTP_KINGDOM_HERALDRY . sprintf('%04d.jpg',$report['KingdomId']) ?>'></div>
+				    <div class='tiny-heraldry'><img src='<?=HTTP_KINGDOM_HERALDRY . Common::resolve_image_ext(DIR_KINGDOM_HERALDRY, sprintf('%04d',$report['KingdomId'])) ?>'></div>
 				    <?=stripslashes($report['KingdomName'] ?? ''); ?>
 				</td>
 				<td class='data-column'><?=$report['ParkCount']; ?></td>
@@ -86,7 +86,7 @@
             <?php $parks += $report['ParkCount']; $part += $report['Participation']; $ave += $report['Attendance']/26.0; $total += $report['Attendance'];  $month_total += $report['Monthly'];?>
 			<tr onclick='javascript:window.location.href="<?=UIR;?>Kingdom/index/<?=$report['KingdomId']; ?>";'>
 				<td>
-				    <div class='tiny-heraldry'><img src='<?=HTTP_KINGDOM_HERALDRY . sprintf('%04d.jpg',$report['KingdomId']) ?>'></div>
+				    <div class='tiny-heraldry'><img src='<?=HTTP_KINGDOM_HERALDRY . Common::resolve_image_ext(DIR_KINGDOM_HERALDRY, sprintf('%04d',$report['KingdomId'])) ?>'></div>
 				    <?=stripslashes($report['KingdomName']); ?>
 				</td>
 				<td class='data-column'><?=$report['ParkCount']; ?></td>
@@ -140,7 +140,7 @@
 				<td>
 					<div class='tiny-heraldry'>
 						<?php if ($event['HasHeraldry']==1): ?>
-							<img src="<?=HTTP_EVENT_HERALDRY . sprintf("%05d", $event['EventId']) ?>.jpg" onerror="this.src='<?=HTTP_EVENT_HERALDRY ?>00000.jpg';">
+							<img src="<?=HTTP_EVENT_HERALDRY . Common::resolve_image_ext(DIR_EVENT_HERALDRY, sprintf("%05d", $event['EventId'])) ?>" onerror="this.src='<?=HTTP_EVENT_HERALDRY ?>00000.jpg';">
 						<?php else: ?>
 							<img src="<?=HTTP_EVENT_HERALDRY ?>00000.jpg">
 						<?php endif; ?>

--- a/system/lib/ork3/class.Heraldry.php
+++ b/system/lib/ork3/class.Heraldry.php
@@ -14,21 +14,35 @@ class Heraldry  extends Ork3 {
 	public function GetHeraldry($request) {
 		$response = array('Heraldry'=>'');
 		switch ($request['Type']) {
-			case 'Player': $response['Heraldry'] = base64_encode(file_get_contents(DIR_PLAYER_HERALDRY . sprintf('%06d.jpg', $request['Id']))); break;
+			case 'Player':
+				$name = sprintf('%06d', $request['Id']);
+				$path = file_exists(DIR_PLAYER_HERALDRY . $name . '.png')
+					? DIR_PLAYER_HERALDRY . $name . '.png'
+					: DIR_PLAYER_HERALDRY . $name . '.jpg';
+				$response['Heraldry'] = base64_encode(file_get_contents($path));
+				break;
 		}
 		return $response;
 	}
-	
+
 	public function GetHeraldryUrl($request) {
 		$response = array('Url'=>'');
 		switch ($request['Type']) {
-			case 'Player': $response['Url'] = HTTP_PLAYER_HERALDRY . sprintf('%06d.jpg', $request['Id']); break;
-			case 'Park': $response['Url'] = HTTP_PARK_HERALDRY . sprintf('%05d.jpg', $request['Id']); break;
-			case 'Kingdom': $response['Url'] = HTTP_KINGDOM_HERALDRY . sprintf('%04d.jpg', $request['Id']); break;
-			case 'Unit': $response['Url'] = HTTP_UNIT_HERALDRY . sprintf('%05d.jpg', $request['Id']); break;
-			case 'Event': $response['Url'] = HTTP_EVENT_HERALDRY . sprintf('%05d.jpg', $request['Id']); break;
+			case 'Player': $response['Url'] = $this->resolve_heraldry_url(HTTP_PLAYER_HERALDRY, DIR_PLAYER_HERALDRY, 6, $request['Id']); break;
+			case 'Park': $response['Url'] = $this->resolve_heraldry_url(HTTP_PARK_HERALDRY, DIR_PARK_HERALDRY, 5, $request['Id']); break;
+			case 'Kingdom': $response['Url'] = $this->resolve_heraldry_url(HTTP_KINGDOM_HERALDRY, DIR_KINGDOM_HERALDRY, 4, $request['Id']); break;
+			case 'Unit': $response['Url'] = $this->resolve_heraldry_url(HTTP_UNIT_HERALDRY, DIR_UNIT_HERALDRY, 5, $request['Id']); break;
+			case 'Event': $response['Url'] = $this->resolve_heraldry_url(HTTP_EVENT_HERALDRY, DIR_EVENT_HERALDRY, 5, $request['Id']); break;
 		}
 		return $response;
+	}
+
+	private function resolve_heraldry_url($http_base, $dir_base, $pad_len, $id) {
+		$name = sprintf("%0" . $pad_len . "d", $id);
+		if (file_exists($dir_base . $name . '.png')) {
+			return $http_base . $name . '.png';
+		}
+		return $http_base . $name . '.jpg';
 	}
 	
 	public function SetPlayerHeraldry($request) {
@@ -54,14 +68,23 @@ class Heraldry  extends Ork3 {
     
     private function store_heraldry($request, $path, $img_len, $table) {
 		if (strlen($request['Heraldry']) > 0 && strlen($request['Heraldry']) < 465000 && Common::supported_mime_types($request['HeraldryMimeType'])) {
-			$heraldry = @imagecreatefromstring(base64_decode($request['Heraldry'])); 
-			if($heraldry !== false) 
-			{ 
-                $src_id = ucwords($table) . 'Id';
-				if (file_exists( $path.(sprintf("%0" . $img_len . "d",$request[$src_id])).'.jpg')) 
-                    unlink( $path.(sprintf("%0" . $img_len . "d",$request[$src_id])).'.jpg');
-				$fullpath = $path.(sprintf("%0" . $img_len . "d",$request[$src_id])).'.jpg';
-				imagejpeg($heraldry, $fullpath); 
+			$heraldry = @imagecreatefromstring(base64_decode($request['Heraldry']));
+			if ($heraldry !== false) {
+				$src_id = ucwords($table) . 'Id';
+				$base = $path . sprintf("%0" . $img_len . "d", $request[$src_id]);
+				$use_png = Common::gd_has_transparency($heraldry);
+
+				if (file_exists($base . '.jpg')) unlink($base . '.jpg');
+				if (file_exists($base . '.png')) unlink($base . '.png');
+
+				if ($use_png) {
+					imagealphablending($heraldry, false);
+					imagesavealpha($heraldry, true);
+					imagepng($heraldry, $base . '.png');
+				} else {
+					imagejpeg($heraldry, $base . '.jpg');
+				}
+
 				$this->$table->has_heraldry = 1;
 			}
 		}

--- a/system/lib/ork3/class.Player.php
+++ b/system/lib/ork3/class.Player.php
@@ -247,7 +247,7 @@ class Player extends Ork3 {
 					'HasHeraldry' => $this->mundane->has_heraldry,
 					'Heraldry' => $heraldry['Url'] . '?' . strtotime($this->mundane->modified),
 					'HasImage' => $this->mundane->has_image,
-					'Image' => HTTP_PLAYER_IMAGE . sprintf('%06d.jpg?' . strtotime($this->mundane->modified), $this->mundane->mundane_id),
+					'Image' => $this->resolve_player_image_url($this->mundane->mundane_id, $this->mundane->modified),
 					'PenaltyBox' => $this->mundane->penalty_box,
 					'Active' => $this->mundane->active,
 					'PasswordExpires' => $this->mundane->password_expires,
@@ -520,11 +520,24 @@ class Player extends Ork3 {
 
 				if ($request['Waivered'] && strlen($request['Waiver']) > 0 && strlen($request['Waiver']) < 465000 && Common::supported_mime_types($request['WaiverMimeType']) && !Common::is_pdf_mime_type($request['WaiverMimeType'])) {
 					$waiver = @imagecreatefromstring(base64_decode($request['Waiver']));
-					if($waiver !== false)
+					if ($waiver !== false)
 					{
-						imagejpeg($waiver, DIR_WAIVERS.(sprintf("%06d",$this->mundane->mundane_id)).'.jpg');
+						$base = DIR_WAIVERS . sprintf("%06d", $this->mundane->mundane_id);
+						$use_png = Common::gd_has_transparency($waiver);
+
+						if (file_exists($base . '.jpg')) unlink($base . '.jpg');
+						if (file_exists($base . '.png')) unlink($base . '.png');
+
+						if ($use_png) {
+							imagealphablending($waiver, false);
+							imagesavealpha($waiver, true);
+							imagepng($waiver, $base . '.png');
+							$this->mundane->waiver_ext = 'png';
+						} else {
+							imagejpeg($waiver, $base . '.jpg');
+							$this->mundane->waiver_ext = 'jpg';
+						}
 						$this->mundane->waivered = 1;
-						$this->mundane->waiver_ext = 'jpg';
 					} else {
 						$this->mundane->saivered = 0;
 					}
@@ -538,9 +551,21 @@ class Player extends Ork3 {
 				}
 				if ($request['HasImage'] && strlen($request['Image']) > 0 && strlen($request['Image']) < 465000 && Common::supported_mime_types($request['ImageMimeType']) && !Common::is_pdf_mime_type($request['ImageMimeType'])) {
 					$playerimage = @imagecreatefromstring(base64_decode($request['Image']));
-					if($playerimage !== false)
+					if ($playerimage !== false)
 					{
-						imagejpeg($playerimage, DIR_PLAYER_IMAGE.(sprintf("%06d",$this->mundane->mundane_id)).'.jpg');
+						$base = DIR_PLAYER_IMAGE . sprintf("%06d", $this->mundane->mundane_id);
+						$use_png = Common::gd_has_transparency($playerimage);
+
+						if (file_exists($base . '.jpg')) unlink($base . '.jpg');
+						if (file_exists($base . '.png')) unlink($base . '.png');
+
+						if ($use_png) {
+							imagealphablending($playerimage, false);
+							imagesavealpha($playerimage, true);
+							imagepng($playerimage, $base . '.png');
+						} else {
+							imagejpeg($playerimage, $base . '.jpg');
+						}
 						$this->mundane->has_image = 1;
 					} else {
 						$this->mundane->has_image = 0;
@@ -917,11 +942,21 @@ class Player extends Ork3 {
         $request = $this->media_fetch('Image', $request);
 		if (strlen($request['Image']) > 0 && strlen($request['Image']) < 465000 && Common::supported_mime_types($request['ImageMimeType']) && !Common::is_pdf_mime_type($request['ImageMimeType'])) {
 			$playerimage = imagecreatefromstring(base64_decode($request['Image']));
-			if($playerimage !== false)
+			if ($playerimage !== false)
 			{
-    			if (file_exists( DIR_PLAYER_IMAGE.(sprintf("%06d",$this->mundane->mundane_id)).'.jpg' ))
-                    unlink( DIR_PLAYER_IMAGE.(sprintf("%06d",$this->mundane->mundane_id)).'.jpg' );
-				imagejpeg($playerimage, DIR_PLAYER_IMAGE.(sprintf("%06d",$this->mundane->mundane_id)).'.jpg');
+				$base = DIR_PLAYER_IMAGE . sprintf("%06d", $this->mundane->mundane_id);
+				$use_png = Common::gd_has_transparency($playerimage);
+
+				if (file_exists($base . '.jpg')) unlink($base . '.jpg');
+				if (file_exists($base . '.png')) unlink($base . '.png');
+
+				if ($use_png) {
+					imagealphablending($playerimage, false);
+					imagesavealpha($playerimage, true);
+					imagepng($playerimage, $base . '.png');
+				} else {
+					imagejpeg($playerimage, $base . '.jpg');
+				}
 				$this->mundane->has_image = 1;
 			} else {
 				$notices .= "Image could not be decoded.";
@@ -931,6 +966,12 @@ class Player extends Ork3 {
 		}
 		logtrace("set_image() complete", array($request, $notices));
 		return Success($notices);
+	}
+
+	private function resolve_player_image_url($mundane_id, $modified) {
+		$name = sprintf('%06d', $mundane_id);
+		$ext = file_exists(DIR_PLAYER_IMAGE . $name . '.png') ? 'png' : 'jpg';
+		return HTTP_PLAYER_IMAGE . $name . '.' . $ext . '?' . strtotime($modified);
 	}
 
 	public function set_waiver($request) {
@@ -944,13 +985,24 @@ class Player extends Ork3 {
     		if ($request['Waivered'] && strlen($request['Waiver']) > 0 && strlen($request['Waiver']) < 465000 && Common::supported_mime_types($request['WaiverMimeType']) && !Common::is_pdf_mime_type($request['WaiverMimeType'])) {
 				logtrace("set_waiver() - image", $request);
     			$waiver = @imagecreatefromstring(base64_decode($request['Waiver']));
-    			if($waiver !== false)
+    			if ($waiver !== false)
     			{
-            		if (file_exists( DIR_WAIVERS.(sprintf("%06d",$request['MundaneId'])).'.jpg' ))
-                        unlink( DIR_WAIVERS.(sprintf("%06d",$request['MundaneId'])).'.jpg' );
-    				imagejpeg($waiver, DIR_WAIVERS.(sprintf("%06d",$request['MundaneId'])).'.jpg');
+					$base = DIR_WAIVERS . sprintf("%06d", $request['MundaneId']);
+					$use_png = Common::gd_has_transparency($waiver);
+
+					if (file_exists($base . '.jpg')) unlink($base . '.jpg');
+					if (file_exists($base . '.png')) unlink($base . '.png');
+
+					if ($use_png) {
+						imagealphablending($waiver, false);
+						imagesavealpha($waiver, true);
+						imagepng($waiver, $base . '.png');
+						$this->mundane->waiver_ext = 'png';
+					} else {
+						imagejpeg($waiver, $base . '.jpg');
+						$this->mundane->waiver_ext = 'jpg';
+					}
     				$this->mundane->waivered = 1;
-    				$this->mundane->waiver_ext = 'jpg';
     			} else {
     				$notices .= 'There was an error uploading or decoding your image.<br />';
 					return InvalidParameter($notices);

--- a/system/lib/ork3/common.php
+++ b/system/lib/ork3/common.php
@@ -258,6 +258,36 @@ class Common
 		return false;
 	}
 
+	public static function gd_has_transparency( $gd )
+	{
+		// Check palette-based transparency (GIF)
+		if ( imagecolortransparent( $gd ) >= 0 ) {
+			return true;
+		}
+		// Sample a grid of pixels for alpha channel transparency (PNG)
+		$w = imagesx( $gd );
+		$h = imagesy( $gd );
+		$step_x = max( 1, (int)( $w / 16 ) );
+		$step_y = max( 1, (int)( $h / 16 ) );
+		for ( $x = 0; $x < $w; $x += $step_x ) {
+			for ( $y = 0; $y < $h; $y += $step_y ) {
+				$rgba = imagecolorsforindex( $gd, imagecolorat( $gd, $x, $y ) );
+				if ( $rgba['alpha'] > 0 ) {
+					return true;
+				}
+			}
+		}
+		return false;
+	}
+
+	public static function resolve_image_ext( $dir_base, $name )
+	{
+		if ( file_exists( $dir_base . $name . '.png' ) ) {
+			return $name . '.png';
+		}
+		return $name . '.jpg';
+	}
+
 	public static function supported_mime_types( $type )
 	{
 		switch ( strtoupper( $type ) ) {


### PR DESCRIPTION
## Summary

Previously, all uploaded images (heraldry, player photos, waivers) were unconditionally converted to JPEG via PHP GD's `imagecreatefromstring()` + `imagejpeg()`. Because JPEG has no alpha channel support, transparent areas in PNGs rendered as **black backgrounds**. This PR detects transparency in uploaded images and preserves PNG format when present, falling back to JPEG for opaque images.

Closes #91 

## Changes by file

### PHP Backend

- **`system/lib/ork3/common.php`** — Added two new static methods to `Common`:
  - `gd_has_transparency($gd)` — Samples a 16×16 grid of pixels from a GD resource to detect alpha channel transparency; also checks for palette-based transparency (GIF)
  - `resolve_image_ext($dir_base, $name)` — Filesystem probe that checks for `.png` first, falls back to `.jpg`; used by templates for thumbnail URLs

- **`system/lib/ork3/class.Heraldry.php`** — Updated image save and retrieval for all entity types (player, park, kingdom, unit, event):
  - `store_heraldry()` — Detects transparency and saves as PNG (with `imagesavealpha`) or JPEG accordingly; cleans up both `.jpg` and `.png` before writing to prevent orphan files
  - `GetHeraldryUrl()` — New `resolve_heraldry_url()` private helper probes filesystem for `.png` first, falls back to `.jpg`
  - `GetHeraldry()` — Same filesystem probe for the raw base64 content endpoint

- **`system/lib/ork3/class.Player.php`** — Updated all image save locations:
  - `set_image()` — Transparency-aware save (PNG or JPEG) for player photos
  - `player_info()` — New `resolve_player_image_url()` private helper replaces hardcoded `.jpg` extension in the Image URL
  - `set_waiver()` — Transparency-aware save; sets `waiver_ext` to `'png'` or `'jpg'` accordingly
  - `create_player()` — Both inline waiver and player image saves updated with same transparency detection pattern

### Client-Side JavaScript

- **`orkui/template/default/script/orkui.js`** — Updated the auto-resize logic:
  - `resizeImageToLimit()` — New `preservePng` parameter: PNGs use `canvas.toBlob('image/png')` to preserve transparency; JPEGs get a white canvas fill before drawing to prevent black backgrounds on any residual transparency
  - `.restricted-image-type` change handler — Detects PNG source files and passes format through to resize function and output `File` object

### Templates (thumbnail URL fixes)

Replaced hardcoded `.jpg` extensions with `Common::resolve_image_ext()` calls for dynamic heraldry thumbnails:

- **`orkui/template/default/Kingdom_index.tpl`** — Park, principality, and event heraldry thumbnails
- **`orkui/template/default/Park_index.tpl`** — Event heraldry thumbnail
- **`orkui/template/default/default.tpl`** — Kingdom heraldry in summary tables, event heraldry thumbnail
- **`orkui/template/default/Atlas_index.tpl`** — Park heraldry on atlas map
- **`orkui/template/default/Atlas_map.tpl`** — Park heraldry on atlas map
- **`orkui/template/default/Kingdom_map.tpl`** — Park heraldry on kingdom map

## Backward compatibility

- All existing `.jpg` files continue to work — URL resolvers fall back to `.jpg` when no `.png` exists
- No database migration required
- Default/placeholder heraldry images (e.g., `00000.jpg`) are unchanged

## Note from Tobias

This is a sizeable PR, tested quite a bit of pages but let me know if review finds anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)