### PR TITLE
Enhancement: Top Parks Report

### DIFF
--- a/orkservice/Report/ReportService.definitions.php
+++ b/orkservice/Report/ReportService.definitions.php
@@ -233,6 +233,60 @@ $server->wsdl->addComplexType(
 	);
 	
 $server->wsdl->addComplexType(
+		'GetTopParksByAttendanceRequest',
+		'complextType',
+		'struct',
+		'all',
+		'',
+		array(
+				'StartDate'=>array('name'=>'StartDate','type'=>'xsd:date'),
+				'EndDate'=>array('name'=>'EndDate','type'=>'xsd:date'),
+				'Limit'=>array('name'=>'Limit','type'=>'xsd:int'),
+				'NativePopulace'=>array('name'=>'NativePopulace','type'=>'xsd:boolean')
+			)
+	);
+
+$server->wsdl->addComplexType(
+		'TopParksSummaryItemType',
+		'complextType',
+		'struct',
+		'all',
+		'',
+		array(
+				'ParkId'=>array('name'=>'ParkId','type'=>'xsd:int'),
+				'ParkName'=>array('name'=>'ParkName','type'=>'xsd:string'),
+				'KingdomId'=>array('name'=>'KingdomId','type'=>'xsd:int'),
+				'KingdomName'=>array('name'=>'KingdomName','type'=>'xsd:string'),
+				'AttendanceCount'=>array('name'=>'AttendanceCount','type'=>'xsd:int')
+			)
+	);
+
+$server->wsdl->addComplexType(
+		'TopParksSummaryListType',
+		'complexType',
+		'array',
+		'',
+		'SOAP-ENC:Array',
+		array(),
+		array(
+			array('ref'=>'SOAP-ENC:arrayType', 'wsdl:arrayType'=> 'tns:TopParksSummaryItemType[]')
+			),
+		'tns:TopParksSummaryItemType'
+	);
+
+$server->wsdl->addComplexType(
+		'GetTopParksByAttendanceResponse',
+		'complextType',
+		'struct',
+		'all',
+		'',
+		array(
+				'Status'=>array('name'=>'Status','type'=>'tns:StatusType'),
+				'TopParksSummary'=>array('name'=>'TopParksSummary','type'=>'tns:TopParksSummaryListType')
+			)
+	);
+
+$server->wsdl->addComplexType(
 		'GetPlayerRosterRequest',
 		'complextType',
 		'struct',

--- a/orkservice/Report/ReportService.function.php
+++ b/orkservice/Report/ReportService.function.php
@@ -20,6 +20,11 @@ function GetKingdomParkMonthlyAverages($request) {
 	return $R->GetKingdomParkMonthlyAverages($request);
 }
 
+function GetTopParksByAttendance($request) {
+	$R = new Report();
+	return $R->GetTopParksByAttendance($request);
+}
+
 function GetPlayerRoster($request) {
 	$R = new Report();
 	return $R->GetPlayerRoster($request);

--- a/orkservice/Report/ReportService.registration.php
+++ b/orkservice/Report/ReportService.registration.php
@@ -28,6 +28,13 @@ $server->register(
 	);
 
 $server->register(
+		'GetTopParksByAttendance',
+		array('GetTopParksByAttendance'=>'tns:GetTopParksByAttendanceRequest'),
+		array('return' => 'tns:GetTopParksByAttendanceResponse'),
+		$namespace
+	);
+
+$server->register(
 		'GetPlayerRoster',
 		array('GetPlayerRoster'=>'tns:GetPlayerRosterRequest'),
 		array('return' => 'tns:GetPlayerRosterResponse'),

--- a/orkui/controller/controller.Admin.php
+++ b/orkui/controller/controller.Admin.php
@@ -1543,6 +1543,26 @@ class Controller_Admin extends Controller {
 		$this->data[ 'page_title' ] = "Admin: " . $this->data['ParkInfo']['ParkName'];
 	}
 
+	public function topparks($limit = null) {
+		$this->load_model('Admin');
+		$limit = intval($limit) > 0 ? intval($limit) : 25;
+		$start_date = isset($this->request->StartDate) && preg_match('/^\d{4}-\d{2}-\d{2}$/', $this->request->StartDate)
+			? $this->request->StartDate
+			: date("Y-m-d", strtotime("-12 month"));
+		$end_date = isset($this->request->EndDate) && preg_match('/^\d{4}-\d{2}-\d{2}$/', $this->request->EndDate)
+			? $this->request->EndDate
+			: date("Y-m-d");
+		$week_count = max(1, ceil((strtotime($end_date) - strtotime($start_date)) / (7 * 86400)));
+		$native_populace = !empty($this->request->NativePopulace);
+		$result = $this->Admin->get_top_parks_by_attendance($limit, $start_date, $end_date, $native_populace);
+		$this->data['TopParks'] = $result['TopParksSummary'];
+		$this->data['StartDate'] = $start_date;
+		$this->data['EndDate'] = $end_date;
+		$this->data['WeekCount'] = $week_count;
+		$this->data['Limit'] = $limit;
+		$this->data['NativePopulace'] = $native_populace;
+	}
+
 	private function kingdom_route($id) {
 		$this->data['kingdom_id'] = $id;
 		$this->session->kingdom_id = $id;

--- a/orkui/model/model.Admin.php
+++ b/orkui/model/model.Admin.php
@@ -16,7 +16,11 @@ class Model_Admin extends Model {
 	function get_park_summary($kingdom_id) {
 		return $this->Report->GetKingdomParkAverages(array('KingdomId'=>$kingdom_id));
 	}
-	
+
+	function get_top_parks_by_attendance($limit = 25, $start_date = null, $end_date = null, $native_populace = false) {
+		return $this->Report->GetTopParksByAttendance(array('Limit'=>$limit, 'StartDate'=>$start_date, 'EndDate'=>$end_date, 'NativePopulace'=>$native_populace));
+	}
+
 }
 
 ?>

--- a/orkui/template/default/Admin_index.tpl
+++ b/orkui/template/default/Admin_index.tpl
@@ -30,5 +30,6 @@
 		<li><a href='<?=UIR ?>Reports/player_awards&Ladder=8'>Kingdom-level Awards</a></li>
 		<li><a href='<?=UIR ?>Reports/class_masters'>Class Masters/Paragons</a></li>
 		<li><a href='<?=UIR ?>Unit/unitlist'>Companies and Households</a></li>
+		<li><a href='<?=UIR ?>Admin/topparks'>Top Parks by Attendance</a></li>
 	</ul>
 </div>

--- a/orkui/template/default/Admin_topparks.tpl
+++ b/orkui/template/default/Admin_topparks.tpl
@@ -1,0 +1,62 @@
+<script>
+	$(function() {
+		$('#StartDate').datepicker({dateFormat: 'yy-mm-dd'});
+		$('#EndDate').datepicker({dateFormat: 'yy-mm-dd'});
+	});
+</script>
+<div class='info-container'>
+	<h3>Top <?=$Limit; ?> Parks by Attendance</h3>
+	<form class='form-container' method='post' action='<?=UIR ?>Admin/topparks'>
+		<table>
+			<tr>
+				<td><label>Start Date</label></td>
+				<td><input type='text' name='StartDate' id='StartDate' value='<?=htmlspecialchars($StartDate); ?>' /></td>
+			</tr>
+			<tr>
+				<td><label>End Date</label></td>
+				<td><input type='text' name='EndDate' id='EndDate' value='<?=htmlspecialchars($EndDate); ?>' /></td>
+			</tr>
+			<tr>
+				<td><label>Local Players Only</label></td>
+				<td><input type='checkbox' name='NativePopulace' value='1' <?=$NativePopulace ? "checked='checked'" : ''; ?> /></td>
+			</tr>
+			<tr>
+				<td></td>
+				<td><input type='submit' value='Update' /></td>
+			</tr>
+		</table>
+	</form>
+	<table class='information-table'>
+		<thead>
+			<tr>
+				<th class='data-column'>Rank</th>
+				<th class='data-column'>Weekly Avg</th>
+				<th>Park</th>
+				<th>Kingdom</th>
+			</tr>
+		</thead>
+		<tbody>
+<?php if (is_array($TopParks)): ?>
+	<?php foreach ($TopParks as $rank => $park): ?>
+			<tr onclick='javascript:window.location.href="<?=UIR;?>Park/index/<?=$park['ParkId']; ?>";'>
+				<td class='data-column'><?=($rank + 1); ?></td>
+				<td class='data-column'><?=sprintf("%0.2f", $park['AttendanceCount'] / $WeekCount); ?></td>
+				<td><?=stripslashes($park['ParkName'] ?? ''); ?></td>
+				<td><?=stripslashes($park['KingdomName'] ?? ''); ?></td>
+			</tr>
+	<?php endforeach; ?>
+<?php else: ?>
+			<tr><td colspan='4'>No data available.</td></tr>
+<?php endif; ?>
+		</tbody>
+	</table>
+</div>
+<div class='info-container'>
+	<h3>About This Report</h3>
+	<p>This report ranks the top <?=$Limit; ?> parks across all active Amtgard kingdoms by their average weekly attendance over the selected date range (<?=htmlspecialchars($StartDate); ?> to <?=htmlspecialchars($EndDate); ?>, approximately <?=$WeekCount; ?> weeks).</p>
+	<p><strong>How attendance is counted:</strong> Each player who attends a given park in a given calendar week counts once toward that park's total, regardless of how many days they attended that week. This deduplication prevents multi-day events from inflating a park's numbers.</p>
+	<p><strong>How the weekly average is calculated:</strong> The total deduplicated attendance count over the date range is divided by the number of weeks in the range. A park with a weekly average of 10.5 had, on average, 10&ndash;11 unique players attending each week.</p>
+	<p><strong>Local Players Only:</strong> When checked, only attendance by players whose home park matches the park being measured is counted. This filters out visitors and traveling players, giving a view of each park's core local membership activity rather than total foot traffic.</p>
+	<p><strong>Filters applied:</strong> Only parks and kingdoms marked <em>Active</em> are included. Attendance records with no associated player (guest sign-ins with mundane ID 0) are excluded.</p>
+
+</div>


### PR DESCRIPTION
## Summary

Adds a new global admin report — **Top Parks by Attendance** — accessible from the Admin panel's Reports section. The report ranks the top 25 parks across all active Amtgard kingdoms by their average weekly unique attendance over a configurable date range.

This is a native ORK3 implementation of the concept pioneered by Ken Walker's [jsork Top 10 Average Parks report](https://github.com/kenwalker/jsork), rebuilt as a server-side report with additional filtering options.

## What's New

- **New SOAP service method** — `GetTopParksByAttendance` in the Report service, with full request/response type definitions and registration
- **New admin controller action** — `Admin/topparks`, no kingdom or park context required
- **New template** — `Admin_topparks.tpl` with a configurable filter form and an "About This Report" section explaining the methodology
- **Link added** to the Admin index Reports panel

## Report Features

- **Date range filter** — Start and end date pickers (jQuery UI datepicker), defaulting to the past 12 months
- **Local Players Only checkbox** — When checked, counts only attendance by players whose home park matches the park being measured, filtering out visitors and travelers
- **Weekly average** — Attendance is deduplicated per player per week (matching existing ORK attendance logic), then divided by the number of weeks in the selected range
- **Clickable rows** — Each park row links through to the park's page

## Files Changed

| File | Change |
|------|--------|
| `system/lib/ork3/class.Report.php` | New `GetTopParksByAttendance()` method |
| `orkservice/Report/ReportService.definitions.php` | New request/response SOAP types |
| `orkservice/Report/ReportService.function.php` | New function wrapper |
| `orkservice/Report/ReportService.registration.php` | SOAP registration |
| `orkui/model/model.Admin.php` | New `get_top_parks_by_attendance()` model method |
| `orkui/controller/controller.Admin.php` | New `topparks()` controller action |
| `orkui/template/default/Admin_topparks.tpl` | New report template |
| `orkui/template/default/Admin_index.tpl` | Added link in Reports section |

## Test Plan

- [ ] Visit Admin panel → Reports → "Top Parks by Attendance" and confirm the table renders with 25 rows
- [ ] Change start/end dates and click Update — confirm results update correctly
- [ ] Check "Local Players Only" and confirm attendance counts change (parks with large visitor traffic should rank lower)
- [ ] Click a park row and confirm navigation to the correct park page
- [ ] Confirm CLAUDE.md and agent-instructions/ are not included in this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)