### PR TITLE
Enhancement: Optimize kingdom index page

### DIFF
--- a/orkservice/Report/ReportService.definitions.php
+++ b/orkservice/Report/ReportService.definitions.php
@@ -133,6 +133,54 @@ $server->wsdl->addComplexType(
 	);
 
 $server->wsdl->addComplexType(
+		'GetKingdomParkMonthlyAveragesRequest',
+		'complextType',
+		'struct',
+		'all',
+		'',
+		array(
+				'KingdomId'=>array('name'=>'KingdomId','type'=>'xsd:int')
+			)
+	);
+
+$server->wsdl->addComplexType(
+		'ParkMonthlySummaryItemType',
+		'complextType',
+		'struct',
+		'all',
+		'',
+		array(
+				'ParkId'=>array('name'=>'ParkId','type'=>'xsd:int'),
+				'MonthlyCount'=>array('name'=>'MonthlyCount','type'=>'xsd:int')
+			)
+	);
+
+$server->wsdl->addComplexType(
+		'ParkMonthlySummaryListType',
+		'complexType',
+		'array',
+		'',
+		'SOAP-ENC:Array',
+		array(),
+		array(
+			array('ref'=>'SOAP-ENC:arrayType', 'wsdl:arrayType'=> 'tns:ParkMonthlySummaryItemType[]')
+			),
+		'tns:ParkMonthlySummaryItemType'
+	);
+
+$server->wsdl->addComplexType(
+		'GetKingdomParkMonthlyAveragesResponse',
+		'complextType',
+		'struct',
+		'all',
+		'',
+		array(
+				'Status'=>array('name'=>'Status','type'=>'tns:StatusType'),
+				'KingdomParkMonthlySummary'=>array('name'=>'KingdomParkMonthlySummary','type'=>'tns:ParkMonthlySummaryListType')
+			)
+	);
+
+$server->wsdl->addComplexType(
 		'GetKingdomParkAveragesRequest',
 		'complextType',
 		'struct',

--- a/orkservice/Report/ReportService.function.php
+++ b/orkservice/Report/ReportService.function.php
@@ -15,6 +15,11 @@ function GetKingdomParkAverages($request) {
 	return $R->GetKingdomParkAverages($request);
 }
 
+function GetKingdomParkMonthlyAverages($request) {
+	$R = new Report();
+	return $R->GetKingdomParkMonthlyAverages($request);
+}
+
 function GetPlayerRoster($request) {
 	$R = new Report();
 	return $R->GetPlayerRoster($request);

--- a/orkservice/Report/ReportService.registration.php
+++ b/orkservice/Report/ReportService.registration.php
@@ -21,6 +21,13 @@ $server->register(
 	);
 
 $server->register(
+		'GetKingdomParkMonthlyAverages',
+		array('GetKingdomParkMonthlyAverages'=>'tns:GetKingdomParkMonthlyAveragesRequest'),
+		array('return' => 'tns:GetKingdomParkMonthlyAveragesResponse'),
+		$namespace
+	);
+
+$server->register(
 		'GetPlayerRoster',
 		array('GetPlayerRoster'=>'tns:GetPlayerRosterRequest'),
 		array('return' => 'tns:GetPlayerRosterResponse'),

--- a/orkui/controller/controller.Kingdom.php
+++ b/orkui/controller/controller.Kingdom.php
@@ -50,6 +50,18 @@ class Controller_Kingdom extends Controller {
 		logtrace("index($kingdom_id = null)", $this->data['kingdom_tournaments']);
 	}
 	
+	public function park_monthly_json($kingdom_id = null) {
+		$kingdom_id = preg_replace('/[^0-9]/', '', $kingdom_id);
+		$summary = $this->Report->GetKingdomParkMonthlyAverages(['KingdomId' => $kingdom_id]);
+		$result = array();
+		foreach ((array)($summary['KingdomParkMonthlySummary'] ?? []) as $park) {
+			$result[$park['ParkId']] = $park['MonthlyCount'];
+		}
+		header('Content-Type: application/json');
+		echo json_encode($result);
+		exit();
+	}
+
 	public function map($kingdom_id = null) {
 		if (valid_id($kingdom_id)) {
 	    	$kingdom_details = $this->Kingdom->GetKingdomDetails(array('KingdomId' => $kingdom_id));

--- a/orkui/template/default/Kingdom_index.tpl
+++ b/orkui/template/default/Kingdom_index.tpl
@@ -35,11 +35,9 @@
 		<tbody>
 <?php if (!is_array($park_summary['KingdomParkAveragesSummary'])) $park_summary['KingdomParkAveragesSummary'] = array() ?>
 <?php $att = 0 ?>
-<?php $monthly_total = 0 ?>
 <?php foreach ($park_summary['KingdomParkAveragesSummary'] as $k => $park): ?>
     <?php $att += $park['AttendanceCount']; ?>
-    <?php $monthly_total += $park['MonthlyCount']; ?>
-			<tr onclick='javascript:window.location.href="<?=UIR;?>Park/index/<?=$park['ParkId'];?>"'>
+			<tr onclick='javascript:window.location.href="<?=UIR;?>Park/index/<?=$park['ParkId'];?>"' data-park-id='<?=$park['ParkId']?>'>
 				<td>
 					<div class='tiny-heraldry'>
 						<?php if ($park['HasHeraldry']==1): ?>
@@ -52,7 +50,7 @@
 				</td>
 				<td><?=!empty($park['Title']) ? $park['Title'] : '' ?></td>
 				<td class='data-column'><?=sprintf("%0.02f",($park['AttendanceCount']/26)); ?></td>
-				<td class='data-column'><?=sprintf("%0.01f",($park['MonthlyCount']/12)); ?></td>
+				<td class='data-column monthly-stat'>—</td>
 				<td class='data-column'><?=$park['AttendanceCount']; ?></td>
 			</tr>
 <?php endforeach; ?>
@@ -60,9 +58,25 @@
 				<td></td>
 				<td></td>
 				<td class='data-column'><?=sprintf("%0.02f",($att/26)); ?></td>
-				<td class='data-column'><?=sprintf("%0.01f",($monthly_total/12)); ?></td>
+				<td class='data-column monthly-total'>—</td>
 				<td class='data-column'><?=$att; ?></td>
 			</tr>
+<script>
+jQuery(document).ready(function($) {
+	$.get('<?=UIR?>Kingdom/park_monthly_json/<?=$kingdom_id?>', function(data) {
+		var total = 0;
+		$('[data-park-id]').each(function() {
+			var parkId = $(this).data('park-id');
+			var monthlyCount = data[parkId] || 0;
+			total += monthlyCount;
+			$(this).find('.monthly-stat').text((monthlyCount / 12).toFixed(1));
+		});
+		$('.monthly-total').text((total / 12).toFixed(1));
+	}, 'json').fail(function() {
+		$('.monthly-stat, .monthly-total').text('err');
+	});
+});
+</script>
 		</tbody>
 	</table>
 </div>


### PR DESCRIPTION
## Summary

- **Split weekly and monthly attendance into separate queries.** `GetKingdomParkAverages` previously scanned `ork_attendance` twice in a single query — once for 26 weeks and once for 12 months. The monthly subquery has been extracted into a new `GetKingdomParkMonthlyAverages` function with its own independent 600 s cache, eliminating the double scan on page load.
- **Monthly column now loads asynchronously.** The kingdom index page renders immediately with weekly (Ave.) and Total columns populated synchronously. After `DOMContentLoaded`, a jQuery `$.get` fetches `Kingdom/park_monthly_json/{id}` and fills in the Monthly column without blocking page render.
- **Fixed a correctness bug in monthly grouping.** The old monthly subquery grouped by `date_month` (integer 1–12) without `date_year`, causing attendance records from the same calendar month in two different years (e.g. Feb 2025 and Feb 2026) to collapse into a single row. The new query groups by `date_year, date_month, mundane_id, park_id`, counting each year-month occurrence separately.
- **Removed an unnecessary `LEFT JOIN ork_mundane` from the weekly subquery.** That join is only needed when the `NativePopulace` or `Waivered` filter flags are active. For the kingdom index (which passes neither), the join was evaluated against every attendance row with no effect. It is now added conditionally.

## Files changed

| File | Change |
|---|---|
| `system/lib/ork3/class.Report.php` | `GetKingdomParkAverages` → weekly-only + conditional mundane JOIN; new `GetKingdomParkMonthlyAverages` |
| `orkservice/Report/ReportService.function.php` | Thin wrapper for new function |
| `orkservice/Report/ReportService.definitions.php` | WSDL type definitions for new function |
| `orkservice/Report/ReportService.registration.php` | SOAP registration for new function |
| `orkui/controller/controller.Kingdom.php` | New `park_monthly_json` action — returns `{park_id: monthly_count}` JSON and exits |
| `orkui/template/default/Kingdom_index.tpl` | Monthly cells use `—` placeholder + async jQuery fill; `data-park-id` added to park rows |

## Test plan

- [ ] Load a kingdom index page (e.g. `/orkui/index.php?Route=Kingdom/index/18`) and confirm it renders without delay — Ave. and Total columns should be populated immediately
- [ ] Confirm the Monthly column shows `—` briefly then populates with decimal values (e.g. `12.3`) after a short pause
- [ ] Open DevTools Network tab and confirm a second request to `Kingdom/park_monthly_json/18` returns valid JSON `{"123": 45, ...}`
- [ ] Verify the Monthly totals row also updates correctly
- [ ] Test a kingdom with `NativePopulace` or `Waivered` filters (via reports) to confirm the conditional mundane JOIN still works for those callers
- [ ] Clear the cache and reload to confirm both the weekly and monthly queries execute correctly from cold

🤖 Generated with [Claude Code](https://claude.com/claude-code)