### PR TITLE
Bugfix: Top Parks Report Calculations

### DIFF
--- a/system/lib/ork3/class.Report.php
+++ b/system/lib/ork3/class.Report.php
@@ -1060,7 +1060,7 @@ class Report  extends Ork3 {
 										date > '$per_period'
 										and a.kingdom_id = '$escaped_kingdom_id'
 										and a.mundane_id > 0
-									group by date_year, date_week3, mundane_id) mundanesbyweek
+									group by date_year, date_week3, mundane_id, a.park_id) mundanesbyweek
 								on p.park_id = mundanesbyweek.park_id
 					where p.kingdom_id = '$escaped_kingdom_id' and p.active = 'Active'
 					group by park_id
@@ -1157,7 +1157,7 @@ class Report  extends Ork3 {
 									date >= '$escaped_start'
 									and date <= '$escaped_end'
 									and a.mundane_id > 0
-								group by date_year, date_week3, mundane_id) mundanesbyweek
+								group by date_year, date_week3, mundane_id, a.park_id) mundanesbyweek
 							on p.park_id = mundanesbyweek.park_id
 				where p.active = 'Active'
 					and k.active = 'Active'


### PR DESCRIPTION
## Summary

- The attendance deduplication subquery in `class.Report.php` grouped by `(year, week, mundane_id)` without including `park_id`
- With MySQL's non-deterministic `GROUP BY` behavior (empty `sql_mode`), a player who attended multiple parks in the same week was arbitrarily attributed to only one park, causing other parks to undercount that player's attendance
- This produced a counterintuitive result where enabling "Local Players Only" could show a *higher* average than all-attendances for some parks (e.g. Greenwood Keep NL: 36.81 local-only vs 35.42 all)
- Fixed by adding `a.park_id` to the `GROUP BY` in both `GetTopParksByAttendance` and `GetKingdomParkAverages`, so deduplication is correctly scoped to `(player, week, park)` rather than just `(player, week)`

## Test plan

- [ ] Load the Top Parks report (`Admin/topparks`) and confirm "Local Players Only" never produces a higher average than the all-attendances view for any park
- [ ] Confirm park rankings and averages look reasonable with and without the filter
- [ ] Check the per-kingdom park averages report for the same consistency

🤖 Generated with [Claude Code](https://claude.com/claude-code)