### PR TITLE
Add Waivered Players Only filter to Top Parks report

### DIFF
--- a/orkui/controller/controller.Admin.php
+++ b/orkui/controller/controller.Admin.php
@@ -1554,13 +1554,15 @@ class Controller_Admin extends Controller {
 			: date("Y-m-d");
 		$week_count = max(1, ceil((strtotime($end_date) - strtotime($start_date)) / (7 * 86400)));
 		$native_populace = !empty($this->request->NativePopulace);
-		$result = $this->Admin->get_top_parks_by_attendance($limit, $start_date, $end_date, $native_populace);
+		$waivered = !empty($this->request->Waivered);
+		$result = $this->Admin->get_top_parks_by_attendance($limit, $start_date, $end_date, $native_populace, $waivered);
 		$this->data['TopParks'] = $result['TopParksSummary'];
 		$this->data['StartDate'] = $start_date;
 		$this->data['EndDate'] = $end_date;
 		$this->data['WeekCount'] = $week_count;
 		$this->data['Limit'] = $limit;
 		$this->data['NativePopulace'] = $native_populace;
+		$this->data['Waivered'] = $waivered;
 	}
 
 	public function resetwaivers($params = null) {

--- a/orkui/model/model.Admin.php
+++ b/orkui/model/model.Admin.php
@@ -17,8 +17,8 @@ class Model_Admin extends Model {
 		return $this->Report->GetKingdomParkAverages(array('KingdomId'=>$kingdom_id));
 	}
 
-	function get_top_parks_by_attendance($limit = 25, $start_date = null, $end_date = null, $native_populace = false) {
-		return $this->Report->GetTopParksByAttendance(array('Limit'=>$limit, 'StartDate'=>$start_date, 'EndDate'=>$end_date, 'NativePopulace'=>$native_populace));
+	function get_top_parks_by_attendance($limit = 25, $start_date = null, $end_date = null, $native_populace = false, $waivered = false) {
+		return $this->Report->GetTopParksByAttendance(array('Limit'=>$limit, 'StartDate'=>$start_date, 'EndDate'=>$end_date, 'NativePopulace'=>$native_populace, 'Waivered'=>$waivered));
 	}
 
 }

--- a/orkui/template/default/Admin_topparks.tpl
+++ b/orkui/template/default/Admin_topparks.tpl
@@ -21,6 +21,10 @@
 				<td><input type='checkbox' name='NativePopulace' value='1' <?=$NativePopulace ? "checked='checked'" : ''; ?> /></td>
 			</tr>
 			<tr>
+				<td><label>Waivered Players Only</label></td>
+				<td><input type='checkbox' name='Waivered' value='1' <?=$Waivered ? "checked='checked'" : ''; ?> /></td>
+			</tr>
+			<tr>
 				<td></td>
 				<td><input type='submit' value='Update' /></td>
 			</tr>
@@ -57,6 +61,7 @@
 	<p><strong>How attendance is counted:</strong> Each player who attends a given park in a given calendar week counts once toward that park's total, regardless of how many days they attended that week. This deduplication prevents multi-day events from inflating a park's numbers.</p>
 	<p><strong>How the weekly average is calculated:</strong> The total deduplicated attendance count over the date range is divided by the number of weeks in the range. A park with a weekly average of 10.5 had, on average, 10&ndash;11 unique players attending each week.</p>
 	<p><strong>Local Players Only:</strong> When checked, only attendance by players whose home park matches the park being measured is counted. This filters out visitors and traveling players, giving a view of each park's core local membership activity rather than total foot traffic.</p>
+	<p><strong>Waivered Players Only:</strong> When checked, only attendance by players with a signed waiver on file is counted. This can give a more conservative view of active, registered membership.</p>
 	<p><strong>Filters applied:</strong> Only parks and kingdoms marked <em>Active</em> are included. Attendance records with no associated player (guest sign-ins with mundane ID 0) are excluded.</p>
 
 </div>

--- a/system/lib/ork3/class.Report.php
+++ b/system/lib/ork3/class.Report.php
@@ -1137,6 +1137,10 @@ class Report  extends Ork3 {
 		$escaped_end = mysql_real_escape_string($request['EndDate']);
 		$escaped_limit = intval($request['Limit']);
 		$native_populace = $request['NativePopulace'] ? "m.park_id = a.park_id and" : "";
+		$waivered = $request['Waivered'] ? "m.waivered = 1 and" : "";
+		$mundane_join = (!empty($native_populace) || !empty($waivered))
+			? "left join " . DB_PREFIX . "mundane m on a.mundane_id = m.mundane_id"
+			: "";
 
 		$sql = "select
 					count(mundanesbyweek.mundane_id) attendance_count,
@@ -1151,9 +1155,10 @@ class Report  extends Ork3 {
 							(select
 									a.mundane_id, a.date_week3 as week, a.park_id
 								from " . DB_PREFIX . "attendance a
-									left join " . DB_PREFIX . "mundane m on a.mundane_id = m.mundane_id
+									$mundane_join
 								where
 									$native_populace
+									$waivered
 									date >= '$escaped_start'
 									and date <= '$escaped_end'
 									and a.mundane_id > 0


### PR DESCRIPTION
## Summary

- Adds a **Waivered Players Only** checkbox to the Top Parks by Attendance admin report, alongside the existing Local Players Only filter
- When checked, only attendance records from players with `waivered = 1` in `ork_mundane` are counted
- The mundane table join is made conditional — it's only added to the subquery when NativePopulace or Waivered is active (matching the pattern already used in `GetKingdomParkAverages`)

## Files changed

| File | Change |
|------|--------|
| `system/lib/ork3/class.Report.php` | Add `$waivered` condition and conditional `$mundane_join` to `GetTopParksByAttendance` |
| `orkui/model/model.Admin.php` | Add `$waivered` param, pass through to Report |
| `orkui/controller/controller.Admin.php` | Read `Waivered` from request, pass to model, expose to template |
| `orkui/template/default/Admin_topparks.tpl` | Add checkbox row and About section description |

## Test plan

- [ ] Load Top Parks report — confirm it renders without errors with both checkboxes unchecked
- [ ] Check **Waivered Players Only** — confirm results change (lower counts expected)
- [ ] Check **Local Players Only** + **Waivered Players Only** together — confirm both filters apply
- [ ] Confirm checkbox state is preserved after submitting the form

🤖 Generated with [Claude Code](https://claude.com/claude-code)