### PR TITLE
Add New Player Attendance report to Kingdom reports

### DIFF
--- a/orkui/model/model.Reports.php
+++ b/orkui/model/model.Reports.php
@@ -220,6 +220,17 @@ class Model_Reports extends Model {
 		return false;
 	}
 
+	function new_player_attendance($request) {
+		$r = $this->Report->GetNewPlayerAttendance($request);
+		if ($r['Status']['Status'] == 0) {
+			return array(
+				'Summary'       => $r['Summary'],
+				'PlayerDetails' => $r['PlayerDetails']
+			);
+		}
+		return false;
+	}
+
 	function get_kingdom_parks($kingdom_id) {
 		$kingdom = new APIModel('Kingdom');
 		$r = $kingdom->GetParks(array('KingdomId' => $kingdom_id));

--- a/orkui/template/default/Kingdom_index.tpl
+++ b/orkui/template/default/Kingdom_index.tpl
@@ -150,6 +150,7 @@ jQuery(document).ready(function($) {
 				<li><a href='<?=UIR ?>Reports/attendance/Kingdom/<?=$kingdom_id ?>/Months/12'>Past 12 Months</a></li>
 				<li><a href='<?=UIR ?>Reports/attendance/Kingdom/<?=$kingdom_id ?>/All'>All</a></li>
 				<li><a href='<?=UIR ?>Reports/park_attendance_explorer'>Park Attendance Explorer</a></li>
+				<li><a href='<?=UIR ?>Reports/new_player_attendance'>New Player Attendance</a></li>
 			</ul>
 		</li>
 		<li>

--- a/orkui/template/default/Reports_newplayerattendance.tpl
+++ b/orkui/template/default/Reports_newplayerattendance.tpl
@@ -1,0 +1,174 @@
+<div class='info-container'>
+	<h3>New Player Attendance</h3>
+
+<?php if (isset($no_kingdom)): ?>
+	<p>Please navigate to a kingdom first to use this report.</p>
+<?php else: ?>
+	<form method="POST" action="<?=UIR?>Reports/new_player_attendance">
+		<table class="search-table">
+			<tr>
+				<td><label for="StartDate">Start Date</label></td>
+				<td><input type="text" id="StartDate" name="StartDate" class="datepicker" value="<?=htmlspecialchars($form['StartDate'] ?? '')?>" /></td>
+				<td><label for="EndDate">End Date</label></td>
+				<td><input type="text" id="EndDate" name="EndDate" class="datepicker" value="<?=htmlspecialchars($form['EndDate'] ?? '')?>" /></td>
+			</tr>
+			<tr>
+				<td><label for="ParkId">Park</label></td>
+				<td>
+					<select id="ParkId" name="ParkId">
+						<option value="0">All Parks</option>
+<?php if (is_array($parks)): ?>
+<?php 	foreach ($parks as $park): ?>
+<?php 		if ($park['Active'] != 'Active') continue; ?>
+						<option value="<?=$park['ParkId']?>"<?=($form['ParkId'] ?? 0) == $park['ParkId'] ? ' selected' : ''?>><?=htmlspecialchars($park['Name'])?></option>
+<?php 	endforeach; ?>
+<?php endif; ?>
+					</select>
+				</td>
+				<td><label for="ShowPlayerDetails">Show Player Details</label></td>
+				<td><input type="checkbox" id="ShowPlayerDetails" name="ShowPlayerDetails" value="1"<?=!empty($form['ShowPlayerDetails']) ? ' checked' : ''?> /></td>
+			</tr>
+			<tr>
+				<td colspan="4">
+					<button type="submit" name="RunReport" value="1" class="button">Run Report</button>
+				</td>
+			</tr>
+		</table>
+	</form>
+<?php endif; ?>
+</div>
+
+<?php if (isset($summary) && is_array($summary) && count($summary) > 0): ?>
+<?php
+	$period_label = htmlspecialchars(($form['StartDate'] ?? '') . ' to ' . ($form['EndDate'] ?? ''));
+	$totals = array(
+		'NewPlayers'            => 0,
+		'ReturningPlayers'      => 0,
+		'NewPlayerVisits'       => 0
+	);
+	foreach ($summary as $row) {
+		$totals['NewPlayers']       += $row['NewPlayers'];
+		$totals['ReturningPlayers'] += $row['ReturningPlayers'];
+		$totals['NewPlayerVisits']  += $row['NewPlayerVisits'];
+	}
+	$totals['ReturnPct']             = $totals['NewPlayers'] > 0
+		? round(($totals['ReturningPlayers'] / $totals['NewPlayers']) * 100, 1) : 0;
+	$totals['AvgVisitsPerNewPlayer'] = $totals['NewPlayers'] > 0
+		? round($totals['NewPlayerVisits'] / $totals['NewPlayers'], 2) : 0;
+?>
+<div class='info-container'>
+	<h3>New Player Attendance Summary</h3>
+	<div class="actions"><button class="print button">Print</button> <button class="download button">Download CSV</button></div>
+	<table class='information-table'>
+		<thead>
+			<tr>
+				<th>Period</th>
+				<th>Park Name</th>
+				<th title="Players whose very first sign-in ever falls within the date range">New Players</th>
+				<th title="New players who signed in 2 or more times during the range">Returning Players</th>
+				<th title="Returning ÷ New">Return %</th>
+				<th title="Total sign-in events for new players within the range">New Player Visits</th>
+				<th title="Total visits ÷ new players">Avg Visits / New Player</th>
+			</tr>
+		</thead>
+		<tbody>
+<?php foreach ($summary as $row): ?>
+			<tr>
+				<td><?=$period_label?></td>
+				<td><?=htmlspecialchars($row['ParkName'])?></td>
+				<td class="data-column"><?=$row['NewPlayers']?></td>
+				<td class="data-column"><?=$row['ReturningPlayers']?></td>
+				<td class="data-column"><?=$row['ReturnPct']?>%</td>
+				<td class="data-column"><?=$row['NewPlayerVisits']?></td>
+				<td class="data-column"><?=number_format($row['AvgVisitsPerNewPlayer'], 2)?></td>
+			</tr>
+<?php endforeach; ?>
+		</tbody>
+<?php if (count($summary) > 1): ?>
+		<tfoot>
+			<tr style="text-align:center; font-size:1.15em;">
+				<td style="text-align:left;"><strong>Total</strong></td>
+				<td></td>
+				<td><strong><?=$totals['NewPlayers']?></strong></td>
+				<td><strong><?=$totals['ReturningPlayers']?></strong></td>
+				<td><strong><?=$totals['ReturnPct']?>%</strong></td>
+				<td><strong><?=$totals['NewPlayerVisits']?></strong></td>
+				<td><strong><?=number_format($totals['AvgVisitsPerNewPlayer'], 2)?></strong></td>
+			</tr>
+		</tfoot>
+<?php endif; ?>
+	</table>
+</div>
+<?php elseif (isset($summary)): ?>
+<div class='info-container'>
+	<p>No new players found for the selected date range and park.</p>
+</div>
+<?php endif; ?>
+
+<?php if (isset($player_details) && is_array($player_details) && count($player_details) > 0): ?>
+<div class='info-container'>
+	<h3>New Player Details</h3>
+	<div class="actions"><button class="print button">Print</button> <button class="download button">Download CSV</button></div>
+	<table class='information-table'>
+		<thead>
+			<tr>
+				<th>Park</th>
+				<th>Persona Name</th>
+				<th>First Sign-in Date</th>
+				<th title="Sign-ins within the selected date range">Visits in Period</th>
+				<th title="Most recent sign-in date across all time">Last Sign-in Date</th>
+			</tr>
+		</thead>
+		<tbody>
+<?php foreach ($player_details as $player): ?>
+			<tr onclick='javascript:window.location.href="<?=UIR?>Player/index/<?=$player['MundaneId']?>"' style="cursor:pointer;">
+				<td><?=htmlspecialchars($player['ParkName'])?></td>
+				<td><?=htmlspecialchars($player['Persona'])?></td>
+				<td class="data-column"><?=htmlspecialchars($player['FirstSignInDate'])?></td>
+				<td class="data-column"><?=$player['VisitsInPeriod']?></td>
+				<td class="data-column"><?=htmlspecialchars($player['LastSignInDate'])?></td>
+			</tr>
+<?php endforeach; ?>
+		</tbody>
+	</table>
+</div>
+<?php endif; ?>
+
+<div class='info-container'>
+	<h3>About This Report</h3>
+	<dl>
+		<dt><strong>New Players</strong></dt>
+		<dd>A count of players whose very first sign-in in the entire ORK system falls within the selected date range. Players who played elsewhere before this period are not counted, even if this is their first visit to this kingdom.</dd>
+
+		<dt><strong>Park Attribution</strong></dt>
+		<dd>Each new player is credited to the park where their first sign-in occurred. If a player signed in at multiple parks on the same day as their first-ever sign-in, the park with the lowest system ID is used as the tiebreaker.</dd>
+
+		<dt><strong>Returning Players</strong></dt>
+		<dd>Of the new players identified above, a count of those who signed in two or more times during the selected date range. This measures same-period retention — how many newcomers came back at least once before the period ended.</dd>
+
+		<dt><strong>Return %</strong></dt>
+		<dd>Returning Players ÷ New Players × 100. A higher percentage indicates that more new players returned for a second visit within the period.</dd>
+
+		<dt><strong>New Player Visits</strong></dt>
+		<dd>The total number of individual sign-in events (attendance rows) for all new players during the date range. Each sign-in on a distinct date counts as one visit — the credits field is not summed.</dd>
+
+		<dt><strong>Avg Visits / New Player</strong></dt>
+		<dd>New Player Visits ÷ New Players. Indicates how engaged new players were on average during the period.</dd>
+
+		<dt><strong>Last Sign-in Date (Player Details)</strong></dt>
+		<dd>The most recent sign-in date for each player across all time, not limited to the report period. This lets you see whether a new player from a past muster is still active today.</dd>
+	</dl>
+</div>
+
+<script>
+$(function() {
+	$('.datepicker').datepicker({dateFormat: 'yy-mm-dd'});
+	$('.information-table').tablesorter({
+		theme: 'jui',
+		widgets: ['zebra', 'print'],
+		widgetOptions: {
+			zebra: ['normal-row', 'alt-row']
+		}
+	});
+});
+</script>

--- a/system/lib/ork3/class.Report.php
+++ b/system/lib/ork3/class.Report.php
@@ -1695,6 +1695,168 @@ class Report  extends Ork3 {
 		return Ork3::$Lib->ghettocache->cache(__CLASS__ . '.' . __FUNCTION__, $cache_key, $response);
 	}
 
+	public function GetNewPlayerAttendance($request) {
+		$cache_key = Ork3::$Lib->ghettocache->key($request);
+		if (($cache = Ork3::$Lib->ghettocache->get(__CLASS__ . '.' . __FUNCTION__, $cache_key, 300)) !== false)
+			return $cache;
+
+		$kingdom_id     = intval($request['KingdomId']);
+		$park_id        = intval($request['ParkId']);
+		$start_date     = mysql_real_escape_string($request['StartDate']);
+		$end_date       = mysql_real_escape_string($request['EndDate']);
+		$include_detail = !empty($request['IncludePlayerDetails']);
+
+		// Build the WHERE clause for the kingdom/park scope.
+		// The "first park" is determined by joining ork_park to check its kingdom.
+		if ($park_id > 0) {
+			$scope_where = "AND fp.park_id = $park_id";
+		} else {
+			$scope_where = "AND pk.kingdom_id = $kingdom_id";
+		}
+
+		// Visit counts: only count visits at parks within the target kingdom during the range.
+		if ($park_id > 0) {
+			$visit_scope = "AND a_range.park_id = $park_id";
+		} else {
+			$visit_scope = "AND a_range.kingdom_id = $kingdom_id";
+		}
+
+		// Summary query: new players, returning players, and total visits — grouped by first park.
+		$sql_summary = "SELECT
+				p.park_id,
+				p.name AS park_name,
+				COUNT(DISTINCT np.mundane_id) AS new_players,
+				SUM(CASE WHEN vc.visit_count >= 2 THEN 1 ELSE 0 END) AS returning_players,
+				COALESCE(SUM(vc.visit_count), 0) AS new_player_visits
+			FROM (
+				-- New players: global first sign-in is in range and was at a park in the scope.
+				SELECT fd.mundane_id, MIN(a2.park_id) AS first_park_id
+				FROM (
+					SELECT mundane_id, MIN(date) AS min_date
+					FROM " . DB_PREFIX . "attendance
+					WHERE mundane_id > 0
+					GROUP BY mundane_id
+				) fd
+				INNER JOIN " . DB_PREFIX . "attendance a2
+					ON a2.mundane_id = fd.mundane_id
+					AND a2.date = fd.min_date
+					AND a2.mundane_id > 0
+					AND a2.park_id > 0
+				INNER JOIN " . DB_PREFIX . "park fp ON fp.park_id = a2.park_id
+				LEFT JOIN " . DB_PREFIX . "kingdom pk ON pk.kingdom_id = fp.kingdom_id
+				WHERE fd.min_date >= '$start_date'
+				  AND fd.min_date <= '$end_date'
+				  $scope_where
+				GROUP BY fd.mundane_id
+			) np
+			INNER JOIN " . DB_PREFIX . "park p ON p.park_id = np.first_park_id
+			INNER JOIN (
+				-- Count visits in range per new player (within kingdom scope).
+				SELECT a_range.mundane_id, COUNT(*) AS visit_count
+				FROM " . DB_PREFIX . "attendance a_range
+				WHERE a_range.date >= '$start_date'
+				  AND a_range.date <= '$end_date'
+				  AND a_range.mundane_id > 0
+				  $visit_scope
+				GROUP BY a_range.mundane_id
+			) vc ON vc.mundane_id = np.mundane_id
+			GROUP BY np.first_park_id, p.park_id, p.name
+			HAVING COUNT(DISTINCT np.mundane_id) > 0 AND p.name IS NOT NULL AND p.name != ''
+			ORDER BY p.name";
+
+		$r = $this->db->query($sql_summary);
+		$response = array(
+			'Status'        => Success(),
+			'Summary'       => array(),
+			'PlayerDetails' => array()
+		);
+
+		if ($r !== false && $r->size() > 0) {
+			do {
+				$new   = intval($r->new_players);
+				if ($new === 0 || empty($r->park_name)) continue;
+				$ret   = intval($r->returning_players);
+				$visits = intval($r->new_player_visits);
+				$response['Summary'][] = array(
+					'ParkId'                => $r->park_id,
+					'ParkName'              => $r->park_name,
+					'NewPlayers'            => $new,
+					'ReturningPlayers'      => $ret,
+					'ReturnPct'             => $new > 0 ? round(($ret / $new) * 100, 1) : 0,
+					'NewPlayerVisits'       => $visits,
+					'AvgVisitsPerNewPlayer' => $new > 0 ? round($visits / $new, 2) : 0
+				);
+			} while ($r->next());
+		}
+
+		if ($include_detail) {
+			$sql_detail = "SELECT
+					p.park_id,
+					p.name AS park_name,
+					np.mundane_id,
+					m.persona,
+					np.first_signin_date,
+					vc.visit_count AS visits_in_period,
+					ls.last_signin_date
+				FROM (
+					SELECT fd.mundane_id, fd.min_date AS first_signin_date, MIN(a2.park_id) AS first_park_id
+					FROM (
+						SELECT mundane_id, MIN(date) AS min_date
+						FROM " . DB_PREFIX . "attendance
+						WHERE mundane_id > 0
+						GROUP BY mundane_id
+					) fd
+					INNER JOIN " . DB_PREFIX . "attendance a2
+						ON a2.mundane_id = fd.mundane_id
+						AND a2.date = fd.min_date
+						AND a2.mundane_id > 0
+						AND a2.park_id > 0
+					INNER JOIN " . DB_PREFIX . "park fp ON fp.park_id = a2.park_id
+					LEFT JOIN " . DB_PREFIX . "kingdom pk ON pk.kingdom_id = fp.kingdom_id
+					WHERE fd.min_date >= '$start_date'
+					  AND fd.min_date <= '$end_date'
+					  $scope_where
+					GROUP BY fd.mundane_id, fd.min_date
+				) np
+				INNER JOIN " . DB_PREFIX . "park p ON p.park_id = np.first_park_id
+				INNER JOIN " . DB_PREFIX . "mundane m ON m.mundane_id = np.mundane_id
+				INNER JOIN (
+					SELECT a_range.mundane_id, COUNT(*) AS visit_count
+					FROM " . DB_PREFIX . "attendance a_range
+					WHERE a_range.date >= '$start_date'
+					  AND a_range.date <= '$end_date'
+					  AND a_range.mundane_id > 0
+					  $visit_scope
+					GROUP BY a_range.mundane_id
+				) vc ON vc.mundane_id = np.mundane_id
+				INNER JOIN (
+					SELECT mundane_id, MAX(date) AS last_signin_date
+					FROM " . DB_PREFIX . "attendance
+					WHERE mundane_id > 0
+					GROUP BY mundane_id
+				) ls ON ls.mundane_id = np.mundane_id
+				ORDER BY p.name, m.persona";
+
+			$rd = $this->db->query($sql_detail);
+			if ($rd !== false && $rd->size() > 0) {
+				do {
+					$response['PlayerDetails'][] = array(
+						'ParkId'          => $rd->park_id,
+						'ParkName'        => $rd->park_name,
+						'MundaneId'       => $rd->mundane_id,
+						'Persona'         => $rd->persona,
+						'FirstSignInDate' => $rd->first_signin_date,
+						'VisitsInPeriod'  => $rd->visits_in_period,
+						'LastSignInDate'  => $rd->last_signin_date
+					);
+				} while ($rd->next());
+			}
+		}
+
+		logtrace("Report->GetNewPlayerAttendance()", array($this->db->lastSql, $request));
+		return Ork3::$Lib->ghettocache->cache(__CLASS__ . '.' . __FUNCTION__, $cache_key, $response);
+	}
+
 	public function ParkAttendanceSinglePark($request) {
 		$key = Ork3::$Lib->ghettocache->key($request);
 		if (($cache = Ork3::$Lib->ghettocache->get(__CLASS__ . '.' . __FUNCTION__, $key, 300)) !== false)


### PR DESCRIPTION
## Summary

- Adds a new **New Player Attendance** report, accessible from the Attendance section of the Kingdom reports list
- Identifies players whose **very first sign-in in the entire ORK system** falls within a user-selected date range, making it ideal for evaluating newcomer turnout and retention at seasonal events (e.g. Spring Muster)
- Includes a **Show Player Details** option that adds a per-player breakdown table below the summary

## Report Columns

| Column | Description |
|---|---|
| Period | The selected date range (start → end) |
| Park Name | Each park in the kingdom with new players |
| New Players | Count of players whose global first sign-in falls in the range |
| Returning Players | New players who signed in 2+ times during the range |
| Return % | Returning ÷ New × 100 |
| New Player Visits | Total sign-in events for new players in the range (count of rows, not credits field) |
| Avg Visits / New Player | New Player Visits ÷ New Players |

When **Show Player Details** is checked, a second table lists each new player with their park, persona, first sign-in date, visits in period, and all-time last sign-in date (to check if a Spring Muster newcomer is still active months later).

## Filters

- **Start Date / End Date** — inclusive date range; defaults to last 3 months on first load
- **Park** — "All Parks" (default) or any active park in the kingdom, sorted alphabetically
- **Show Player Details** — toggles the per-player table

## Park Attribution

Each new player is credited to the park of their first sign-in. If a player has multiple sign-ins on their very first day across different parks, the minimum `park_id` is used as a tiebreaker. Attendance rows with `park_id = 0` are excluded from attribution.

## Files Changed

- **`system/lib/ork3/class.Report.php`** — `GetNewPlayerAttendance()` method with summary and optional detail SQL queries; uses `ghettocache` with 5-minute TTL
- **`orkui/model/model.Reports.php`** — `new_player_attendance()` model wrapper
- **`orkui/controller/controller.Reports.php`** — `new_player_attendance()` controller action; follows the same `RunReport` submit-flag pattern as Park Attendance Explorer
- **`orkui/template/default/Reports_newplayerattendance.tpl`** — new template with filter form, summary table (with totals footer for multi-park results), optional player details table, and an "About This Report" reference panel
- **`orkui/template/default/Kingdom_index.tpl`** — adds "New Player Attendance" link under the Attendance section of kingdom reports

## Test plan

- [ ] Navigate to a Kingdom page → Reports → Attendance → New Player Attendance
- [ ] Confirm the filter form renders with the park dropdown populated alphabetically
- [ ] Run report for a date range with known data; verify New Players count matches players with no attendance records before the start date
- [ ] Verify Returning Players count matches new players with 2+ sign-ins in range
- [ ] Verify Return % = Returning ÷ New × 100
- [ ] Verify New Player Visits = sum of all attendance rows for new players in range
- [ ] Verify Avg Visits / New Player = Visits ÷ New Players
- [ ] Check that no blank / zero-player rows appear in the summary table
- [ ] Check totals footer appears when more than one park has results, and is centered/bold
- [ ] Enable Show Player Details; confirm second table appears with correct per-player data
- [ ] Confirm Last Sign-in Date in the details table can be outside the report period
- [ ] Filter to a single park; confirm only that park's new players appear
- [ ] Confirm "About This Report" panel renders at the bottom

🤖 Generated with [Claude Code](https://claude.com/claude-code)