### PR TITLE
Add New Player Attendance report (Kingdom and Admin level)

### DIFF
--- a/orkui/controller/controller.Admin.php
+++ b/orkui/controller/controller.Admin.php
@@ -1543,6 +1543,28 @@ class Controller_Admin extends Controller {
 		$this->data[ 'page_title' ] = "Admin: " . $this->data['ParkInfo']['ParkName'];
 	}
 
+	public function new_player_attendance() {
+		$this->template = 'Admin_newplayerattendance.tpl';
+		$this->load_model('Admin');
+
+		$start_date = isset($this->request->StartDate) && preg_match('/^\d{4}-\d{2}-\d{2}$/', $this->request->StartDate)
+			? $this->request->StartDate
+			: date('Y-m-d', strtotime('-3 months'));
+		$end_date = isset($this->request->EndDate) && preg_match('/^\d{4}-\d{2}-\d{2}$/', $this->request->EndDate)
+			? $this->request->EndDate
+			: date('Y-m-d');
+
+		$this->data['form'] = array('StartDate' => $start_date, 'EndDate' => $end_date);
+		$this->data['page_title'] = 'New Player Attendance';
+
+		if (!isset($this->request->RunReport)) return;
+
+		$result = $this->Admin->get_new_player_attendance_by_kingdom($start_date, $end_date);
+		if (is_array($result)) {
+			$this->data['summary'] = $result['Summary'];
+		}
+	}
+
 	public function topparks($limit = null) {
 		$this->load_model('Admin');
 		$limit = intval($limit) > 0 ? intval($limit) : 25;

--- a/orkui/model/model.Admin.php
+++ b/orkui/model/model.Admin.php
@@ -21,6 +21,10 @@ class Model_Admin extends Model {
 		return $this->Report->GetTopParksByAttendance(array('Limit'=>$limit, 'StartDate'=>$start_date, 'EndDate'=>$end_date, 'NativePopulace'=>$native_populace, 'Waivered'=>$waivered));
 	}
 
+	function get_new_player_attendance_by_kingdom($start_date, $end_date) {
+		return $this->Report->GetNewPlayerAttendanceByKingdom(array('StartDate'=>$start_date, 'EndDate'=>$end_date));
+	}
+
 }
 
 ?>

--- a/orkui/model/model.Reports.php
+++ b/orkui/model/model.Reports.php
@@ -220,6 +220,17 @@ class Model_Reports extends Model {
 		return false;
 	}
 
+	function new_player_attendance($request) {
+		$r = $this->Report->GetNewPlayerAttendance($request);
+		if ($r['Status']['Status'] == 0) {
+			return array(
+				'Summary'       => $r['Summary'],
+				'PlayerDetails' => $r['PlayerDetails']
+			);
+		}
+		return false;
+	}
+
 	function get_kingdom_parks($kingdom_id) {
 		$kingdom = new APIModel('Kingdom');
 		$r = $kingdom->GetParks(array('KingdomId' => $kingdom_id));

--- a/orkui/template/default/Admin_index.tpl
+++ b/orkui/template/default/Admin_index.tpl
@@ -31,5 +31,6 @@
 		<li><a href='<?=UIR ?>Reports/class_masters'>Class Masters/Paragons</a></li>
 		<li><a href='<?=UIR ?>Unit/unitlist'>Companies and Households</a></li>
 		<li><a href='<?=UIR ?>Admin/topparks'>Top Parks by Attendance</a></li>
+		<li><a href='<?=UIR ?>Admin/new_player_attendance'>New Player Attendance</a></li>
 	</ul>
 </div>

--- a/orkui/template/default/Admin_newplayerattendance.tpl
+++ b/orkui/template/default/Admin_newplayerattendance.tpl
@@ -1,0 +1,126 @@
+<div class='info-container'>
+	<h3>New Player Attendance by Kingdom</h3>
+	<form method="POST" action="<?=UIR?>Admin/new_player_attendance">
+		<table class="search-table">
+			<tr>
+				<td><label for="StartDate">Start Date</label></td>
+				<td><input type="text" id="StartDate" name="StartDate" class="datepicker" value="<?=htmlspecialchars($form['StartDate'] ?? '')?>" /></td>
+				<td><label for="EndDate">End Date</label></td>
+				<td><input type="text" id="EndDate" name="EndDate" class="datepicker" value="<?=htmlspecialchars($form['EndDate'] ?? '')?>" /></td>
+				<td>
+					<button type="submit" name="RunReport" value="1" class="button">Run Report</button>
+				</td>
+			</tr>
+		</table>
+	</form>
+</div>
+
+<?php if (isset($summary) && is_array($summary) && count($summary) > 0): ?>
+<?php
+	$period_label = htmlspecialchars(($form['StartDate'] ?? '') . ' to ' . ($form['EndDate'] ?? ''));
+	$totals = array(
+		'NewPlayers'       => 0,
+		'ReturningPlayers' => 0,
+		'NewPlayerVisits'  => 0
+	);
+	foreach ($summary as $row) {
+		$totals['NewPlayers']       += $row['NewPlayers'];
+		$totals['ReturningPlayers'] += $row['ReturningPlayers'];
+		$totals['NewPlayerVisits']  += $row['NewPlayerVisits'];
+	}
+	$totals['ReturnPct']             = $totals['NewPlayers'] > 0
+		? round(($totals['ReturningPlayers'] / $totals['NewPlayers']) * 100, 1) : 0;
+	$totals['AvgVisitsPerNewPlayer'] = $totals['NewPlayers'] > 0
+		? round($totals['NewPlayerVisits'] / $totals['NewPlayers'], 2) : 0;
+?>
+<div class='info-container'>
+	<h3>New Player Attendance Summary</h3>
+	<p><?=$period_label?></p>
+	<div class="actions"><button class="print button">Print</button> <button class="download button">Download CSV</button></div>
+	<table class='information-table'>
+		<thead>
+			<tr>
+				<th>Kingdom / Principality</th>
+				<th title="Players whose very first sign-in ever falls within the date range">New Players</th>
+				<th title="New players who signed in 2 or more times during the range">Returning Players</th>
+				<th title="Returning ÷ New">Return %</th>
+				<th title="Total sign-in events for new players within the range">New Player Visits</th>
+				<th title="Total visits ÷ new players">Avg Visits / New Player</th>
+			</tr>
+		</thead>
+		<tbody>
+<?php foreach ($summary as $row): ?>
+			<tr onclick='javascript:window.location.href="<?=UIR?>Kingdom/index/<?=$row['KingdomId']?>"' style="cursor:pointer;">
+				<td><?=htmlspecialchars($row['KingdomName'])?></td>
+				<td class="data-column"><?=$row['NewPlayers']?></td>
+				<td class="data-column"><?=$row['ReturningPlayers']?></td>
+				<td class="data-column"><?=$row['ReturnPct']?>%</td>
+				<td class="data-column"><?=$row['NewPlayerVisits']?></td>
+				<td class="data-column"><?=number_format($row['AvgVisitsPerNewPlayer'], 2)?></td>
+			</tr>
+<?php endforeach; ?>
+<?php if (count($summary) > 1): ?>
+			<tr class="static" style="background-color:#eee; color:#999; text-shadow:0px 2px 3px #fff; font-weight:bold; font-size:11pt; font-family:'Gill Sans MT','lucida sans unicode',helvetica,arial;">
+				<td>Total</td>
+				<td class="data-column"><?=$totals['NewPlayers']?></td>
+				<td class="data-column"><?=$totals['ReturningPlayers']?></td>
+				<td class="data-column"><?=$totals['ReturnPct']?>%</td>
+				<td class="data-column"><?=$totals['NewPlayerVisits']?></td>
+				<td class="data-column"><?=number_format($totals['AvgVisitsPerNewPlayer'], 2)?></td>
+			</tr>
+<?php endif; ?>
+		</tbody>
+	</table>
+</div>
+<?php elseif (isset($summary)): ?>
+<div class='info-container'>
+	<p>No new players found for the selected date range.</p>
+</div>
+<?php endif; ?>
+
+<div class='info-container'>
+	<h3>About This Report</h3>
+	<dl>
+		<dt><strong>New Players</strong></dt>
+		<dd>A count of players whose very first sign-in in the entire ORK system falls within the selected date range. Each new player is attributed to the kingdom of the park where their first sign-in occurred.</dd>
+
+		<dt><strong>Returning Players</strong></dt>
+		<dd>Of the new players identified above, a count of those who signed in two or more times during the selected date range at parks within their attribution kingdom. Measures same-period retention.</dd>
+
+		<dt><strong>Return %</strong></dt>
+		<dd>Returning Players ÷ New Players × 100.</dd>
+
+		<dt><strong>New Player Visits</strong></dt>
+		<dd>The total number of individual sign-in events for all new players at parks within their attribution kingdom during the date range.</dd>
+
+		<dt><strong>Avg Visits / New Player</strong></dt>
+		<dd>New Player Visits ÷ New Players. Indicates how engaged new players were on average during the period.</dd>
+	</dl>
+</div>
+
+<script>
+$(function() {
+	$('.datepicker').datepicker({dateFormat: 'yy-mm-dd'});
+	$('.information-table').tablesorter({
+		theme: 'jui',
+		widgets: ['zebra', 'print', 'staticRow'],
+		widgetOptions: {
+			zebra: ['normal-row', 'alt-row']
+		}
+	});
+
+	$('.print.button').click(function(e) {
+		e.preventDefault();
+		var $table = $(this).closest('.info-container').find('table.information-table');
+		var config = $table.data('tablesorter');
+		if (config) {
+			$.tablesorter.printTable.process(config, config.widgetOptions);
+		}
+	});
+
+	$('.download.button').click(function(e) {
+		e.preventDefault();
+		$(this).closest('.info-container').find('table.information-table').table2csv({filename: 'New Player Attendance by Kingdom'});
+	});
+});
+</script>

--- a/orkui/template/default/Kingdom_index.tpl
+++ b/orkui/template/default/Kingdom_index.tpl
@@ -150,6 +150,7 @@ jQuery(document).ready(function($) {
 				<li><a href='<?=UIR ?>Reports/attendance/Kingdom/<?=$kingdom_id ?>/Months/12'>Past 12 Months</a></li>
 				<li><a href='<?=UIR ?>Reports/attendance/Kingdom/<?=$kingdom_id ?>/All'>All</a></li>
 				<li><a href='<?=UIR ?>Reports/park_attendance_explorer'>Park Attendance Explorer</a></li>
+				<li><a href='<?=UIR ?>Reports/new_player_attendance'>New Player Attendance</a></li>
 			</ul>
 		</li>
 		<li>

--- a/orkui/template/default/Reports_newplayerattendance.tpl
+++ b/orkui/template/default/Reports_newplayerattendance.tpl
@@ -1,0 +1,186 @@
+<div class='info-container'>
+	<h3>New Player Attendance</h3>
+
+<?php if (isset($no_kingdom)): ?>
+	<p>Please navigate to a kingdom first to use this report.</p>
+<?php else: ?>
+	<form method="POST" action="<?=UIR?>Reports/new_player_attendance">
+		<table class="search-table">
+			<tr>
+				<td><label for="StartDate">Start Date</label></td>
+				<td><input type="text" id="StartDate" name="StartDate" class="datepicker" value="<?=htmlspecialchars($form['StartDate'] ?? '')?>" /></td>
+				<td><label for="EndDate">End Date</label></td>
+				<td><input type="text" id="EndDate" name="EndDate" class="datepicker" value="<?=htmlspecialchars($form['EndDate'] ?? '')?>" /></td>
+			</tr>
+			<tr>
+				<td><label for="ParkId">Park</label></td>
+				<td>
+					<select id="ParkId" name="ParkId">
+						<option value="0">All Parks</option>
+<?php if (is_array($parks)): ?>
+<?php 	foreach ($parks as $park): ?>
+<?php 		if ($park['Active'] != 'Active') continue; ?>
+						<option value="<?=$park['ParkId']?>"<?=($form['ParkId'] ?? 0) == $park['ParkId'] ? ' selected' : ''?>><?=htmlspecialchars($park['Name'])?></option>
+<?php 	endforeach; ?>
+<?php endif; ?>
+					</select>
+				</td>
+				<td><label for="ShowPlayerDetails">Show Player Details</label></td>
+				<td><input type="checkbox" id="ShowPlayerDetails" name="ShowPlayerDetails" value="1"<?=!empty($form['ShowPlayerDetails']) ? ' checked' : ''?> /></td>
+			</tr>
+			<tr>
+				<td colspan="4">
+					<button type="submit" name="RunReport" value="1" class="button">Run Report</button>
+				</td>
+			</tr>
+		</table>
+	</form>
+<?php endif; ?>
+</div>
+
+<?php if (isset($summary) && is_array($summary) && count($summary) > 0): ?>
+<?php
+	$period_label = htmlspecialchars(($form['StartDate'] ?? '') . ' to ' . ($form['EndDate'] ?? ''));
+	$totals = array(
+		'NewPlayers'            => 0,
+		'ReturningPlayers'      => 0,
+		'NewPlayerVisits'       => 0
+	);
+	foreach ($summary as $row) {
+		$totals['NewPlayers']       += $row['NewPlayers'];
+		$totals['ReturningPlayers'] += $row['ReturningPlayers'];
+		$totals['NewPlayerVisits']  += $row['NewPlayerVisits'];
+	}
+	$totals['ReturnPct']             = $totals['NewPlayers'] > 0
+		? round(($totals['ReturningPlayers'] / $totals['NewPlayers']) * 100, 1) : 0;
+	$totals['AvgVisitsPerNewPlayer'] = $totals['NewPlayers'] > 0
+		? round($totals['NewPlayerVisits'] / $totals['NewPlayers'], 2) : 0;
+?>
+<div class='info-container'>
+	<h3>New Player Attendance Summary</h3>
+	<div class="actions"><button class="print button">Print</button> <button class="download button">Download CSV</button></div>
+	<table class='information-table'>
+		<thead>
+			<tr>
+				<th>Period</th>
+				<th>Park Name</th>
+				<th title="Players whose very first sign-in ever falls within the date range">New Players</th>
+				<th title="New players who signed in 2 or more times during the range">Returning Players</th>
+				<th title="Returning ÷ New">Return %</th>
+				<th title="Total sign-in events for new players within the range">New Player Visits</th>
+				<th title="Total visits ÷ new players">Avg Visits / New Player</th>
+			</tr>
+		</thead>
+		<tbody>
+<?php foreach ($summary as $row): ?>
+			<tr>
+				<td><?=$period_label?></td>
+				<td><?=htmlspecialchars($row['ParkName'])?></td>
+				<td class="data-column"><?=$row['NewPlayers']?></td>
+				<td class="data-column"><?=$row['ReturningPlayers']?></td>
+				<td class="data-column"><?=$row['ReturnPct']?>%</td>
+				<td class="data-column"><?=$row['NewPlayerVisits']?></td>
+				<td class="data-column"><?=number_format($row['AvgVisitsPerNewPlayer'], 2)?></td>
+			</tr>
+<?php endforeach; ?>
+<?php if (count($summary) > 1): ?>
+			<tr class="static" style="background-color:#eee; color:#999; text-shadow:0px 2px 3px #fff; font-weight:bold; font-size:11pt; font-family:'Gill Sans MT','lucida sans unicode',helvetica,arial;">
+				<td>Total</td>
+				<td></td>
+				<td class="data-column"><?=$totals['NewPlayers']?></td>
+				<td class="data-column"><?=$totals['ReturningPlayers']?></td>
+				<td class="data-column"><?=$totals['ReturnPct']?>%</td>
+				<td class="data-column"><?=$totals['NewPlayerVisits']?></td>
+				<td class="data-column"><?=number_format($totals['AvgVisitsPerNewPlayer'], 2)?></td>
+			</tr>
+<?php endif; ?>
+		</tbody>
+	</table>
+</div>
+<?php elseif (isset($summary)): ?>
+<div class='info-container'>
+	<p>No new players found for the selected date range and park.</p>
+</div>
+<?php endif; ?>
+
+<?php if (isset($player_details) && is_array($player_details) && count($player_details) > 0): ?>
+<div class='info-container'>
+	<h3>New Player Details</h3>
+	<div class="actions"><button class="print button">Print</button> <button class="download button">Download CSV</button></div>
+	<table class='information-table'>
+		<thead>
+			<tr>
+				<th>Park</th>
+				<th>Persona Name</th>
+				<th>First Sign-in Date</th>
+				<th title="Sign-ins within the selected date range">Visits in Period</th>
+				<th title="Most recent sign-in date across all time">Last Sign-in Date</th>
+			</tr>
+		</thead>
+		<tbody>
+<?php foreach ($player_details as $player): ?>
+			<tr onclick='javascript:window.location.href="<?=UIR?>Player/index/<?=$player['MundaneId']?>"' style="cursor:pointer;">
+				<td><?=htmlspecialchars($player['ParkName'])?></td>
+				<td><?=htmlspecialchars($player['Persona'])?></td>
+				<td class="data-column"><?=htmlspecialchars($player['FirstSignInDate'])?></td>
+				<td class="data-column"><?=$player['VisitsInPeriod']?></td>
+				<td class="data-column"><?=htmlspecialchars($player['LastSignInDate'])?></td>
+			</tr>
+<?php endforeach; ?>
+		</tbody>
+	</table>
+</div>
+<?php endif; ?>
+
+<div class='info-container'>
+	<h3>About This Report</h3>
+	<dl>
+		<dt><strong>New Players</strong></dt>
+		<dd>A count of players whose very first sign-in in the entire ORK system falls within the selected date range. Players who played elsewhere before this period are not counted, even if this is their first visit to this kingdom.</dd>
+
+		<dt><strong>Park Attribution</strong></dt>
+		<dd>Each new player is credited to the park where their first sign-in occurred. If a player signed in at multiple parks on the same day as their first-ever sign-in, the park with the lowest system ID is used as the tiebreaker.</dd>
+
+		<dt><strong>Returning Players</strong></dt>
+		<dd>Of the new players identified above, a count of those who signed in two or more times during the selected date range. This measures same-period retention — how many newcomers came back at least once before the period ended.</dd>
+
+		<dt><strong>Return %</strong></dt>
+		<dd>Returning Players ÷ New Players × 100. A higher percentage indicates that more new players returned for a second visit within the period.</dd>
+
+		<dt><strong>New Player Visits</strong></dt>
+		<dd>The total number of individual sign-in events (attendance rows) for all new players during the date range. Each sign-in on a distinct date counts as one visit — the credits field is not summed.</dd>
+
+		<dt><strong>Avg Visits / New Player</strong></dt>
+		<dd>New Player Visits ÷ New Players. Indicates how engaged new players were on average during the period.</dd>
+
+		<dt><strong>Last Sign-in Date (Player Details)</strong></dt>
+		<dd>The most recent sign-in date for each player across all time, not limited to the report period. This lets you see whether a new player from a past muster is still active today.</dd>
+	</dl>
+</div>
+
+<script>
+$(function() {
+	$('.datepicker').datepicker({dateFormat: 'yy-mm-dd'});
+	$('.information-table').tablesorter({
+		theme: 'jui',
+		widgets: ['zebra', 'print', 'staticRow'],
+		widgetOptions: {
+			zebra: ['normal-row', 'alt-row']
+		}
+	});
+
+	$('.print.button').click(function(e) {
+		e.preventDefault();
+		var $table = $(this).closest('.info-container').find('table.information-table');
+		var config = $table.data('tablesorter');
+		if (config) {
+			$.tablesorter.printTable.process(config, config.widgetOptions);
+		}
+	});
+
+	$('.download.button').click(function(e) {
+		e.preventDefault();
+		$(this).closest('.info-container').find('table.information-table').table2csv({filename: 'New Player Attendance'});
+	});
+});
+</script>


### PR DESCRIPTION
Kingdom-level report (Reports/new_player_attendance):
- Lists all active parks in the kingdom, including those with zero new players
- Columns: Park Name, New Players, Returning Players, Return %, New Player Visits, Avg Visits / New Player
- Optional Show Player Details table with per-player breakdown
- Totals row pinned to bottom during column sorting (staticRow widget)
- Print and Download CSV buttons

Admin-level report (Admin/new_player_attendance):
- Aggregates the same metrics by Kingdom / Principality across all of ORK
- All active kingdoms shown even with zero new players
- Same table features: sortable columns, pinned totals row, Print, Download CSV

Also includes:
- Add Waivered Players Only filter to the existing Top Parks report