### PR TITLE
Fix double-counting in Park Attendance Explorer report

### DIFF
--- a/orkui/controller/controller.Reports.php
+++ b/orkui/controller/controller.Reports.php
@@ -494,24 +494,25 @@ class Controller_Reports extends Controller {
 			$this->data['mode'] = 'all_parks';
 
 			if (is_array($result)) {
-				$this->data['attendance'] = $result;
+				$attendance = $result['Attendance'];
+				$kingdom_summary = $result['Summary'];
+				$this->data['attendance'] = $attendance;
 
-				// Compute kingdom summary
+				// Compute kingdom summary row; UniquePlayers/UniqueMembers come from the
+				// server-side distinct query to avoid double-counting cross-park visitors.
 				$summary = array(
 					'TotalSignins' => 0,
-					'UniquePlayers' => 0,
-					'UniqueMembers' => 0,
+					'UniquePlayers' => (int)($kingdom_summary['UniquePlayers'] ?? 0),
+					'UniqueMembers' => (int)($kingdom_summary['UniqueMembers'] ?? 0),
 					'Members2Plus' => 0,
 					'Members3Plus' => 0,
 					'Members4Plus' => 0,
 					'WeeksInPeriod' => 0,
 					'MonthsInPeriod' => 0,
-					'RowCount' => count($result)
+					'RowCount' => count($attendance)
 				);
-				foreach ($result as $row) {
+				foreach ($attendance as $row) {
 					$summary['TotalSignins'] += $row['TotalSignins'];
-					$summary['UniquePlayers'] += $row['UniquePlayers'];
-					$summary['UniqueMembers'] += $row['UniqueMembers'];
 					$summary['Members2Plus'] += $row['Members2Plus'];
 					$summary['Members3Plus'] += $row['Members3Plus'];
 					$summary['Members4Plus'] += $row['Members4Plus'];

--- a/orkui/model/model.Reports.php
+++ b/orkui/model/model.Reports.php
@@ -207,7 +207,7 @@ class Model_Reports extends Model {
 	function park_attendance_all_parks($request) {
 		$r = $this->Report->ParkAttendanceAllParks($request);
 		if ($r['Status']['Status'] == 0) {
-			return $r['Attendance'];
+			return array('Attendance' => $r['Attendance'], 'Summary' => $r['Summary'] ?? array());
 		}
 		return false;
 	}

--- a/orkui/template/default/Reports_parkattendanceexplorer.tpl
+++ b/orkui/template/default/Reports_parkattendanceexplorer.tpl
@@ -210,8 +210,10 @@
 				within that specific period. These values are calculated per-period, so a member who signed in 3 times in Q1 but only once in Q2
 				would count toward 2+ and 3+ in Q1 but not in Q2. These numbers are useful for determining insurance needs and park activity levels.</li>
 		</ul>
-		<p>A <strong>Kingdom Totals</strong> row appears at the bottom, summing the values across all parks. Note that Unique Players and Unique Members
-			in the totals row are sums of per-park counts, so a player who visited multiple parks may be counted more than once in the kingdom total.</p>
+		<p>A <strong>Kingdom Totals</strong> row appears at the bottom. <strong>Total Sign-Ins</strong> is the sum of all per-park counts.
+			<strong>Unique Players</strong> and <strong>Unique Members</strong> are true kingdom-wide distinct counts, so a player who visited
+			multiple parks is counted only once. <strong>Members 2+/3+/4+</strong> are summed from per-park per-period values, so a member who
+			met the threshold in multiple periods contributes once per qualifying period.</p>
 
 		<h4>Individual Park View</h4>
 		<p>Shows one row per player with the following columns:</p>

--- a/system/lib/ork3/class.Report.php
+++ b/system/lib/ork3/class.Report.php
@@ -1691,6 +1691,26 @@ class Report  extends Ork3 {
 		}
 		unset($row);
 
+		// Summary query: kingdom-wide distinct player/member counts (avoids per-park summation double-counting visitors)
+		$sql_summary = "SELECT
+					COUNT(DISTINCT a.mundane_id) as unique_players,
+					COUNT(DISTINCT CASE WHEN m.park_id = a.park_id THEN a.mundane_id END) as unique_members
+				FROM " . DB_PREFIX . "attendance a
+					INNER JOIN " . DB_PREFIX . "park p ON a.park_id = p.park_id
+					LEFT JOIN " . DB_PREFIX . "mundane m ON a.mundane_id = m.mundane_id
+				WHERE a.kingdom_id = '$kingdom_id'
+					AND a.date >= '$start_date'
+					AND a.date <= '$end_date'
+					AND a.park_id > 0
+					AND p.active = 'Active'";
+
+		$r_summary = $this->db->query($sql_summary);
+		$response['Summary'] = array('UniquePlayers' => 0, 'UniqueMembers' => 0);
+		if ($r_summary !== false && $r_summary->size() > 0) {
+			$response['Summary']['UniquePlayers'] = (int)$r_summary->unique_players;
+			$response['Summary']['UniqueMembers'] = (int)$r_summary->unique_members;
+		}
+
 		logtrace("Report->ParkAttendanceAllParks()", array($this->db->lastSql, $request));
 		return Ork3::$Lib->ghettocache->cache(__CLASS__ . '.' . __FUNCTION__, $cache_key, $response);
 	}
@@ -1731,7 +1751,7 @@ class Report  extends Ork3 {
 					m.persona,
 					m.waivered,
 					$period_expr as period_label,
-					COUNT(*) as signin_count,
+					COUNT(DISTINCT a.attendance_id) as signin_count,
 					MAX(d.dues_until) as dues_until,
 					MAX(d.dues_for_life) as dues_for_life
 				FROM " . DB_PREFIX . "attendance a


### PR DESCRIPTION
## Summary

Two bugs in the Park Attendance Explorer caused attendance figures to be silently overcounted.

### Bug 1 — Dues JOIN multiplied `signin_count` per player (Individual Park view)

`ParkAttendanceSinglePark` joins `ork_dues` with a `LEFT JOIN` that matches all active, non-revoked dues rows. Players with more than one valid dues record (e.g. a lifetime dues row **and** an unexpired regular dues row, or two overlapping payment windows) caused a Cartesian product with each of their attendance rows. `COUNT(*)` then counted the multiplied rows rather than the actual sign-ins.

**Fix:** `COUNT(*)` → `COUNT(DISTINCT a.attendance_id)` so the aggregate counts attendance records, not join output rows. The `MAX()` aggregates used for dues display are unaffected.

### Bug 2 — Kingdom Totals double-counted cross-park visitors (All Parks view)

The Kingdom Totals summary row was built by summing `UniquePlayers` and `UniqueMembers` from each per-park row. A player who signed in at multiple parks was counted once per park, inflating both figures.

**Fix:** A new SQL query is added to `ParkAttendanceAllParks()` that computes `COUNT(DISTINCT a.mundane_id)` and `COUNT(DISTINCT CASE WHEN m.park_id = a.park_id THEN a.mundane_id END)` in a single pass across the whole kingdom. These true distinct counts flow through the model and controller into the summary row. `TotalSignins` and `Members 2+/3+/4+` continue to be summed from per-park rows, which is correct for those fields.

The "About This Report" copy is updated to reflect the corrected behaviour.

## Files changed

- `system/lib/ork3/class.Report.php` — Fix #1 (`COUNT(DISTINCT)`); add summary query for Fix #2
- `orkui/model/model.Reports.php` — Surface `Summary` key alongside `Attendance`
- `orkui/controller/controller.Reports.php` — Use summary for `UniquePlayers`/`UniqueMembers` in kingdom totals
- `orkui/template/default/Reports_parkattendanceexplorer.tpl` — Update "About This Report" note

## Test plan

- [ ] Run All Parks report for a kingdom; confirm Kingdom Totals Unique Players/Members are ≤ the sum of per-park values (they should be equal only when no player visited more than one park)
- [ ] Run Individual Park report for a player known to have multiple active dues records; confirm per-period sign-in counts match actual attendance, not a multiple thereof
- [ ] Verify Dues Paid column still shows correct value (Life / expiry date / blank)
- [ ] Spot-check Total Sign-Ins and Members 2+/3+/4+ are unchanged from previous behaviour

🤖 Generated with [Claude Code](https://claude.com/claude-code)