### PR TITLE
Enhancement: Park distance reports

### DIFF
--- a/orkui/controller/controller.Reports.php
+++ b/orkui/controller/controller.Reports.php
@@ -576,6 +576,38 @@ class Controller_Reports extends Controller {
 		}
 	}
 
+	public function park_distance_matrix($type = null) {
+		$this->template = 'Reports_parkdistancematrix.tpl';
+		$this->data['page_title'] = "Park Distance Matrix";
+
+		$kingdom_id = intval($this->request->KingdomId ?: $this->session->kingdom_id);
+		if (!valid_id($kingdom_id)) {
+			$this->data['error'] = "No kingdom specified.";
+			return;
+		}
+
+		$result = $this->Reports->park_distance_matrix(array('KingdomId' => $kingdom_id));
+		$this->data['parks']      = $result['Parks'];
+		$this->data['matrix']     = $result['Matrix'];
+		$this->data['kingdom_id'] = $kingdom_id;
+	}
+
+	public function closest_parks($type = null) {
+		$this->template = 'Reports_closestparks.tpl';
+		$this->data['page_title'] = "Closest Parks";
+
+		$park_id = intval($this->request->ParkId);
+		if (!valid_id($park_id)) {
+			$this->data['error'] = "No park specified.";
+			return;
+		}
+
+		$result = $this->Reports->closest_parks(array('ParkId' => $park_id));
+		$this->data['parks']       = $result['Parks'];
+		$this->data['origin_park'] = $result['OriginPark'];
+		$this->data['park_id']     = $park_id;
+	}
+
 }
 
 ?>

--- a/orkui/model/model.Reports.php
+++ b/orkui/model/model.Reports.php
@@ -239,6 +239,22 @@ class Model_Reports extends Model {
 		}
 		return array();
 	}
+
+	function park_distance_matrix($request) {
+		$r = $this->Report->GetParkDistanceMatrix($request);
+		return array(
+			'Parks'  => isset($r['Parks'])  ? $r['Parks']  : array(),
+			'Matrix' => isset($r['Matrix']) ? $r['Matrix'] : array(),
+		);
+	}
+
+	function closest_parks($request) {
+		$r = $this->Report->GetClosestParks($request);
+		return array(
+			'Parks'      => isset($r['Parks']) ? $r['Parks'] : array(),
+			'OriginPark' => isset($r['OriginPark']) ? $r['OriginPark'] : null,
+		);
+	}
 }
 
 ?>

--- a/orkui/template/default/Kingdom_index.tpl
+++ b/orkui/template/default/Kingdom_index.tpl
@@ -151,6 +151,7 @@ jQuery(document).ready(function($) {
 				<li><a href='<?=UIR ?>Reports/attendance/Kingdom/<?=$kingdom_id ?>/All'>All</a></li>
 				<li><a href='<?=UIR ?>Reports/park_attendance_explorer'>Park Attendance Explorer</a></li>
 				<li><a href='<?=UIR ?>Reports/new_player_attendance'>New Player Attendance</a></li>
+				<li><a href='<?=UIR ?>Reports/park_distance_matrix&KingdomId=<?=$kingdom_id ?>'>Park Distance Matrix</a></li>
 			</ul>
 		</li>
 		<li>

--- a/orkui/template/default/Park_index.tpl
+++ b/orkui/template/default/Park_index.tpl
@@ -148,6 +148,7 @@
 				<li><a href='<?=UIR ?>Reports/attendance/Park/<?=$park_id ?>/All'>All</a></li>
 			</ul>
 		</li>
+		<li><a href='<?=UIR ?>Reports/closest_parks&ParkId=<?=$park_id ?>'>Closest Parks</a></li>
 		<li><a href='' class='unimplemented'>Treasury Report</a></li>
 	</ul>
 </div>

--- a/orkui/template/default/Reports_closestparks.tpl
+++ b/orkui/template/default/Reports_closestparks.tpl
@@ -1,0 +1,74 @@
+<div class='info-container'>
+	<h3>Closest Parks<?php if (!empty($origin_park)): ?> to <?=htmlspecialchars($origin_park)?><?php endif; ?></h3>
+<?php if (!empty($error)): ?>
+	<p class="error"><?=htmlspecialchars($error)?></p>
+<?php elseif (empty($parks)): ?>
+	<p>No nearby parks found. This park may not have geocoordinates on file.</p>
+<?php else: ?>
+	<div class="actions"><button class="print button">Print</button> <button class="download button">Download CSV</button></div>
+	<table class='information-table'>
+		<thead>
+			<tr>
+				<th>#</th>
+				<th>Park</th>
+				<th>Kingdom</th>
+				<th>Location</th>
+				<th>Distance</th>
+			</tr>
+		</thead>
+		<tbody>
+<?php foreach ($parks as $i => $park): ?>
+			<tr>
+				<td><?=$i + 1?></td>
+				<td><a href='<?=UIR.'Park/index/'.$park['ParkId']?>'><?=htmlspecialchars($park['ParkName'])?></a></td>
+				<td><?=htmlspecialchars($park['KingdomName'])?></td>
+				<td><?=htmlspecialchars(trim($park['City'].', '.$park['Province'], ', '))?></td>
+				<td><?=htmlspecialchars($park['Miles'])?> mi</td>
+			</tr>
+<?php endforeach; ?>
+		</tbody>
+	</table>
+
+<script>
+	$(function() {
+		$(".information-table").tablesorter({
+			theme: 'jui',
+			widgets: ["zebra", "filter", "print"],
+			widgetOptions: {
+				zebra: ["normal-row", "alt-row"],
+				print_title: '',
+				print_dataAttrib: 'data-name',
+				print_rows: 'f',
+				print_columns: 's',
+				print_extraCSS: '',
+				print_now: true,
+				print_callback: function(config, $table, printStyle) {
+					$.tablesorter.printTable.printOutput(config, $table.html(), printStyle);
+				}
+			}
+		});
+
+		$('.print.button').click(function(e) {
+			e.preventDefault();
+			$('.tablesorter').trigger('printTable');
+		});
+
+		$('.download.button').click(function(e) {
+			e.preventDefault();
+			$("table.information-table").table2csv({"filename": "Closest Parks", "excludeRows": ".tablesorter-filter-row"});
+		});
+	});
+</script>
+<?php endif; ?>
+</div>
+
+<div class='info-container'>
+	<h3>About this Report</h3>
+	<p>The <strong>Closest Parks</strong> report lists the 10 nearest active Amtgard parks to this park, ranked by straight-line distance.</p>
+	<ul>
+		<li><strong>Data source:</strong> Each park's recorded GPS coordinates (latitude &amp; longitude) stored in the ORK.</li>
+		<li><strong>Distance method:</strong> Great-circle distance using the Haversine formula (<code>ST_Distance_Sphere</code>), which measures the shortest path along the surface of the Earth. This is straight-line distance — it does not account for roads, terrain, or travel time.</li>
+		<li><strong>Units:</strong> Miles.</li>
+		<li><strong>Exclusions:</strong> Parks with no coordinates on file, and Retired parks, are excluded. If this park has no coordinates on file, the report cannot run.</li>
+	</ul>
+</div>

--- a/orkui/template/default/Reports_parkdistancematrix.tpl
+++ b/orkui/template/default/Reports_parkdistancematrix.tpl
@@ -1,0 +1,100 @@
+<style>
+.pdm-wrap { overflow-x: auto; }
+.pdm-table { border-collapse: collapse; white-space: nowrap; font-size: 0.8em; }
+.pdm-table th, .pdm-table td { border: 1px solid #ccc; padding: 4px 6px; text-align: center; }
+.pdm-table td.pdm-rowhead { text-align: left; font-weight: bold; white-space: nowrap; background: #f5f5f5; }
+.pdm-table td.pdm-location { text-align: left; white-space: nowrap; background: #f5f5f5; color: #555; }
+.pdm-table th.pdm-colhead { vertical-align: bottom; padding: 4px 2px; background: #f5f5f5; }
+.pdm-table th.pdm-colhead > div {
+	writing-mode: vertical-rl;
+	transform: rotate(180deg);
+	white-space: nowrap;
+	max-height: 120px;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	font-weight: bold;
+	cursor: default;
+}
+.pdm-table td.pdm-self { background: #ddd; color: #999; }
+.pdm-table th.pdm-corner { background: #f5f5f5; }
+</style>
+
+<div class='info-container'>
+	<h3>Park Distance Matrix (miles)</h3>
+<?php if (!empty($error)): ?>
+	<p class="error"><?=htmlspecialchars($error)?></p>
+<?php elseif (empty($parks)): ?>
+	<p>No parks with geocoordinates found for this kingdom.</p>
+<?php else:
+	// Compute global min/max across all off-diagonal cells for HSL normalization
+	$all_miles = array();
+	foreach ($matrix as $row) foreach ($row as $miles) $all_miles[] = $miles;
+	$min_miles = $all_miles ? min($all_miles) : 0;
+	$max_miles = $all_miles ? max($all_miles) : 1;
+	$range     = max($max_miles - $min_miles, 1);
+?>
+	<p><?=count($parks)?> parks with coordinates. Distances shown in miles.</p>
+	<div class="pdm-wrap">
+		<table class="pdm-table">
+			<thead>
+				<tr>
+					<th class="pdm-corner"></th>
+					<th class="pdm-corner"></th>
+<?php foreach ($parks as $col_id => $col): ?>
+					<th class="pdm-colhead" title="<?=htmlspecialchars($col['Name'])?>">
+						<div><?=htmlspecialchars($col['Name'])?></div>
+					</th>
+<?php endforeach; ?>
+				</tr>
+			</thead>
+			<tbody>
+<?php foreach ($parks as $row_id => $row): ?>
+				<tr>
+					<td class="pdm-rowhead"><a href="<?=UIR.'Park/index/'.$row_id?>"><?=htmlspecialchars($row['Name'])?></a></td>
+					<td class="pdm-location"><?=htmlspecialchars(trim($row['City'].', '.$row['Province'], ', '))?></td>
+<?php 	foreach ($parks as $col_id => $col):
+			if ($row_id === $col_id):
+?>
+					<td class="pdm-self" title="<?=htmlspecialchars($row['Name'])?>">—</td>
+<?php 		elseif (isset($matrix[$row_id][$col_id])):
+				$miles = $matrix[$row_id][$col_id];
+				$t = ($miles - $min_miles) / $range;  // 0 = closest, 1 = farthest
+				// Piecewise: green(120,70%,65%) → yellow(55,95%,60%) → orange(25,90%,50%)
+				if ($t < 0.5) {
+					$tt    = $t * 2;
+					$hue   = round(120 - ($tt * 65));  // 120 → 55
+					$sat   = round(70  + ($tt * 25));  // 70% → 95%
+					$light = round(65  - ($tt * 5));   // 65% → 60%
+				} else {
+					$tt    = ($t - 0.5) * 2;
+					$hue   = round(55  - ($tt * 30));  // 55 → 25
+					$sat   = round(95  - ($tt * 5));   // 95% → 90%
+					$light = round(60  - ($tt * 10));  // 60% → 50%
+				}
+				$style = "background:hsl($hue,$sat%,$light%)";
+?>
+					<td style="<?=$style?>" title="<?=htmlspecialchars($row['Name'])?> → <?=htmlspecialchars($col['Name'])?>"><?=$miles?></td>
+<?php 		else: ?>
+					<td>N/A</td>
+<?php 		endif; ?>
+<?php 	endforeach; ?>
+				</tr>
+<?php endforeach; ?>
+			</tbody>
+		</table>
+	</div>
+<?php endif; ?>
+</div>
+
+<div class='info-container'>
+	<h3>About this Report</h3>
+	<p>The <strong>Park Distance Matrix</strong> shows the straight-line distance in miles between every pair of active parks in this kingdom that have GPS coordinates on file.</p>
+	<ul>
+		<li><strong>Rows &amp; columns:</strong> Each park appears once as a row (with its city/state) and once as a column header. The cell where a row and column intersect shows the distance between those two parks.</li>
+		<li><strong>Diagonal:</strong> Cells where a park intersects with itself are shown as "—" (zero distance).</li>
+		<li><strong>Distance method:</strong> Great-circle distance using the Haversine formula (<code>ST_Distance_Sphere</code>), measuring the shortest path along the Earth's surface. Straight-line only — roads and terrain are not considered.</li>
+		<li><strong>Units:</strong> Miles, rounded to one decimal place.</li>
+		<li><strong>Color scale:</strong> Cells are color-coded from <span style="background:hsl(120,70%,65%);padding:0 6px;border-radius:3px;">green</span> (shortest distance) through <span style="background:hsl(55,95%,60%);padding:0 6px;border-radius:3px;">yellow</span> (midpoint) to <span style="background:hsl(25,90%,50%);color:#fff;padding:0 6px;border-radius:3px;">orange</span> (longest distance). The scale is relative to this kingdom's own min and max distances, so colors always span the full range regardless of how spread out the parks are.</li>
+		<li><strong>Exclusions:</strong> Parks with no coordinates on file and Retired parks are not included.</li>
+	</ul>
+</div>

--- a/system/lib/ork3/class.Report.php
+++ b/system/lib/ork3/class.Report.php
@@ -2042,6 +2042,100 @@ class Report  extends Ork3 {
 		logtrace("Report->ParkAttendanceSinglePark()", array($this->db->lastSql, $request));
 		return Ork3::$Lib->ghettocache->cache(__CLASS__ . '.' . __FUNCTION__, $key, $response);
 	}
+
+	public function GetParkDistanceMatrix($request) {
+		$kingdom_id = intval($request['KingdomId']);
+
+		$sql = "SELECT
+					p1.park_id  AS row_id,
+					p1.name     AS row_name,
+					p1.city     AS row_city,
+					p1.province AS row_province,
+					p2.park_id  AS col_id,
+					ROUND(ST_Distance_Sphere(POINT(p1.longitude, p1.latitude), POINT(p2.longitude, p2.latitude)) / 1609.344, 1) AS miles
+				FROM " . DB_PREFIX . "park p1
+				CROSS JOIN " . DB_PREFIX . "park p2
+				WHERE p1.kingdom_id = '$kingdom_id'
+					AND p2.kingdom_id = '$kingdom_id'
+					AND p1.active = 'Active'
+					AND p2.active = 'Active'
+					AND p1.latitude  IS NOT NULL AND p1.latitude  != 0
+					AND p1.longitude IS NOT NULL AND p1.longitude != 0
+					AND p2.latitude  IS NOT NULL AND p2.latitude  != 0
+					AND p2.longitude IS NOT NULL AND p2.longitude != 0
+				ORDER BY p1.name ASC, p2.name ASC";
+
+		$r = $this->db->query($sql);
+
+		$parks  = array();
+		$matrix = array();
+
+		if ($r !== false && $r->size() > 0) {
+			while ($r->next()) {
+				$row_id = $r->row_id;
+				$col_id = $r->col_id;
+				if (!isset($parks[$row_id])) {
+					$parks[$row_id] = array(
+						'Name'     => $r->row_name,
+						'City'     => $r->row_city,
+						'Province' => $r->row_province,
+					);
+				}
+				if ($row_id !== $col_id) $matrix[$row_id][$col_id] = floatval($r->miles);
+			}
+		}
+
+		return array('Parks' => $parks, 'Matrix' => $matrix);
+	}
+
+	public function GetClosestParks($request) {
+		$park_id = intval($request['ParkId']);
+
+		$origin_sql = "SELECT latitude, longitude, name FROM " . DB_PREFIX . "park WHERE park_id = '$park_id'";
+		$origin = $this->db->query($origin_sql);
+		if ($origin === false || $origin->size() == 0) return array('Parks' => array(), 'OriginPark' => null);
+
+		$origin->next();
+		$lat = floatval($origin->latitude);
+		$lng = floatval($origin->longitude);
+		$origin_name = $origin->name;
+
+		if ($lat == 0 && $lng == 0) return array('Parks' => array(), 'OriginPark' => $origin_name);
+
+		$sql = "SELECT
+					p.park_id,
+					p.name AS park_name,
+					k.name AS kingdom_name,
+					p.city,
+					p.province,
+					ROUND(ST_Distance_Sphere(POINT(p.longitude, p.latitude), POINT('$lng', '$lat')) / 1609.344, 1) AS miles
+				FROM " . DB_PREFIX . "park p
+				INNER JOIN " . DB_PREFIX . "kingdom k ON p.kingdom_id = k.kingdom_id
+				WHERE p.park_id != '$park_id'
+					AND p.active = 'Active'
+					AND p.latitude IS NOT NULL
+					AND p.longitude IS NOT NULL
+					AND p.latitude != 0
+					AND p.longitude != 0
+				ORDER BY miles ASC
+				LIMIT 25";
+
+		$r = $this->db->query($sql);
+		$response = array('Parks' => array(), 'OriginPark' => $origin_name);
+		if ($r !== false && $r->size() > 0) {
+			while ($r->next()) {
+				$response['Parks'][] = array(
+					'ParkId'      => $r->park_id,
+					'ParkName'    => $r->park_name,
+					'KingdomName' => $r->kingdom_name,
+					'City'        => $r->city,
+					'Province'    => $r->province,
+					'Miles'       => $r->miles,
+				);
+			}
+		}
+		return $response;
+	}
 }
 
 ?>


### PR DESCRIPTION
## Summary

Adds two new geography-based reports that use MariaDB's `ST_Distance_Sphere` function to calculate great-circle distances between parks. Both reports require no schema changes — they use the existing `latitude` and `longitude` columns on `ork_park`.

### Closest Parks (Park-level)

- Lists the **25 nearest active parks** to the current park, sorted by straight-line distance in miles
- Accessible from the Park profile Reports section
- Handles parks with missing geocoordinates gracefully

### Park Distance Matrix (Kingdom-level)

- Renders a full **N×N grid** showing pairwise distances (in miles) between every active, geocoded park in a kingdom
- Each row includes the park's city/state for quick orientation
- Column headers rotate 90° for readability on wide tables
- Cells are **color-coded green → yellow → orange** using a piecewise HSL scale normalized to the kingdom's own min/max distance range, so the full color spectrum is always used regardless of how geographically spread out the parks are
- Accessible from the Kingdom profile Reports section

Both reports include an **"About this Report"** explainer box describing the data source, distance methodology (Haversine/great-circle, not driving distance), units, and exclusions.

## Files Changed

| File | Change |
|------|--------|
| `system/lib/ork3/class.Report.php` | `GetClosestParks()`, `GetParkDistanceMatrix()` |
| `orkui/model/model.Reports.php` | `closest_parks()`, `park_distance_matrix()` |
| `orkui/controller/controller.Reports.php` | `closest_parks()`, `park_distance_matrix()` |
| `orkui/template/default/Reports_closestparks.tpl` | New template |
| `orkui/template/default/Reports_parkdistancematrix.tpl` | New template |
| `orkui/template/default/Park_index.tpl` | Closest Parks link |
| `orkui/template/default/Kingdom_index.tpl` | Park Distance Matrix link |

## Test plan

- [ ] Navigate to a Park profile → Reports → **Closest Parks** — confirm top 10 list renders with park links, kingdom, city/state, and miles
- [ ] Navigate to a Park with no coordinates on file — confirm graceful "no coordinates" message
- [ ] Navigate to a Kingdom profile → Reports → **Park Distance Matrix** — confirm grid renders with rotated column headers and color-coded cells
- [ ] Verify diagonal cells show "—"
- [ ] Verify color scale spans green → yellow → orange (closest cells greenest, farthest cells most orange)
- [ ] Confirm parks without coordinates are excluded from both reports
- [ ] Confirm Retired parks are excluded from both reports

🤖 Generated with [Claude Code](https://claude.com/claude-code)