### PR TITLE
Enhancement: Add Reconcile Copied Event action for future occurrences with past attendance

### DIFF
--- a/orkui/controller/controller.Event.php
+++ b/orkui/controller/controller.Event.php
@@ -288,6 +288,8 @@ class Controller_Event extends Controller {
 			return;
 		}
 
+		$cdInfo = $this->Attendance->get_eventdetail_info($detail_id);
+
 		if ( strlen($action) > 0 && $uid > 0 ) {
 
 			if ( $action === 'edit' ) {
@@ -331,6 +333,79 @@ class Controller_Event extends Controller {
 					}
 				}
 
+			} elseif ( $action === 'reconcile' ) {
+				if ( Ork3::$Lib->authorization->HasAuthority($uid, AUTH_EVENT, $event_id, AUTH_CREATE) ) {
+					$today   = date('Y-m-d');
+					$attData = $this->Attendance->get_attendance_for_event($event_id, $detail_id);
+					$pastAtt = array_filter(
+						$attData['Attendance'] ?? [],
+						fn($a) => !empty($a['Date']) && strtotime($a['Date']) < strtotime($today)
+					);
+					if ( !empty($pastAtt) ) {
+						$dates   = array_map(fn($a) => strtotime($a['Date']), $pastAtt);
+						$minDate = date('Y-m-d', min($dates)) . ' 12:00:00';
+						$maxDate = date('Y-m-d', max($dates)) . ' 18:00:00';
+						$r = $this->Event->add_event_detail([
+							'Token'       => $this->session->token,
+							'EventId'     => $event_id,
+							'AtParkId'    => valid_id($cdInfo['AtParkId']) ? $cdInfo['AtParkId'] : null,
+							'Current'     => 0,
+							'Price'       => $cdInfo['Price']       ?? '',
+							'EventStart'  => $minDate,
+							'EventEnd'    => $maxDate,
+							'Description' => $cdInfo['Description'] ?? '',
+							'Url'         => $cdInfo['Url']         ?? '',
+							'UrlName'     => $cdInfo['UrlName']     ?? '',
+							'Address'     => $cdInfo['Address']     ?? '',
+							'Province'    => $cdInfo['Province']    ?? '',
+							'PostalCode'  => $cdInfo['PostalCode']  ?? '',
+							'City'        => $cdInfo['City']        ?? '',
+							'Country'     => $cdInfo['Country']     ?? '',
+							'MapUrl'      => $cdInfo['MapUrl']      ?? '',
+							'MapUrlName'  => $cdInfo['MapUrlName']  ?? '',
+						]);
+						if ( $r['Status'] == 0 ) {
+							$new_detail_id = (int)($r['Detail'] ?? 0);
+							if ( !$new_detail_id ) {
+								$fresh = $this->Event->get_event_details($event_id);
+								$all   = $fresh['CalendarEventDetails'] ?? [];
+								if ( $all ) $new_detail_id = max(array_map('intval', array_column($all, 'EventCalendarDetailId')));
+							}
+							if ( $new_detail_id ) {
+								global $DB;
+								$DB->Clear();
+								$DB->Execute(
+									"UPDATE " . DB_PREFIX . "attendance " .
+									"SET event_calendardetail_id = " . $new_detail_id .
+									" WHERE event_calendardetail_id = " . $detail_id .
+									" AND date < '" . $today . "'"
+								);
+								$DB->Clear();
+								$DB->Execute(
+									"UPDATE " . DB_PREFIX . "attendance_myisam " .
+									"SET event_calendardetail_id = " . $new_detail_id .
+									" WHERE event_calendardetail_id = " . $detail_id .
+									" AND date < '" . $today . "'"
+								);
+								$evKey  = Ork3::$Lib->ghettocache->key(['', null, null, null, null, null, $event_id]);
+								$oldKey = Ork3::$Lib->ghettocache->key([$detail_id]);
+								$newKey = Ork3::$Lib->ghettocache->key([$new_detail_id]);
+								Ork3::$Lib->ghettocache->bust('SearchService.Event', $evKey);
+								Ork3::$Lib->ghettocache->bust('SearchService.CalendarDetail', $oldKey);
+								Ork3::$Lib->ghettocache->bust('SearchService.CalendarDetail', $newKey);
+								header('Location: ' . UIR . 'Event/detail/' . $event_id . '/' . $detail_id . '&reconciled=1');
+								exit;
+							} else {
+								$this->data['Error'] = 'Reconciliation failed: could not determine the new occurrence ID.';
+							}
+						} else {
+							$this->data['Error'] = 'Reconciliation failed: ' . ($r['Error'] ?? 'unknown error') . ' — ' . ($r['Detail'] ?? '');
+						}
+					} else {
+						$this->data['Error'] = 'No past-dated attendance found to reconcile.';
+					}
+				}
+
 			} else {
 				// Attendance actions
 				$this->request->save('Attendance_event', true);
@@ -365,7 +440,7 @@ class Controller_Event extends Controller {
 			}
 		}
 
-		$this->data['EventDetail'] = $this->Attendance->get_eventdetail_info($detail_id);
+		$this->data['EventDetail'] = $cdInfo;
 
 		$atParkId = (int)($this->data['EventDetail']['AtParkId'] ?? 0);
 		$_parkLookupId = $atParkId ?: (int)($this->data['EventInfo']['ParkId'] ?? 0);

--- a/orkui/template/revised-frontend/Eventnew_index.tpl
+++ b/orkui/template/revised-frontend/Eventnew_index.tpl
@@ -106,6 +106,7 @@
 		$attDateMismatch = $allPast;
 	}
 
+	$reconciled    = isset($_GET['reconciled']);
 	$rsvpCounts    = is_array($RsvpCount ?? null) ? $RsvpCount : ['going' => 0, 'interested' => 0, 'total' => (int)($RsvpCount ?? 0)];
 	$rsvpCount     = $rsvpCounts['total'];
 	$userAttending = $UserAttending ?? false; // false or 'going' or 'interested'
@@ -470,11 +471,28 @@
 			<?php // ---- Attendance Tab ---- ?>
 			<div class="ev-tab-panel" id="ev-tab-attendance">
 
-				<?php if ($attDateMismatch): ?>
+				<?php if ($reconciled): ?>
+				<div style="background:#f0fff4;border:1px solid #68d391;border-radius:6px;padding:12px 16px;margin-bottom:14px;color:#276749;font-size:13px;line-height:1.5;">
+					<i class="fas fa-check-circle" style="margin-right:6px;"></i>
+					<strong>Reconciled.</strong> Past attendance has been moved to a new occurrence dated to match those records.
+				</div>
+				<?php endif; ?>
+				<?php if ($attDateMismatch && $canManage): ?>
 				<div style="background:#fffbeb;border:1px solid #f6ad55;border-radius:6px;padding:12px 16px;margin-bottom:14px;color:#7b341e;font-size:13px;line-height:1.5;">
-					<strong><i class="fas fa-exclamation-triangle" style="margin-right:6px;"></i>Warning:</strong>
-					It looks like this future event already has attendance. This is most likely due to the event being edited to move it forward instead of a new event being created.
-					Please edit this event to move it back to its original date and create a new event instead.
+					<strong><i class="fas fa-exclamation-triangle" style="margin-right:6px;"></i>Data mismatch detected:</strong>
+					This future event has <?= count($attendanceList) ?> attendance record<?= count($attendanceList) != 1 ? 's' : '' ?> dated in the past —
+					likely because this occurrence's date was edited forward after attendance was entered.
+					<?php if ($canManageAttendance): ?>
+					<br><br>
+					<strong>Reconcile</strong> will create a new past occurrence for those dates and move the attendance there, leaving this future occurrence clean.
+					<form method="post" action="<?= UIR ?>Event/detail/<?= $eventId ?>/<?= $detailId ?>/reconcile"
+						  style="display:inline-block;margin-top:8px;"
+						  onsubmit="return confirm('Move <?= count($attendanceList) ?> attendance record(s) to a new past occurrence? This cannot be undone.');">
+						<button type="submit" style="background:#c05621;color:#fff;border:none;border-radius:4px;padding:7px 16px;font-size:13px;font-weight:600;cursor:pointer;">
+							<i class="fas fa-tools" style="margin-right:5px;"></i>Reconcile Attendance
+						</button>
+					</form>
+					<?php endif; ?>
 				</div>
 				<?php endif; ?>
 				<div class="ev-export-bar">

--- a/orkui/template/revised-frontend/Eventnew_index.tpl
+++ b/orkui/template/revised-frontend/Eventnew_index.tpl
@@ -485,10 +485,10 @@
 					<?php if ($canManageAttendance): ?>
 					<br><br>
 					<strong>Reconcile</strong> will create a new past occurrence for those dates and move the attendance there, leaving this future occurrence clean.
-					<form method="post" action="<?= UIR ?>Event/detail/<?= $eventId ?>/<?= $detailId ?>/reconcile"
-						  style="display:inline-block;margin-top:8px;"
-						  onsubmit="return confirm('Move <?= count($attendanceList) ?> attendance record(s) to a new past occurrence? This cannot be undone.');">
-						<button type="submit" style="background:#c05621;color:#fff;border:none;border-radius:4px;padding:7px 16px;font-size:13px;font-weight:600;cursor:pointer;">
+					<form id="ev-reconcile-form" method="post" action="<?= UIR ?>Event/detail/<?= $eventId ?>/<?= $detailId ?>/reconcile"
+						  style="display:inline-block;margin-top:8px;">
+						<button type="button" style="background:#c05621;color:#fff;border:none;border-radius:4px;padding:7px 16px;font-size:13px;font-weight:600;cursor:pointer;"
+						        onclick="pnConfirm({title:'Reconcile Attendance?',message:'Move <?= count($attendanceList) ?> attendance record(s) to a new past occurrence? This cannot be undone.',confirmText:'Reconcile',danger:true},function(){document.getElementById('ev-reconcile-form').submit();});">
 							<i class="fas fa-tools" style="margin-right:5px;"></i>Reconcile Attendance
 						</button>
 					</form>


### PR DESCRIPTION
## Summary

- Adds a **Reconcile Attendance** action to event occurrence detail pages
- When an occurrence's start date has been edited forward in time, attendance recorded under the old date remains linked to it, creating a mismatch. This PR detects that condition and provides a one-click fix
- Reconcile creates a new past occurrence (copying all metadata — location, description, price, etc.) dated to match the stranded attendance records, then bulk-reassigns the attendance rows to it via direct UPDATE on both `ork_attendance` and `ork_attendance_myisam`
- The warning banner and Reconcile button are only shown to users with event management authority (`AUTH_CREATE`)
- On success: redirects back to the now-clean future occurrence with a green confirmation flash; all three relevant caches (event + old detail + new detail) are busted
- On failure: renders the page with a specific error message — no silent failures

## Test plan

- [ ] Navigate to a future event occurrence that has past-dated attendance (e.g. `Event/detail/649/6191`) — confirm the amber warning banner appears for event managers and is hidden for regular users
- [ ] Click **Reconcile Attendance**, confirm the JS dialog, submit — confirm redirect to same page with green "Reconciled." flash and empty attendance table
- [ ] Check `Event/template/{event_id}` — confirm a new past occurrence appears in the Past list with the correct date and attendance count
- [ ] DB spot-check: `SELECT event_calendardetail_id, COUNT(*) FROM ork_attendance WHERE event_id = {id} GROUP BY event_calendardetail_id` — old detail should have 0, new detail should have the moved count
- [ ] Confirm `ork_attendance_myisam` is also updated with the same query
- [ ] Verify a non-manager viewing the page does not see the warning or button

🤖 Generated with [Claude Code](https://claude.com/claude-code)