### PR TITLE
Enhancement: Award system overhaul, kingdom admin improvements, and misc enhancements

### DIFF
--- a/orkui/controller/controller.Kingdom.php
+++ b/orkui/controller/controller.Kingdom.php
@@ -468,6 +468,9 @@ class Controller_Kingdom extends Controller {
 				$adminAwards[] = [
 					'KingdomAwardId'   => (int)$kawId,
 					'KingdomAwardName' => $aw['KingdomAwardName']  ?? '',
+					'AwardId'          => (int)($aw['AwardId']     ?? 0),
+					'AwardName'        => $aw['AwardName']         ?? '',
+					'IsLadder'         => (int)($aw['IsLadder']    ?? 0),
 					'ReignLimit'       => (int)($aw['ReignLimit']  ?? 0),
 					'MonthLimit'       => (int)($aw['MonthLimit']  ?? 0),
 					'IsTitle'          => (int)($aw['IsTitle']     ?? 0),
@@ -475,6 +478,17 @@ class Controller_Kingdom extends Controller {
 				];
 			}
 			$this->data['AdminAwards'] = $adminAwards;
+
+			// System awards list for Add Award Alias dropdown
+			$sysAwardResult = $this->Award->GetAwardList(['IsLadder' => null, 'IsTitle' => null, 'OfficerRole' => 'Awards']);
+			$sysAwards = [];
+			if (($sysAwardResult['Status']['Status'] ?? 1) == 0) {
+				foreach ($sysAwardResult['Awards'] as $sa) {
+					$sysAwards[] = ['AwardId' => (int)$sa['AwardId'], 'Name' => $sa['AwardName'] ?? $sa['KingdomAwardName']];
+				}
+				usort($sysAwards, function($a, $b) { return strcasecmp($a['Name'], $b['Name']); });
+			}
+			$this->data['SystemAwards'] = $sysAwards;
 		}
 
 		$this->data['PronounList']          = $this->Pronoun->fetch_pronoun_list();

--- a/orkui/controller/controller.KingdomAjax.php
+++ b/orkui/controller/controller.KingdomAjax.php
@@ -226,10 +226,6 @@ class Controller_KingdomAjax extends Controller {
 				]);
 			} else {
 				$awardId = (int)($_POST['AwardId'] ?? 0);
-				if (!valid_id($awardId)) {
-					echo json_encode(['status' => 1, 'error' => 'Canonical Award ID is required for new awards.']);
-					exit;
-				}
 				$r = $this->Kingdom->CreateAward([
 					'Token'      => $this->session->token,
 					'KingdomId'  => $kingdom_id,
@@ -796,6 +792,9 @@ class Controller_KingdomAjax extends Controller {
 		} elseif ($scope === 'exclude') {
 			$kingdom_clause = "AND m.kingdom_id != {$kid}";
 			$park_clause    = valid_id($park_id) ? "AND m.park_id = {$park_id}" : '';
+		} elseif ($scope === 'all') {
+			$kingdom_clause = '';
+			$park_clause    = '';
 		} else {
 			$kingdom_clause = "AND m.kingdom_id = {$kid}";
 			$park_clause    = valid_id($park_id) ? "AND m.park_id = {$park_id}" : '';
@@ -817,7 +816,7 @@ class Controller_KingdomAjax extends Controller {
 			    OR m.given_name LIKE '%{$term}%'
 			    OR m.surname LIKE '%{$term}%'
 			    OR m.username LIKE '%{$term}%')
-			ORDER BY m.persona
+			ORDER BY m.active DESC, CASE WHEN m.kingdom_id = {$kid} THEN 0 ELSE 1 END, m.persona
 			LIMIT 15";
 
 		$DB->Clear();

--- a/orkui/controller/controller.ParkAjax.php
+++ b/orkui/controller/controller.ParkAjax.php
@@ -225,7 +225,7 @@ class Controller_ParkAjax extends Controller {
 				    OR m.given_name LIKE '%{$term}%'
 				    OR m.surname LIKE '%{$term}%'
 				    OR m.username LIKE '%{$term}%')
-				ORDER BY {$order_clause} m.persona
+				ORDER BY m.active DESC, {$order_clause} m.persona
 				LIMIT 15";
 			$DB->Clear();
 			$rs      = $DB->DataSet($sql);

--- a/orkui/controller/controller.Reports.php
+++ b/orkui/controller/controller.Reports.php
@@ -1078,6 +1078,60 @@ class Controller_Reports extends Controller {
 		$this->data['park_id']     = $park_id;
 	}
 
+	public function player_status_reconciliation($type = null) {
+		$_uid = isset($this->session->user_id) ? (int)$this->session->user_id : 0;
+		$_isOrkAdmin = $_uid > 0 && Ork3::$Lib->authorization->HasAuthority($_uid, AUTH_ADMIN, 0, AUTH_ADMIN);
+		if (!$_isOrkAdmin && (!in_array($type, array('Kingdom', 'Park')) || !valid_id($this->request->id))) {
+			header('Location: ' . UIR);
+			exit;
+		}
+
+		$this->template = 'Reports_player_status_reconciliation.tpl';
+		$this->data['page_title'] = 'Player Status Reconciliation';
+		$this->data['report_type'] = $type;
+		$this->data['report_id']   = $this->request->id ?? null;
+		$this->data['reconciliation'] = $this->Reports->player_status_reconciliation($type, $this->request->id);
+		$this->data['user_token'] = $this->session->token ?? '';
+
+		// Check if current user can edit players in this scope
+		$can_edit = false;
+		if ($_isOrkAdmin) {
+			$can_edit = true;
+		} elseif ($type === 'Park' && valid_id($this->request->id)) {
+			$can_edit = Ork3::$Lib->authorization->HasAuthority($_uid, AUTH_PARK, $this->request->id, AUTH_CREATE);
+		} elseif ($type === 'Kingdom' && valid_id($this->request->id)) {
+			$can_edit = Ork3::$Lib->authorization->HasAuthority($_uid, AUTH_KINGDOM, $this->request->id, AUTH_EDIT);
+		}
+		$this->data['can_edit'] = $can_edit;
+
+		if ($type === 'Park') {
+			$this->data['menu']['reports']['url'] = UIR . 'Park/profile/' . (int)$this->request->id . '&tab=reports';
+		} elseif ($type === 'Kingdom') {
+			$this->data['menu']['reports']['url'] = UIR . 'Kingdom/profile/' . (int)$this->request->id . '&tab=reports';
+		}
+	}
+
+	public function set_player_active_json() {
+		header('Content-Type: application/json');
+		if (!isset($this->session->user_id) || !isset($this->session->token)) {
+			echo json_encode(['status' => 5, 'error' => 'Not logged in']);
+			exit;
+		}
+		$mundane_id = (int)($_POST['MundaneId'] ?? 0);
+		$active     = (int)($_POST['Active'] ?? -1);
+		if (!valid_id($mundane_id) || !in_array($active, [0, 1])) {
+			echo json_encode(['status' => 1, 'error' => 'Invalid parameters']);
+			exit;
+		}
+		$r = $this->Reports->set_player_active_status($this->session->token, $mundane_id, $active);
+		if ($r['Status'] == 0) {
+			echo json_encode(['status' => 0]);
+		} else {
+			echo json_encode(['status' => $r['Status'], 'error' => ($r['Error'] ?? 'Error') . ': ' . ($r['Detail'] ?? '')]);
+		}
+		exit;
+	}
+
 }
 
 ?>

--- a/orkui/controller/controller.SearchAjax.php
+++ b/orkui/controller/controller.SearchAjax.php
@@ -110,8 +110,8 @@ class Controller_SearchAjax extends Controller {
 		if ($filterPid > 0)           { $playerWhere .= " AND m.park_id = {$filterPid}"; }
 		elseif ($filterKid > 0)       { $playerWhere .= " AND m.kingdom_id = {$filterKid}"; }
 		$playerOrder = valid_id($pid)
-			? "CASE WHEN m.park_id = {$pid} THEN 0 WHEN m.kingdom_id = {$kid} THEN 1 ELSE 2 END, m.persona"
-			: (valid_id($kid) ? "CASE WHEN m.kingdom_id = {$kid} THEN 0 ELSE 1 END, m.persona" : "m.persona");
+			? "m.active DESC, CASE WHEN m.park_id = {$pid} THEN 0 WHEN m.kingdom_id = {$kid} THEN 1 ELSE 2 END, m.persona"
+			: (valid_id($kid) ? "m.active DESC, CASE WHEN m.kingdom_id = {$kid} THEN 0 ELSE 1 END, m.persona" : "m.active DESC, m.persona");
 		$rs = $DB->DataSet("
 			SELECT m.mundane_id, m.persona, m.active, k.abbreviation AS k_abbr, p.name AS park_name
 			FROM ork_mundane m

--- a/orkui/model/model.Award.php
+++ b/orkui/model/model.Award.php
@@ -30,15 +30,34 @@ class Model_Award extends Model {
                     'OfficerRole' => $officer_role
                 ));
         }
-            
+
         if ($awards['Status']['Status'] == 0) {
             uasort($awards['Awards'], array('Model_Award','compareAwardsByName'));
 
-            $ladder = array();
-            $other  = array();
+            $custom = $ladder = $knighthoods = $masterhoods = $paragons = $associates = $nobles = $other = [];
             foreach ($awards['Awards'] as $award) {
-                if (!empty($award['IsLadder'])) {
+                $sysName = $award['AwardName'] ?? $award['KingdomAwardName'];
+                if ($sysName === 'Custom Award') {
+                    $custom[] = $award;
+                } elseif (!empty($award['IsLadder'])) {
                     $ladder[] = $award;
+                } elseif (in_array($sysName, ['Defender', 'Master'])) {
+                    $nobles[] = $award;
+                } elseif ($sysName === 'Weaponmaster') {
+                    $other[] = $award;
+                } elseif (($award['Peerage'] ?? '') === 'Knight') {
+                    $knighthoods[] = $award;
+                } elseif (($award['Peerage'] ?? '') === 'Paragon') {
+                    $paragons[] = $award;
+                } elseif (($award['Peerage'] ?? '') === 'Master'
+                          || (!empty($award['IsTitle']) && ($award['TitleClass'] ?? 0) == 10)) {
+                    $masterhoods[] = $award;
+                } elseif (in_array($award['Peerage'] ?? '', ['Squire','Man-At-Arms','Page','Lords-Page'])
+                          || $sysName === 'Apprentice') {
+                    $associates[] = $award;
+                } elseif ((!empty($award['IsTitle']) && ($award['TitleClass'] ?? 0) >= 30)
+                          || $sysName === 'Esquire') {
+                    $nobles[] = $award;
                 } else {
                     $other[] = $award;
                 }
@@ -46,15 +65,27 @@ class Model_Award extends Model {
 
             $options = '';
             if (!empty($ladder)) {
-                $options .= "<optgroup label='Common Awards'>";
+                $options .= "<optgroup label='Ladder Awards'>";
                 foreach ($ladder as $award) {
                     $options .= "<option value='" . htmlspecialchars($award['KingdomAwardId'], ENT_QUOTES) . "' data-is-ladder='1' data-award-id='" . htmlspecialchars($award['AwardId'], ENT_QUOTES) . "'>" . htmlspecialchars($award['KingdomAwardName'], ENT_QUOTES) . "</option>";
                 }
                 $options .= "</optgroup>";
             }
-            if (!empty($other)) {
-                $options .= "<optgroup label='Awards'>";
-                foreach ($other as $award) {
+            foreach ($custom as $award) {
+                $options .= "<option value='" . htmlspecialchars($award['KingdomAwardId'], ENT_QUOTES) . "'>" . htmlspecialchars($award['KingdomAwardName'], ENT_QUOTES) . "</option>";
+            }
+            $groups = [
+                'Knighthoods' => $knighthoods,
+                'Masterhoods' => $masterhoods,
+                'Paragons' => $paragons,
+                'Noble Titles' => $nobles,
+                'Associate Titles' => $associates,
+                'Other' => $other,
+            ];
+            foreach ($groups as $label => $items) {
+                if (empty($items)) continue;
+                $options .= "<optgroup label='" . htmlspecialchars($label, ENT_QUOTES) . "'>";
+                foreach ($items as $award) {
                     $options .= "<option value='" . htmlspecialchars($award['KingdomAwardId'], ENT_QUOTES) . "'>" . htmlspecialchars($award['KingdomAwardName'], ENT_QUOTES) . "</option>";
                 }
                 $options .= "</optgroup>";
@@ -65,7 +96,7 @@ class Model_Award extends Model {
         }
     }
 
-    
+
 }
 
 ?>

--- a/orkui/model/model.Reports.php
+++ b/orkui/model/model.Reports.php
@@ -310,6 +310,31 @@ class Model_Reports extends Model {
 			'OriginPark' => isset($r['OriginPark']) ? $r['OriginPark'] : null,
 		);
 	}
+
+	function player_status_reconciliation($type, $id) {
+		$request = array();
+		if ($type === 'Park') {
+			$request['ParkId'] = $id;
+		} else {
+			$request['KingdomId'] = $id;
+		}
+		$r = $this->Report->GetPlayerStatusReconciliation($request);
+		if ($r['Status']['Status'] == 0) {
+			return array(
+				'InactiveWithAttendance' => $r['InactiveWithAttendance'],
+				'ActiveNoAttendance'     => $r['ActiveNoAttendance'],
+			);
+		}
+		return false;
+	}
+
+	function set_player_active_status($token, $mundane_id, $active) {
+		return $this->Report->SetPlayerActiveStatus(array(
+			'Token'     => $token,
+			'MundaneId' => $mundane_id,
+			'Active'    => $active,
+		));
+	}
 }
 
 ?>

--- a/orkui/template/default/Reports_player_status_reconciliation.tpl
+++ b/orkui/template/default/Reports_player_status_reconciliation.tpl
@@ -1,0 +1,394 @@
+<?php
+$data = $reconciliation;
+$inactive_with_att = is_array($data['InactiveWithAttendance']) ? $data['InactiveWithAttendance'] : array();
+$active_no_att     = is_array($data['ActiveNoAttendance'])     ? $data['ActiveNoAttendance']     : array();
+$total_inactive = count($inactive_with_att);
+$total_active   = count($active_no_att);
+
+$scope_label = '';
+$scope_link  = '';
+$scope_icon  = 'fa-globe';
+if (($report_type ?? null) === 'Park') {
+	if (!empty($inactive_with_att)) {
+		$scope_label = $inactive_with_att[0]['ParkName'];
+	} elseif (!empty($active_no_att)) {
+		$scope_label = $active_no_att[0]['ParkName'];
+	}
+	$scope_link = UIR . 'Park/profile/' . (int)($report_id ?? 0);
+	$scope_icon = 'fa-tree';
+} elseif (($report_type ?? null) === 'Kingdom') {
+	if (!empty($inactive_with_att)) {
+		$scope_label = $inactive_with_att[0]['KingdomName'];
+	} elseif (!empty($active_no_att)) {
+		$scope_label = $active_no_att[0]['KingdomName'];
+	}
+	$scope_link = UIR . 'Kingdom/profile/' . (int)($report_id ?? 0);
+	$scope_icon = 'fa-chess-rook';
+}
+?>
+
+<link rel="stylesheet" href="https://cdn.datatables.net/1.13.8/css/jquery.dataTables.min.css">
+<link rel="stylesheet" href="https://cdn.datatables.net/buttons/2.4.2/css/buttons.dataTables.min.css">
+<link rel="stylesheet" href="<?=HTTP_TEMPLATE?>default/style/reports.css">
+
+<style>
+.psr-section { margin-bottom: 32px; }
+.psr-section-header {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	padding: 12px 16px;
+	border-radius: 6px;
+	margin-bottom: 12px;
+}
+.psr-section-header h3 {
+	margin: 0; font-size: 15px; font-weight: 600;
+	background: transparent; border: none; padding: 0; border-radius: 0; text-shadow: none;
+}
+.psr-section-header .psr-count {
+	font-size: 13px; font-weight: 500; opacity: 0.85;
+}
+.psr-reactivate-header { background: #ebf8ff; color: #2b6cb0; border: 1px solid #bee3f8; }
+.psr-deactivate-header { background: #fff5f5; color: #c53030; border: 1px solid #fed7d7; }
+
+.psr-bulk-bar {
+	display: flex; align-items: center; gap: 12px;
+	padding: 8px 12px; background: #f7fafc; border: 1px solid #e2e8f0;
+	border-radius: 5px; margin-bottom: 10px; font-size: 13px;
+}
+.psr-bulk-bar button {
+	border: none; border-radius: 4px; padding: 5px 14px;
+	font-size: 13px; font-weight: 500; cursor: pointer; color: #fff;
+	transition: opacity 0.15s;
+}
+.psr-bulk-bar button:disabled { opacity: 0.4; cursor: default; }
+.psr-bulk-bar button:not(:disabled):hover { opacity: 0.85; }
+.psr-btn-reactivate { background: #2b6cb0; }
+.psr-btn-deactivate { background: #c53030; }
+.psr-bulk-bar .psr-selected-count { color: #4a5568; min-width: 90px; }
+.psr-bulk-bar .psr-select-all-label { color: #4a5568; cursor: pointer; user-select: none; }
+.psr-bulk-bar .psr-select-all-label input { margin-right: 4px; vertical-align: middle; }
+
+.psr-action-btn {
+	border: none; border-radius: 4px; padding: 4px 12px;
+	font-size: 12px; font-weight: 500; cursor: pointer; color: #fff;
+	transition: opacity 0.15s;
+}
+.psr-action-btn:hover { opacity: 0.85; }
+.psr-action-btn:disabled { opacity: 0.4; cursor: default; }
+.psr-action-btn.psr-btn-reactivate { background: #2b6cb0; }
+.psr-action-btn.psr-btn-deactivate { background: #c53030; }
+
+.psr-done-icon { color: #38a169; font-weight: 600; font-size: 13px; }
+.psr-error-msg { color: #c53030; font-size: 12px; }
+
+.psr-empty { text-align: center; padding: 24px; color: #a0aec0; font-style: italic; }
+
+table.psr-table td input[type="checkbox"] { margin: 0; vertical-align: middle; }
+</style>
+
+<div class="rp-root">
+
+	<div class="rp-header">
+		<div class="rp-header-left">
+			<div class="rp-header-icon-title">
+				<i class="fas fa-user-check rp-header-icon"></i>
+				<h1 class="rp-header-title">Player Status Reconciliation</h1>
+			</div>
+<?php if ($scope_label) : ?>
+			<div class="rp-header-scope">
+				<a class="rp-scope-chip" href="<?=$scope_link?>">
+					<i class="fas <?=$scope_icon?>"></i>
+					<?=htmlspecialchars($scope_label)?>
+				</a>
+			</div>
+<?php endif; ?>
+		</div>
+	</div>
+
+	<div class="rp-context">
+		<i class="fas fa-info-circle rp-context-icon"></i>
+		<span>
+			This report identifies players whose active/inactive status may not match their attendance history.
+			<strong>Inactive with recent attendance</strong> are marked inactive but have signed in within the past 6 months.
+			<strong>Active with no recent attendance</strong> are marked active but have not signed in within the past 24 months.
+		</span>
+	</div>
+
+	<div class="rp-stats-row">
+		<div class="rp-stat-card">
+			<div class="rp-stat-icon"><i class="fas fa-user-plus" style="color:#2b6cb0"></i></div>
+			<div class="rp-stat-number"><?=$total_inactive?></div>
+			<div class="rp-stat-label">Need Reactivation</div>
+		</div>
+		<div class="rp-stat-card">
+			<div class="rp-stat-icon"><i class="fas fa-user-minus" style="color:#c53030"></i></div>
+			<div class="rp-stat-number"><?=$total_active?></div>
+			<div class="rp-stat-label">Need Deactivation</div>
+		</div>
+		<div class="rp-stat-card">
+			<div class="rp-stat-icon"><i class="fas fa-users"></i></div>
+			<div class="rp-stat-number"><?=$total_inactive + $total_active?></div>
+			<div class="rp-stat-label">Total Mismatches</div>
+		</div>
+	</div>
+
+	<div style="padding: 0 16px 24px;">
+
+		<!-- Section 1: Inactive players with recent attendance (should be reactivated) -->
+		<div class="psr-section" id="psr-section-reactivate">
+			<div class="psr-section-header psr-reactivate-header">
+				<h3><i class="fas fa-user-plus"></i> Inactive Players with Recent Attendance</h3>
+				<span class="psr-count"><?=$total_inactive?> player<?=$total_inactive !== 1 ? 's' : ''?></span>
+			</div>
+<?php if ($total_inactive === 0): ?>
+			<div class="psr-empty">No mismatches found — all inactive players have no recent attendance.</div>
+<?php else: ?>
+<?php if ($can_edit): ?>
+			<div class="psr-bulk-bar" id="psr-bulk-reactivate">
+				<label class="psr-select-all-label"><input type="checkbox" id="psr-select-all-reactivate" onchange="psrToggleAll('reactivate', this.checked)"> Select all</label>
+				<span class="psr-selected-count" id="psr-count-reactivate">0 selected</span>
+				<button class="psr-btn-reactivate" id="psr-bulk-btn-reactivate" disabled onclick="psrBulkAction('reactivate', 1)"><i class="fas fa-user-plus"></i> Reactivate Selected</button>
+			</div>
+<?php endif; ?>
+			<table class="display psr-table" id="psr-table-reactivate" style="width:100%">
+				<thead>
+					<tr>
+<?php if ($can_edit): ?>
+						<th style="width:32px" data-orderable="false"></th>
+<?php endif; ?>
+<?php if ($report_type !== 'Park'): ?>
+						<th>Park</th>
+<?php endif; ?>
+						<th>Persona</th>
+						<th>Last Sign-In</th>
+						<th>Sign-Ins (6 mo)</th>
+<?php if ($can_edit): ?>
+						<th style="width:100px" data-orderable="false">Action</th>
+<?php endif; ?>
+					</tr>
+				</thead>
+				<tbody>
+<?php foreach ($inactive_with_att as $row): ?>
+					<tr data-mundane-id="<?=(int)$row['MundaneId']?>">
+<?php if ($can_edit): ?>
+						<td><input type="checkbox" class="psr-cb-reactivate" value="<?=(int)$row['MundaneId']?>" onchange="psrUpdateCount('reactivate')"></td>
+<?php endif; ?>
+<?php if ($report_type !== 'Park'): ?>
+						<td><a href="<?=UIR?>Park/profile/<?=(int)$row['ParkId']?>"><?=htmlspecialchars($row['ParkName'])?></a></td>
+<?php endif; ?>
+						<td><a href="<?=UIR?>Player/profile/<?=(int)$row['MundaneId']?>"><?=htmlspecialchars($row['Persona'])?></a></td>
+						<td><?=htmlspecialchars($row['LastSignIn'])?></td>
+						<td class="dt-right"><?=(int)$row['SignInCount']?></td>
+<?php if ($can_edit): ?>
+						<td class="psr-action-cell">
+							<button class="psr-action-btn psr-btn-reactivate" onclick="psrSingleAction(this, <?=(int)$row['MundaneId']?>, 1)"><i class="fas fa-user-plus"></i> Reactivate</button>
+						</td>
+<?php endif; ?>
+					</tr>
+<?php endforeach; ?>
+				</tbody>
+			</table>
+<?php endif; ?>
+		</div>
+
+		<!-- Section 2: Active players with no recent attendance (should be deactivated) -->
+		<div class="psr-section" id="psr-section-deactivate">
+			<div class="psr-section-header psr-deactivate-header">
+				<h3><i class="fas fa-user-minus"></i> Active Players with No Recent Attendance</h3>
+				<span class="psr-count"><?=$total_active?> player<?=$total_active !== 1 ? 's' : ''?></span>
+			</div>
+<?php if ($total_active === 0): ?>
+			<div class="psr-empty">No mismatches found — all active players have recent attendance.</div>
+<?php else: ?>
+<?php if ($can_edit): ?>
+			<div class="psr-bulk-bar" id="psr-bulk-deactivate">
+				<label class="psr-select-all-label"><input type="checkbox" id="psr-select-all-deactivate" onchange="psrToggleAll('deactivate', this.checked)"> Select all</label>
+				<span class="psr-selected-count" id="psr-count-deactivate">0 selected</span>
+				<button class="psr-btn-deactivate" id="psr-bulk-btn-deactivate" disabled onclick="psrBulkAction('deactivate', 0)"><i class="fas fa-user-minus"></i> Deactivate Selected</button>
+			</div>
+<?php endif; ?>
+			<table class="display psr-table" id="psr-table-deactivate" style="width:100%">
+				<thead>
+					<tr>
+<?php if ($can_edit): ?>
+						<th style="width:32px" data-orderable="false"></th>
+<?php endif; ?>
+<?php if ($report_type !== 'Park'): ?>
+						<th>Park</th>
+<?php endif; ?>
+						<th>Persona</th>
+						<th>Created On</th>
+						<th>Last Sign-In</th>
+<?php if ($can_edit): ?>
+						<th style="width:100px" data-orderable="false">Action</th>
+<?php endif; ?>
+					</tr>
+				</thead>
+				<tbody>
+<?php foreach ($active_no_att as $row): ?>
+					<tr data-mundane-id="<?=(int)$row['MundaneId']?>">
+<?php if ($can_edit): ?>
+						<td><input type="checkbox" class="psr-cb-deactivate" value="<?=(int)$row['MundaneId']?>" onchange="psrUpdateCount('deactivate')"></td>
+<?php endif; ?>
+<?php if ($report_type !== 'Park'): ?>
+						<td><a href="<?=UIR?>Park/profile/<?=(int)$row['ParkId']?>"><?=htmlspecialchars($row['ParkName'])?></a></td>
+<?php endif; ?>
+						<td><a href="<?=UIR?>Player/profile/<?=(int)$row['MundaneId']?>"><?=htmlspecialchars($row['Persona'])?></a></td>
+						<td><?=$row['ParkMemberSince'] ? htmlspecialchars($row['ParkMemberSince']) : '<em style="color:#a0aec0">Unknown</em>'?></td>
+						<td><?=$row['LastSignIn'] ? htmlspecialchars($row['LastSignIn']) : '<em style="color:#a0aec0">Never</em>'?></td>
+<?php if ($can_edit): ?>
+						<td class="psr-action-cell">
+							<button class="psr-action-btn psr-btn-deactivate" onclick="psrSingleAction(this, <?=(int)$row['MundaneId']?>, 0)"><i class="fas fa-user-minus"></i> Deactivate</button>
+						</td>
+<?php endif; ?>
+					</tr>
+<?php endforeach; ?>
+				</tbody>
+			</table>
+<?php endif; ?>
+		</div>
+
+	</div>
+
+</div>
+
+<script src="https://cdn.datatables.net/1.13.8/js/jquery.dataTables.min.js"></script>
+<script>
+$(function() {
+<?php
+	$react_col_start = ($can_edit ? 1 : 0) + ($report_type !== 'Park' ? 1 : 0);
+	$deact_col_start = $react_col_start;
+?>
+	if ($('#psr-table-reactivate').length) {
+		$('#psr-table-reactivate').DataTable({
+			dom: 'lfrtip',
+			pageLength: 25,
+			order: [[<?=$react_col_start?>, 'asc']],
+			columnDefs: [<?php if ($can_edit): ?>{ targets: [0], orderable: false },<?php endif; ?>]
+		});
+	}
+	if ($('#psr-table-deactivate').length) {
+		$('#psr-table-deactivate').DataTable({
+			dom: 'lfrtip',
+			pageLength: 25,
+			order: [[<?=$deact_col_start?>, 'asc']],
+			columnDefs: [<?php if ($can_edit): ?>{ targets: [0], orderable: false },<?php endif; ?>]
+		});
+	}
+});
+
+var PSR_AJAX_URL = '<?=UIR?>Reports/set_player_active_json';
+
+function psrUpdateCount(group) {
+	var checked = document.querySelectorAll('.psr-cb-' + group + ':checked');
+	var label = document.getElementById('psr-count-' + group);
+	var btn = document.getElementById('psr-bulk-btn-' + group);
+	if (label) label.textContent = checked.length + ' selected';
+	if (btn) btn.disabled = checked.length === 0;
+}
+
+function psrToggleAll(group, checked) {
+	var boxes = document.querySelectorAll('.psr-cb-' + group);
+	boxes.forEach(function(cb) {
+		if (!cb.closest('tr').classList.contains('psr-row-done')) {
+			cb.checked = checked;
+		}
+	});
+	psrUpdateCount(group);
+}
+
+function psrSingleAction(btn, mundaneId, active) {
+	btn.disabled = true;
+	btn.innerHTML = '<i class="fas fa-spinner fa-spin"></i>';
+	var form = new FormData();
+	form.append('MundaneId', mundaneId);
+	form.append('Active', active);
+	fetch(PSR_AJAX_URL, { method: 'POST', body: form })
+		.then(function(r) { return r.json(); })
+		.then(function(data) {
+			if (data.status === 0) {
+				var row = btn.closest('tr');
+				row.classList.add('psr-row-done');
+				var cell = btn.closest('td');
+				cell.innerHTML = '<span class="psr-done-icon"><i class="fas fa-check"></i> Done</span>';
+				var cb = row.querySelector('input[type="checkbox"]');
+				if (cb) { cb.checked = false; cb.disabled = true; }
+				var group = active === 1 ? 'reactivate' : 'deactivate';
+				psrUpdateCount(group);
+			} else {
+				btn.disabled = false;
+				btn.innerHTML = (active === 1 ? '<i class="fas fa-user-plus"></i> Reactivate' : '<i class="fas fa-user-minus"></i> Deactivate');
+				var cell = btn.closest('td');
+				var err = document.createElement('div');
+				err.className = 'psr-error-msg';
+				err.textContent = data.error || 'Failed';
+				cell.appendChild(err);
+				setTimeout(function() { if (err.parentNode) err.parentNode.removeChild(err); }, 5000);
+			}
+		})
+		.catch(function() {
+			btn.disabled = false;
+			btn.innerHTML = (active === 1 ? '<i class="fas fa-user-plus"></i> Retry' : '<i class="fas fa-user-minus"></i> Retry');
+		});
+}
+
+function psrBulkAction(group, active) {
+	var boxes = document.querySelectorAll('.psr-cb-' + group + ':checked');
+	if (boxes.length === 0) return;
+	var label = active === 1 ? 'reactivate' : 'deactivate';
+	if (!confirm('Are you sure you want to ' + label + ' ' + boxes.length + ' player' + (boxes.length > 1 ? 's' : '') + '?')) return;
+
+	var bulkBtn = document.getElementById('psr-bulk-btn-' + group);
+	if (bulkBtn) { bulkBtn.disabled = true; bulkBtn.innerHTML = '<i class="fas fa-spinner fa-spin"></i> Processing...'; }
+
+	var ids = [];
+	boxes.forEach(function(cb) { ids.push(parseInt(cb.value)); });
+
+	var completed = 0;
+	var errors = 0;
+
+	function processNext(i) {
+		if (i >= ids.length) {
+			if (bulkBtn) {
+				bulkBtn.innerHTML = (active === 1 ? '<i class="fas fa-user-plus"></i> Reactivate Selected' : '<i class="fas fa-user-minus"></i> Deactivate Selected');
+				bulkBtn.disabled = true;
+			}
+			psrUpdateCount(group);
+			return;
+		}
+		var form = new FormData();
+		form.append('MundaneId', ids[i]);
+		form.append('Active', active);
+		fetch(PSR_AJAX_URL, { method: 'POST', body: form })
+			.then(function(r) { return r.json(); })
+			.then(function(data) {
+				var row = document.querySelector('tr[data-mundane-id="' + ids[i] + '"]');
+				if (data.status === 0 && row) {
+					row.classList.add('psr-row-done');
+					var actionCell = row.querySelector('.psr-action-cell');
+					if (actionCell) actionCell.innerHTML = '<span class="psr-done-icon"><i class="fas fa-check"></i> Done</span>';
+					var cb = row.querySelector('input[type="checkbox"]');
+					if (cb) { cb.checked = false; cb.disabled = true; }
+					completed++;
+				} else {
+					errors++;
+					if (row) {
+						var actionCell = row.querySelector('.psr-action-cell');
+						if (actionCell) {
+							var errSpan = actionCell.querySelector('.psr-error-msg');
+							if (!errSpan) { errSpan = document.createElement('div'); errSpan.className = 'psr-error-msg'; actionCell.appendChild(errSpan); }
+							errSpan.textContent = data.error || 'Failed';
+						}
+					}
+				}
+				processNext(i + 1);
+			})
+			.catch(function() {
+				errors++;
+				processNext(i + 1);
+			});
+	}
+	processNext(0);
+}
+</script>

--- a/orkui/template/revised-frontend/Kingdomnew_index.tpl
+++ b/orkui/template/revised-frontend/Kingdomnew_index.tpl
@@ -611,6 +611,7 @@
 							<li><a href="<?= UIR ?>Reports/active_waivered_duespaid/Kingdom&id=<?= $kingdom_id ?>">Waivered Attendance</a></li>
 							<li><a href="<?= UIR ?>Reports/reeve/Kingdom&id=<?= $kingdom_id ?>">Reeve Qualified</a></li>
 							<li><a href="<?= UIR ?>Reports/corpora/Kingdom&id=<?= $kingdom_id ?>">Corpora Qualified</a></li>
+							<li><a href="<?= UIR ?>Reports/player_status_reconciliation/Kingdom&id=<?= $kingdom_id ?>">Player Status Reconciliation</a></li>
 							<?php endif; ?>
 							<li><a href="<?= UIR ?>Reports/kingdom_officer_directory&KingdomId=<?= $kingdom_id ?>"><i class="fas fa-crown"></i> Park Officer Directory</a></li>
 						</ul>
@@ -887,6 +888,7 @@ var KnConfig = {
 	adminConfig:     <?= json_encode($AdminConfig     ?? [], JSON_HEX_TAG | JSON_HEX_AMP) ?>,
 	adminParkTitles: <?= json_encode($AdminParkTitles ?? [], JSON_HEX_TAG | JSON_HEX_AMP) ?>,
 	adminAwards:     <?= json_encode($AdminAwards     ?? [], JSON_HEX_TAG | JSON_HEX_AMP) ?>,
+	systemAwards:    <?= json_encode($SystemAwards    ?? [], JSON_HEX_TAG | JSON_HEX_AMP) ?>,
 	adminRecsPublic: <?= !empty($AwardRecsPublic) ? 'true' : 'false' ?>,
 };
 </script>
@@ -1027,6 +1029,7 @@ var KnConfig = {
 					<option value="">Select award...</option>
 					<?= $AwardOptions ?>
 				</select>
+				<div id="kn-rec-award-desc" class="pn-rec-award-desc" style="display:none"></div>
 			</div>
 			<div class="pk-acct-field" id="kn-rec-rank-row" style="display:none">
 				<label>Rank <span style="color:#a0aec0;font-weight:400;font-size:11px">(optional)</span></label>
@@ -1346,7 +1349,7 @@ var KnConfig = {
 						<thead>
 							<tr>
 								<th>Title</th>
-								<th>Class</th>
+								<th><span class="kn-admin-th-tip" title="Title Class determines rank precedence. Higher values = higher rank (e.g. 20=Knight, 30=Lord, 50=Baron, 90=Duke).">Class <i class="fas fa-question-circle" style="font-size:9px;color:#a0aec0;cursor:help"></i></span></th>
 								<th>Min Att.</th>
 								<th>Cutoff</th>
 								<th>Period</th>
@@ -1388,7 +1391,7 @@ var KnConfig = {
 				</button>
 				<div class="kn-admin-panel-body" id="kn-admin-body-awards" style="display:none">
 					<div id="kn-admin-awards-feedback" class="kn-admin-feedback" style="display:none"></div>
-					<table class="kn-admin-table kn-admin-awards-table">
+					<div class="kn-admin-table-wrap"><table class="kn-admin-table kn-admin-awards-table">
 						<thead>
 							<tr>
 								<th>Award Name</th>
@@ -1402,16 +1405,27 @@ var KnConfig = {
 						<tbody id="kn-admin-awards-tbody">
 							<!-- Built by JS -->
 						</tbody>
-					</table>
+					</table></div>
 					<div class="kn-admin-add-award-wrap" id="kn-admin-add-award-wrap" style="display:none">
-						<div class="kn-admin-add-award-title">New Award</div>
+						<div class="kn-admin-add-award-title">Add Award Alias</div>
+						<p class="kn-admin-form-hint">An award alias lets you create additional variations on existing system awards and titles. For example, the default system title of “Man-at-Arms” would have variations such as “Woman-at-Arms” or “Person-at-Arms.” You can add as many aliases as you would like.</p>
 						<div class="kn-admin-field">
-							<label>Canonical Award ID <span class="kn-admin-hint-inline">(from ork_award table)</span></label>
-							<input type="number" id="kn-admin-new-award-id" min="1" placeholder="e.g. 7">
+							<label>System Award</label>
+							<div class="kn-admin-alias-picker-wrap" style="position:relative">
+								<input type="hidden" id="kn-admin-new-award-id">
+								<button type="button" class="kn-admin-alias-trigger" id="kn-admin-alias-trigger">
+									<span class="kn-admin-alias-label">Select a system award&hellip;</span>
+									<i class="fas fa-chevron-down" style="font-size:11px;opacity:.5"></i>
+								</button>
+								<div class="kn-admin-alias-dropdown" id="kn-admin-alias-dropdown" style="display:none">
+									<input type="text" class="kn-admin-alias-search" id="kn-admin-alias-search" placeholder="Search awards&hellip;" autocomplete="off">
+									<div class="kn-admin-alias-list" id="kn-admin-alias-list"></div>
+								</div>
+							</div>
 						</div>
 						<div class="kn-admin-award-row-fields">
 							<div class="kn-admin-field kn-admin-field-grow">
-								<label>Award Name</label>
+								<label>Kingdom Name <span class="kn-admin-hint-inline">(your kingdom&rsquo;s name for this award)</span></label>
 								<input type="text" id="kn-admin-new-award-name" placeholder="e.g. Order of the Warrior">
 							</div>
 							<div class="kn-admin-field">
@@ -1427,20 +1441,57 @@ var KnConfig = {
 								<input type="checkbox" id="kn-admin-new-istitle">
 							</div>
 							<div class="kn-admin-field">
-								<label>Title Class</label>
+								<label>Title Class <i class="fas fa-question-circle" title="Title Class determines rank precedence. Higher values = higher rank (e.g. 20=Knight, 30=Lord, 50=Baron, 90=Duke)." style="font-size:10px;color:#a0aec0;cursor:help"></i></label>
 								<input type="number" id="kn-admin-new-tclass" min="0" value="0" style="width:64px" disabled>
 							</div>
 						</div>
 						<div style="display:flex;gap:8px;margin-top:10px">
 							<button class="kn-admin-save-btn" id="kn-admin-new-award-save">
-								<i class="fas fa-plus"></i> Add Award
+								<i class="fas fa-plus"></i> Add Award Alias
 							</button>
 							<button class="kn-btn-ghost" id="kn-admin-new-award-cancel" style="font-size:13px">Cancel</button>
 						</div>
 					</div>
-					<button class="kn-admin-add-btn" id="kn-admin-awards-add-btn">
-						<i class="fas fa-plus"></i> Add Award
-					</button>
+					<div class="kn-admin-add-award-wrap" id="kn-admin-add-custom-wrap" style="display:none">
+						<div class="kn-admin-add-award-title">Add Kingdom-Specific Award</div>
+						<p class="kn-admin-form-hint">A kingdom-specific award allows you to add awards only given out in your kingdom. For example, if your kingdom awards a custom award called “Order of the Key,” you can add it here so it can be marked in award records.</p>
+						<div class="kn-admin-award-row-fields">
+							<div class="kn-admin-field kn-admin-field-grow">
+								<label>Award Name</label>
+								<input type="text" id="kn-admin-custom-name" placeholder="e.g. Kingdom Spotlight">
+							</div>
+							<div class="kn-admin-field">
+								<label>Reign Limit</label>
+								<input type="number" id="kn-admin-custom-reign" min="0" value="0" style="width:64px">
+							</div>
+							<div class="kn-admin-field">
+								<label>Month Limit</label>
+								<input type="number" id="kn-admin-custom-month" min="0" value="0" style="width:64px">
+							</div>
+							<div class="kn-admin-field kn-admin-field-center">
+								<label>Title?</label>
+								<input type="checkbox" id="kn-admin-custom-istitle">
+							</div>
+							<div class="kn-admin-field">
+								<label>Title Class <i class="fas fa-question-circle" title="Title Class determines rank precedence. Higher values = higher rank (e.g. 20=Knight, 30=Lord, 50=Baron, 90=Duke)." style="font-size:10px;color:#a0aec0;cursor:help"></i></label>
+								<input type="number" id="kn-admin-custom-tclass" min="0" value="0" style="width:64px" disabled>
+							</div>
+						</div>
+						<div style="display:flex;gap:8px;margin-top:10px">
+							<button class="kn-admin-save-btn" id="kn-admin-custom-save">
+								<i class="fas fa-plus"></i> Add Award
+							</button>
+							<button class="kn-btn-ghost" id="kn-admin-custom-cancel" style="font-size:13px">Cancel</button>
+						</div>
+					</div>
+					<div class="kn-admin-award-add-btns">
+						<button class="kn-admin-add-btn" id="kn-admin-awards-add-btn">
+							<i class="fas fa-plus"></i> Add Award Alias
+						</button>
+						<button class="kn-admin-add-btn" id="kn-admin-custom-add-btn">
+							<i class="fas fa-plus"></i> Add Kingdom-Specific Award
+						</button>
+					</div>
 				</div>
 			</div>
 
@@ -1466,8 +1517,7 @@ var KnConfig = {
 							<tbody id="kn-admin-parks-tbody">
 								<!-- Built by JS -->
 							</tbody>
-						</table>
-					</div>
+						</table></div>
 					<button class="kn-admin-save-btn" id="kn-admin-parks-save">
 						<i class="fas fa-save"></i> Save Parks
 					</button>

--- a/orkui/template/revised-frontend/Kingdomnew_index.tpl
+++ b/orkui/template/revised-frontend/Kingdomnew_index.tpl
@@ -699,7 +699,6 @@
 				<div class="kn-report-group">
 					<h5><i class="fas fa-cog"></i> Kingdom</h5>
 					<ul>
-						<li><a href="<?= UIR ?>Admin/kingdom/<?= $kingdom_id ?>">Admin Panel</a></li>
 						<li><a href="<?= UIR ?>Admin/permissions/Kingdom/<?= $kingdom_id ?>">Roles &amp; Permissions</a></li>
 						<li><a href="#" onclick="knOpenClaimParkModal();return false;">Claim Park</a></li>
 					</ul>

--- a/orkui/template/revised-frontend/Parknew_index.tpl
+++ b/orkui/template/revised-frontend/Parknew_index.tpl
@@ -979,6 +979,7 @@
 							<li><a href="<?= UIR ?>Reports/active_waivered_duespaid/Park&id=<?= $park_id ?>">Waivered Attendance</a></li>
 							<li><a href="<?= UIR ?>Reports/reeve&KingdomId=<?= $kingdom_id ?>&ParkId=<?= $park_id ?>">Reeve Qualified</a></li>
 							<li><a href="<?= UIR ?>Reports/corpora&KingdomId=<?= $kingdom_id ?>&ParkId=<?= $park_id ?>">Corpora Qualified</a></li>
+							<li><a href="<?= UIR ?>Reports/player_status_reconciliation/Park&id=<?= $park_id ?>">Player Status Reconciliation</a></li>
 							<li><a href="<?= UIR ?>Reports/closest_parks&ParkId=<?= $park_id ?>"><i class="fas fa-map-marker-alt"></i> Closest Parks</a></li>
 							<?php endif; ?>
 						</ul>
@@ -1427,6 +1428,7 @@ var PkConfig = {
 					<option value="">Select award...</option>
 					<?= $AwardOptions ?>
 				</select>
+				<div id="pk-rec-award-desc" class="pn-rec-award-desc" style="display:none"></div>
 			</div>
 			<div class="pk-acct-field" id="pk-rec-rank-row" style="display:none">
 				<label>Rank <span style="color:#a0aec0;font-weight:400;font-size:11px">(optional)</span></label>

--- a/orkui/template/revised-frontend/Playernew_index.tpl
+++ b/orkui/template/revised-frontend/Playernew_index.tpl
@@ -983,9 +983,23 @@
 				<?php if (count($filteredAwards) === 0): ?>
 					<div class="pn-empty">No awards recorded</div>
 				<?php else: ?>
-				<div class="pn-award-search-bar">
-					<i class="fas fa-search pn-award-search-icon"></i>
-					<input type="text" id="pn-award-search" placeholder="Search awards…" class="pn-award-search-input" autocomplete="off" oninput="pnAwardSearch(this.value)" />
+				<div class="pn-table-toolbar">
+					<?php if (count($filteredAwards) > 10): ?>
+					<div class="pn-pagesize-bar" style="margin-bottom:0">
+						<label for="pn-awards-pagesize">Show</label>
+						<select id="pn-awards-pagesize" class="pn-pagesize-select" onchange="pnSetPageSize('pn-awards-table', this.value)">
+							<option value="10">10</option>
+							<option value="25">25</option>
+							<option value="50">50</option>
+							<option value="100">100</option>
+						</select>
+						<span>per page</span>
+					</div>
+					<?php endif; ?>
+					<div class="pn-award-search-bar" style="margin-bottom:0">
+						<i class="fas fa-search pn-award-search-icon"></i>
+						<input type="text" id="pn-award-search" placeholder="Search awards…" class="pn-award-search-input" autocomplete="off" oninput="pnAwardSearch(this.value)" />
+					</div>
 				</div>
 				<table class="pn-table pn-sortable" id="pn-awards-table">
 					<thead>
@@ -1101,6 +1115,18 @@
 					}
 				?>
 				<?php if (count($filteredTitles) > 0): ?>
+					<?php if (count($filteredTitles) > 10): ?>
+					<div class="pn-pagesize-bar">
+						<label for="pn-titles-pagesize">Show</label>
+						<select id="pn-titles-pagesize" class="pn-pagesize-select" onchange="pnSetPageSize('pn-titles-table', this.value)">
+							<option value="10">10</option>
+							<option value="25">25</option>
+							<option value="50">50</option>
+							<option value="100">100</option>
+						</select>
+						<span>per page</span>
+					</div>
+					<?php endif; ?>
 					<table class="pn-table pn-sortable" id="pn-titles-table">
 						<thead>
 							<tr>
@@ -2161,8 +2187,8 @@ if (typeof nsKid !== 'undefined' && nsKid === 0 && PnConfig.kingdomId) nsKid = P
 </script>
 <script src="<?= HTTP_TEMPLATE ?>revised-frontend/script/revised.js?v=<?= filemtime(__DIR__ . '/script/revised.js') ?>"></script>
 <script>
-pnSortDesc($('#pn-awards-table'), 2, 'date');     pnPaginate($('#pn-awards-table'), 1);
-pnSortDesc($('#pn-titles-table'), 2, 'date');     pnPaginate($('#pn-titles-table'), 1);
+pnSortDesc($('#pn-awards-table'), 2, 'date', 1, 'numeric');     pnPaginate($('#pn-awards-table'), 1);
+pnSortDesc($('#pn-titles-table'), 2, 'date', 1, 'numeric');     pnPaginate($('#pn-titles-table'), 1);
 pnSortDesc($('#pn-attendance-table'), 0, 'date'); pnPaginate($('#pn-attendance-table'), 1);
 pnSortDesc($('#pn-history-table'), 2, 'date');    pnPaginate($('#pn-history-table'), 1);
 // 26-week sparkline

--- a/orkui/template/revised-frontend/Playernew_index.tpl
+++ b/orkui/template/revised-frontend/Playernew_index.tpl
@@ -992,6 +992,7 @@
 							<option value="25">25</option>
 							<option value="50">50</option>
 							<option value="100">100</option>
+							<option value="all">All</option>
 						</select>
 						<span>per page</span>
 					</div>

--- a/orkui/template/revised-frontend/Playernew_index.tpl
+++ b/orkui/template/revised-frontend/Playernew_index.tpl
@@ -2093,6 +2093,7 @@
 						<option value="">Select award...</option>
 						<?= $AwardOptions ?>
 					</select>
+					<div id="pn-rec-award-desc" class="pn-rec-award-desc" style="display:none"></div>
 				</div>
 				<div class="pn-rec-field" id="pn-rec-rank-row" style="display:none">
 					<label>Rank <span style="color:#a0aec0;font-weight:400;font-size:11px">— click to select; light blue = already held, green border = suggested; dark blue = selected</span></label>

--- a/orkui/template/revised-frontend/Playernew_reconcile.tpl
+++ b/orkui/template/revised-frontend/Playernew_reconcile.tpl
@@ -397,6 +397,7 @@ var RcConfig = {
 					gbDrop.innerHTML = items.map(function(p) {
 						return '<div class="rc-ac-item" data-id="' + p.id + '" data-name="' + escH(p.name) + '">'
 							+ escH(p.name)
+							+ (p.active === 0 ? ' <span style="color:#c53030;font-size:10px;font-weight:600">(Inactive)</span>' : '')
 							+ (p.park ? '<div class="rc-ac-item-sub">' + escH(p.park) + '</div>' : '')
 							+ '</div>';
 					}).join('');

--- a/orkui/template/revised-frontend/script/revised.js
+++ b/orkui/template/revised-frontend/script/revised.js
@@ -203,7 +203,7 @@ function pnPaginate($table, page) {
     $pg.html(html);
 }
 
-function pnSortDesc($table, colIndex, sortType) {
+function pnSortDesc($table, colIndex, sortType, secondaryColIndex, secondarySortType) {
     if (!$table.length) return;
     $table.find('thead th').removeClass('sort-asc sort-desc');
     $table.find('thead th').eq(colIndex).addClass('sort-desc');
@@ -219,6 +219,18 @@ function pnSortDesc($table, colIndex, sortType) {
             cmp = (new Date(aVal).getTime() || 0) - (new Date(bVal).getTime() || 0);
         } else {
             cmp = aVal.localeCompare(bVal);
+        }
+        if (cmp === 0 && secondaryColIndex != null) {
+            var aVal2 = $(a).find('td').eq(secondaryColIndex).text().trim();
+            var bVal2 = $(b).find('td').eq(secondaryColIndex).text().trim();
+            var st = secondarySortType || 'text';
+            if (st === 'numeric') {
+                cmp = (parseFloat(aVal2) || 0) - (parseFloat(bVal2) || 0);
+            } else if (st === 'date') {
+                cmp = (new Date(aVal2).getTime() || 0) - (new Date(bVal2).getTime() || 0);
+            } else {
+                cmp = aVal2.localeCompare(bVal2);
+            }
         }
         return -cmp;
     });

--- a/orkui/template/revised-frontend/script/revised.js
+++ b/orkui/template/revised-frontend/script/revised.js
@@ -17,6 +17,27 @@ var AUTOCOMPLETE_DEBOUNCE_MS = 250;
 var AWARD_NOTE_MAX_CHARS     = 400;
 
 /* ===========================
+   Award descriptions (keyed by base AwardId)
+   =========================== */
+var AWARD_DESCRIPTIONS = {
+    21: 'Awarded for service to the club not necessarily related to an elected office.',
+    22: 'Awarded for organizing and running battlegames, quests, workshops, and demonstrations.',
+    23: 'Awarded for going above and beyond the call of duty in executing an office, or for leadership outside of office.',
+    239: 'Awarded for serving with excellence in office from the local level to the kingdom level.',
+    24: 'Awarded for demonstrating ability in the construction sciences: weapons, armor, furniture, shoes, belts, etc.',
+    25: 'Awarded for demonstrating ability in the arts: performance, painting, sculpting, photography, cooking, writing, etc.',
+    26: 'Awarded for the creation of garb: tabards, pants, cloaks, gloves, sashes, pouches, etc.',
+    27: 'Awarded for fighting prowess in tournament and battlefield combat.',
+    243: 'Awarded for understanding of tactics and effectiveness as a player in class battlegaming.',
+    28: 'Awarded for positive attitude and sportsmanship.',
+    29: 'Awarded for excellence in roleplaying.',
+    32: 'Awarded for participation in qualification events.',
+    30: 'Awarded for exceptional service in a calendar month.',
+    33: 'Awarded for demonstrating positive character traits that reflect well on the club.',
+    34: 'Awarded for service as a group (a park, company, household, event team, etc.).'
+};
+
+/* ===========================
    Autocomplete keyboard nav
    =========================== */
 /**
@@ -61,6 +82,208 @@ function acKeyNav(inputEl, resultsEl, openClass, itemSel) {
         }
     });
 }
+
+/* ===========================
+   Searchable Award Dropdown
+   =========================== */
+(function() {
+    var dropdown, searchInput, body, activeSelect, activeTrigger;
+
+    function ensureDOM() {
+        if (dropdown) return;
+        dropdown = document.createElement('div');
+        dropdown.className = 'aw-dropdown';
+        dropdown.innerHTML =
+            '<div class="aw-dropdown-search-wrap"><i class="fas fa-search"></i>' +
+                '<input type="text" class="aw-dropdown-search" placeholder="Type to filter\u2026"></div>' +
+            '<div class="aw-dropdown-body"></div>';
+        document.body.appendChild(dropdown);
+        searchInput = dropdown.querySelector('.aw-dropdown-search');
+        body = dropdown.querySelector('.aw-dropdown-body');
+
+        // Close on outside click
+        document.addEventListener('mousedown', function(e) {
+            if (!dropdown.classList.contains('aw-open')) return;
+            if (dropdown.contains(e.target)) return;
+            if (activeTrigger && activeTrigger.contains(e.target)) return;
+            closeDropdown();
+        });
+        document.addEventListener('keydown', function(e) {
+            if (e.key === 'Escape' && dropdown.classList.contains('aw-open')) { e.stopPropagation(); closeDropdown(); }
+        });
+
+        searchInput.addEventListener('input', function() {
+            var term = this.value.toLowerCase();
+            var items = body.querySelectorAll('.aw-pick-item');
+            for (var i = 0; i < items.length; i++)
+                items[i].style.display = items[i].textContent.toLowerCase().indexOf(term) !== -1 ? '' : 'none';
+            var groups = body.querySelectorAll('.aw-pick-group');
+            for (var i = 0; i < groups.length; i++)
+                groups[i].style.display = groups[i].querySelector('.aw-pick-item:not([style*="display: none"])') ? '' : 'none';
+            var standalones = body.querySelectorAll('.aw-pick-standalone');
+            for (var i = 0; i < standalones.length; i++)
+                standalones[i].style.display = standalones[i].querySelector('.aw-pick-item:not([style*="display: none"])') ? '' : 'none';
+            var any = body.querySelector('.aw-pick-item:not([style*="display: none"])');
+            var empty = body.querySelector('.aw-pick-empty');
+            if (!any && !empty) {
+                var el = document.createElement('div'); el.className = 'aw-pick-empty';
+                el.textContent = 'No awards match'; body.appendChild(el);
+            } else if (any && empty) { empty.remove(); }
+        });
+
+        searchInput.addEventListener('keydown', function(e) {
+            if (e.key === 'ArrowDown') {
+                e.preventDefault();
+                var first = body.querySelector('.aw-pick-item:not([style*="display: none"])');
+                if (first) first.focus();
+            }
+        });
+
+        body.addEventListener('click', function(e) {
+            var item = e.target.closest('.aw-pick-item');
+            if (!item) return;
+            if (!activeSelect) return;
+            activeSelect.value = item.getAttribute('data-value');
+            activeSelect.dispatchEvent(new Event('change', { bubbles: true }));
+            syncTrigger(activeSelect);
+            closeDropdown();
+        });
+
+        body.addEventListener('keydown', function(e) {
+            var item = e.target.closest('.aw-pick-item');
+            if (!item) return;
+            if (e.key === 'Enter') { e.preventDefault(); item.click(); }
+            else if (e.key === 'ArrowDown') {
+                e.preventDefault();
+                var next = item.nextElementSibling;
+                while (next && (!next.classList.contains('aw-pick-item') || next.style.display === 'none')) next = next.nextElementSibling;
+                if (!next) { var ng = item.closest('.aw-pick-group, .aw-pick-standalone');
+                    if (ng) ng = ng.nextElementSibling;
+                    while (ng && !(next = ng.querySelector('.aw-pick-item:not([style*="display: none"])'))) ng = ng.nextElementSibling; }
+                if (next) next.focus();
+            } else if (e.key === 'ArrowUp') {
+                e.preventDefault();
+                var prev = item.previousElementSibling;
+                while (prev && (!prev.classList.contains('aw-pick-item') || prev.style.display === 'none')) prev = prev.previousElementSibling;
+                if (!prev) { var pg = item.closest('.aw-pick-group, .aw-pick-standalone');
+                    if (pg) pg = pg.previousElementSibling;
+                    while (pg && !(prev = pg.querySelector('.aw-pick-item:not([style*="display: none"]):last-child'))) pg = pg.previousElementSibling; }
+                if (prev) prev.focus(); else searchInput.focus();
+            }
+        });
+    }
+
+    function buildHTML(sel) {
+        var html = '', cur = sel.value, ch = sel.children;
+        for (var i = 0; i < ch.length; i++) {
+            if (ch[i].tagName === 'OPTGROUP') {
+                html += '<div class="aw-pick-group"><div class="aw-pick-group-label">' + escHtml(ch[i].label) + '</div>';
+                for (var j = 0; j < ch[i].children.length; j++) html += itemHTML(ch[i].children[j], cur);
+                html += '</div>';
+            } else if (ch[i].tagName === 'OPTION' && ch[i].value) {
+                html += '<div class="aw-pick-standalone">' + itemHTML(ch[i], cur) + '</div>';
+            }
+        }
+        return html;
+    }
+
+    function itemHTML(opt, cur) {
+        var aid = parseInt(opt.getAttribute('data-award-id')) || 0;
+        var isL = opt.getAttribute('data-is-ladder') === '1';
+        var desc = isL && typeof AWARD_DESCRIPTIONS !== 'undefined' ? (AWARD_DESCRIPTIONS[aid] || '') : '';
+        var cls = 'aw-pick-item' + (opt.value === cur && cur ? ' aw-active' : '');
+        var h = '<div class="' + cls + '" data-value="' + opt.value + '" tabindex="0">';
+        h += '<span class="aw-pick-name">' + escHtml(opt.textContent) + '</span>';
+        if (desc) h += '<span class="aw-pick-desc">' + escHtml(desc) + '</span>';
+        return h + '</div>';
+    }
+
+    function openDropdown(sel, trigger) {
+        ensureDOM();
+        if (activeSelect === sel && dropdown.classList.contains('aw-open')) { closeDropdown(); return; }
+        activeSelect = sel; activeTrigger = trigger;
+        body.innerHTML = buildHTML(sel);
+        var empty = body.querySelector('.aw-pick-empty'); if (empty) empty.remove();
+        searchInput.value = '';
+        var rect = trigger.getBoundingClientRect();
+        var vw = window.innerWidth, vh = window.innerHeight;
+        var mobile = vw <= 600;
+        if (mobile) {
+            dropdown.style.left = '8px';
+            dropdown.style.right = '8px';
+            dropdown.style.width = 'auto';
+            dropdown.style.bottom = '0';
+            dropdown.style.top = 'auto';
+            dropdown.style.maxHeight = '55vh';
+            dropdown.style.borderRadius = '10px 10px 0 0';
+        } else {
+            var w = Math.max(rect.width, 320);
+            var left = rect.left;
+            if (left + w > vw - 8) left = vw - w - 8;
+            if (left < 8) left = 8;
+            var spaceBelow = vh - rect.bottom - 8;
+            var spaceAbove = rect.top - 8;
+            var maxH = 360;
+            if (spaceBelow >= 200) {
+                dropdown.style.top = rect.bottom + 2 + 'px';
+                dropdown.style.bottom = 'auto';
+                maxH = Math.min(360, spaceBelow);
+            } else {
+                dropdown.style.bottom = (vh - rect.top + 2) + 'px';
+                dropdown.style.top = 'auto';
+                maxH = Math.min(360, spaceAbove);
+            }
+            dropdown.style.left = left + 'px';
+            dropdown.style.right = 'auto';
+            dropdown.style.width = w + 'px';
+            dropdown.style.maxHeight = maxH + 'px';
+            dropdown.style.borderRadius = '6px';
+        }
+        dropdown.classList.add('aw-open');
+        searchInput.focus();
+        var active = body.querySelector('.aw-active');
+        if (active) active.scrollIntoView({ block: 'center' });
+    }
+
+    function closeDropdown() {
+        if (!dropdown) return;
+        dropdown.classList.remove('aw-open');
+        if (activeTrigger) activeTrigger.focus();
+        activeSelect = null; activeTrigger = null;
+    }
+
+    function syncTrigger(sel) {
+        var btn = sel._awTrigger; if (!btn) return;
+        var opt = sel.options[sel.selectedIndex];
+        var hasVal = opt && opt.value;
+        btn.querySelector('.aw-trigger-label').textContent = hasVal ? opt.text : 'Select award\u2026';
+        btn.classList.toggle('aw-has-value', !!hasVal);
+    }
+
+    function initPicker(sel) {
+        sel.style.display = 'none';
+        var btn = document.createElement('button');
+        btn.type = 'button'; btn.className = 'aw-picker-trigger';
+        var opt = sel.options[sel.selectedIndex];
+        var hasVal = opt && opt.value;
+        btn.innerHTML = '<span class="aw-trigger-label">' + (hasVal ? escHtml(opt.text) : 'Select award\u2026') + '</span>' +
+            '<i class="fas fa-chevron-down" style="color:#a0aec0;font-size:11px"></i>';
+        if (hasVal) btn.classList.add('aw-has-value');
+        sel.parentNode.insertBefore(btn, sel.nextSibling);
+        sel._awTrigger = btn;
+        btn.addEventListener('click', function() { openDropdown(sel, btn); });
+
+        var desc = Object.getOwnPropertyDescriptor(HTMLSelectElement.prototype, 'value');
+        Object.defineProperty(sel, 'value', {
+            get: function() { return desc.get.call(this); },
+            set: function(v) { desc.set.call(this, v); syncTrigger(this); }
+        });
+        new MutationObserver(function() { syncTrigger(sel); }).observe(sel, { childList: true, subtree: true });
+    }
+
+    window.awInitPicker = initPicker;
+    window.awSyncTrigger = syncTrigger;
+})();
 
 /* ===========================
    Player Profile (PnConfig)
@@ -431,8 +654,13 @@ if (PnConfig.recError) {
         p.classList.add('pn-rank-selected');
         input.value = p.dataset.rank;
     });
+    if (gid('pn-rec-award')) awInitPicker(gid('pn-rec-award'));
     $('#pn-rec-award').on('change', function() {
         buildRecRankPills($(this).val());
+        var aid = parseInt($(this).find(':selected').data('award-id') || 0);
+        var desc = AWARD_DESCRIPTIONS[aid] || '';
+        var el = document.getElementById('pn-rec-award-desc');
+        if (el) { el.textContent = desc; el.style.display = desc ? '' : 'none'; }
     });
 
     // ---- Rec dismiss button (player page) ----
@@ -1208,6 +1436,9 @@ if (PnConfig.recError) {
         gid('pn-award-type-awards').addEventListener('click',   function() { setAwardType('awards'); });
         gid('pn-award-type-officers').addEventListener('click', function() { setAwardType('officers'); });
 
+        // ---- Award Picker init ----
+        if (gid('pn-award-select')) awInitPicker(gid('pn-award-select'));
+
         // ---- Award Select Change ----
         var pnNoBadgeAwards = ['griffon', 'griffin', 'hydra', 'jovious', 'jovius', 'mask', 'zodiac', 'walker'];
         gid('pn-award-select').addEventListener('change', function() {
@@ -1287,7 +1518,7 @@ if (PnConfig.recError) {
             var term = this.value.trim();
             if (term.length < 2) { gid('pn-award-givenby-results').classList.remove('pn-ac-open'); return; }
             givenByTimer = setTimeout(function() {
-                var url = SEARCH_URL + '?Action=Search%2FPlayer&type=all&search=' + encodeURIComponent(term) + '&kingdom_id=' + KINGDOM_ID + '&limit=6';
+                var url = PnConfig.uir + 'KingdomAjax/playersearch/' + KINGDOM_ID + '&scope=all&include_inactive=1&q=' + encodeURIComponent(term);
                 fetch(url).then(function(r) { return r.json(); }).then(function(data) {
                     var results = gid('pn-award-givenby-results');
                     if (!data || !data.length) {
@@ -1297,6 +1528,7 @@ if (PnConfig.recError) {
                             return '<div class="pn-ac-item" tabindex="-1" data-id="' + p.MundaneId + '" data-name="' + encodeURIComponent(p.Persona) + '">'
                                 + escHtml(p.Persona)
                                 + ' <span style="color:#a0aec0;font-size:11px">(' + escHtml(p.KAbbr || '') + ':' + escHtml(p.PAbbr || '') + ')</span>'
+                                + (p.Active === 0 ? ' <span style="color:#c53030;font-size:10px;font-weight:600">(Inactive)</span>' : '')
                                 + '</div>';
                         }).join('');
                     }
@@ -2238,6 +2470,7 @@ $(document).ready(function() {
         if (suggestedPill) { suggestedPill.classList.add('kn-rank-selected'); input.value = suggested; }
     }
 
+    if (gid('kn-award-select')) awInitPicker(gid('kn-award-select'));
     gid('kn-award-select').addEventListener('change', function() {
         var awardId = this.value;
         var isCustom = this.options[this.selectedIndex] && this.options[this.selectedIndex].text.toLowerCase().indexOf('custom') >= 0;
@@ -2261,13 +2494,14 @@ $(document).ready(function() {
         if (term.length < 2) { gid('kn-award-player-results').classList.remove('kn-ac-open'); return; }
         clearTimeout(playerTimer);
         playerTimer = setTimeout(function() {
-            var url = UIR_JS + 'KingdomAjax/playersearch/' + KINGDOM_ID + '&q=' + encodeURIComponent(term);
+            var url = UIR_JS + 'KingdomAjax/playersearch/' + KINGDOM_ID + '&include_inactive=1&q=' + encodeURIComponent(term);
             fetch(url).then(function(r) { return r.json(); }).then(function(data) {
                 var el = gid('kn-award-player-results');
                 el.innerHTML = (data && data.length)
                     ? data.map(function(p) {
                         return '<div class="kn-ac-item" tabindex="-1" data-id="' + p.MundaneId + '" data-name="' + encodeURIComponent(p.Persona) + '">'
-                            + escHtml(p.Persona) + ' <span style="color:#a0aec0;font-size:11px">(' + escHtml(p.KAbbr||'') + ':' + escHtml(p.PAbbr||'') + ')</span></div>';
+                            + escHtml(p.Persona) + ' <span style="color:#a0aec0;font-size:11px">(' + escHtml(p.KAbbr||'') + ':' + escHtml(p.PAbbr||'') + ')</span>'
+                            + (p.Active === 0 ? ' <span style="color:#c53030;font-size:10px;font-weight:600">(Inactive)</span>' : '') + '</div>';
                     }).join('')
                     : '<div class="kn-ac-item" style="color:#a0aec0;cursor:default">No players found</div>';
                 el.classList.add('kn-ac-open');
@@ -2313,13 +2547,14 @@ $(document).ready(function() {
         if (term.length < 2) { gid('kn-award-givenby-results').classList.remove('kn-ac-open'); return; }
         clearTimeout(givenByTimer);
         givenByTimer = setTimeout(function() {
-            var url = SEARCH_URL + '?Action=Search%2FPlayer&type=all&search=' + encodeURIComponent(term) + '&kingdom_id=' + KINGDOM_ID + '&limit=6';
+            var url = UIR_JS + 'KingdomAjax/playersearch/' + KINGDOM_ID + '&scope=all&include_inactive=1&q=' + encodeURIComponent(term);
             fetch(url).then(function(r) { return r.json(); }).then(function(data) {
                 var el = gid('kn-award-givenby-results');
                 el.innerHTML = (data && data.length)
                     ? data.map(function(p) {
                         return '<div class="kn-ac-item" tabindex="-1" data-id="' + p.MundaneId + '" data-name="' + encodeURIComponent(p.Persona) + '">'
-                            + escHtml(p.Persona) + ' <span style="color:#a0aec0;font-size:11px">(' + escHtml(p.KAbbr||'') + ':' + escHtml(p.PAbbr||'') + ')</span></div>';
+                            + escHtml(p.Persona) + ' <span style="color:#a0aec0;font-size:11px">(' + escHtml(p.KAbbr||'') + ':' + escHtml(p.PAbbr||'') + ')</span>'
+                            + (p.Active === 0 ? ' <span style="color:#c53030;font-size:10px;font-weight:600">(Inactive)</span>' : '') + '</div>';
                     }).join('')
                     : '<div class="kn-ac-item" style="color:#a0aec0;cursor:default">No results</div>';
                 el.classList.add('kn-ac-open');
@@ -2677,9 +2912,14 @@ $(document).ready(function() {
         if (suggestedPill) { suggestedPill.classList.add('pk-rank-selected'); input.value = suggested; }
     }
 
+    if (gid('kn-rec-award-select')) awInitPicker(gid('kn-rec-award-select'));
     gid('kn-rec-award-select').addEventListener('change', function() {
         buildRecRankPills(this.value);
         checkRequired();
+        var aid = parseInt(this.options[this.selectedIndex].getAttribute('data-award-id') || 0);
+        var desc = AWARD_DESCRIPTIONS[aid] || '';
+        var el = gid('kn-rec-award-desc');
+        if (el) { el.textContent = desc; el.style.display = desc ? '' : 'none'; }
     });
 
     gid('kn-rec-player-text').addEventListener('input', function() {
@@ -2689,13 +2929,14 @@ $(document).ready(function() {
         clearTimeout(playerTimer);
         if (term.length < 2) { gid('kn-rec-player-results').classList.remove('pk-ac-open'); return; }
         playerTimer = setTimeout(function() {
-            var url = UIR_JS + 'KingdomAjax/playersearch/' + KINGDOM_ID + '&q=' + encodeURIComponent(term);
+            var url = UIR_JS + 'KingdomAjax/playersearch/' + KINGDOM_ID + '&include_inactive=1&q=' + encodeURIComponent(term);
             fetch(url).then(function(r) { return r.json(); }).then(function(data) {
                 var el = gid('kn-rec-player-results');
                 el.innerHTML = (data && data.length)
                     ? data.map(function(p) {
                         return '<div class="pk-ac-item" tabindex="-1" data-id="' + p.MundaneId + '" data-name="' + encodeURIComponent(p.Persona) + '">'
-                            + escHtml(p.Persona) + ' <span style="color:#a0aec0;font-size:11px">(' + escHtml(p.KAbbr||'') + ':' + escHtml(p.PAbbr||'') + ')</span></div>';
+                            + escHtml(p.Persona) + ' <span style="color:#a0aec0;font-size:11px">(' + escHtml(p.KAbbr||'') + ':' + escHtml(p.PAbbr||'') + ')</span>'
+                            + (p.Active === 0 ? ' <span style="color:#c53030;font-size:10px;font-weight:600">(Inactive)</span>' : '') + '</div>';
                     }).join('')
                     : '<div class="pk-ac-item" style="color:#a0aec0;cursor:default">No players found</div>';
                 el.classList.add('pk-ac-open');
@@ -3724,7 +3965,8 @@ $(document).ready(function() {
         var delTd  = document.createElement('td');
         var delBtn = document.createElement('button');
         delBtn.className   = 'kn-admin-tdel';
-        delBtn.textContent = 'Delete';
+        delBtn.innerHTML   = '<i class="fas fa-trash"></i>';
+        delBtn.title       = 'Delete';
         (function(row, titleName, titleId) {
             delBtn.addEventListener('click', function() {
                 if (!confirm('Delete "' + titleName + '"? Parks using this title must be reassigned first.')) return;
@@ -3819,6 +4061,17 @@ $(document).ready(function() {
         }
 
         var nameCell  = ntd(true,  aw.KingdomAwardName);
+
+        // If kingdom name differs from system name, show (?) hint
+        var sysName = aw.AwardName || '';
+        if (sysName && sysName !== aw.KingdomAwardName) {
+            var hint = document.createElement('span');
+            hint.className = 'kn-admin-alias-hint';
+            hint.innerHTML = '<i class="fas fa-question-circle"></i>';
+            hint.setAttribute('data-tip', 'Alias for system award ' + sysName);
+            nameCell.td.appendChild(hint);
+        }
+
         var reignCell = ntd(false, aw.ReignLimit);
         var monthCell = ntd(false, aw.MonthLimit);
 
@@ -3838,7 +4091,8 @@ $(document).ready(function() {
 
         var saveBtn = document.createElement('button');
         saveBtn.className   = 'kn-admin-tsave';
-        saveBtn.textContent = 'Save';
+        saveBtn.innerHTML   = '<i class="fas fa-save"></i>';
+        saveBtn.title       = 'Save';
         saveBtn.style.marginRight = '4px';
         (function(btn, nc, rc, mc, cb, cc, kawId) {
             btn.addEventListener('click', function() {
@@ -3861,7 +4115,8 @@ $(document).ready(function() {
 
         var delBtn = document.createElement('button');
         delBtn.className   = 'kn-admin-tdel';
-        delBtn.textContent = 'Delete';
+        delBtn.innerHTML   = '<i class="fas fa-trash"></i>';
+        delBtn.title       = 'Delete';
         (function(btn, row, kawId, awName) {
             btn.addEventListener('click', function() {
                 if (!confirm('Delete award "' + awName + '"? This cannot be undone.')) return;
@@ -3895,16 +4150,39 @@ $(document).ready(function() {
         var addWrap   = gid('kn-admin-add-award-wrap');
         var cancelBtn = gid('kn-admin-new-award-cancel');
 
-        if (addBtn && addWrap) {
-            addBtn.addEventListener('click', function() {
-                addWrap.style.display = '';
-                addBtn.style.display  = 'none';
+        var customAddBtn  = gid('kn-admin-custom-add-btn');
+        var customWrap    = gid('kn-admin-add-custom-wrap');
+        var customCancel  = gid('kn-admin-custom-cancel');
+        var btnRow        = addBtn ? addBtn.parentNode : null;
+
+        function showAliasForm() {
+            if (addWrap) addWrap.style.display = '';
+            if (customWrap) customWrap.style.display = 'none';
+            if (btnRow) btnRow.style.display = 'none';
+        }
+        function showCustomForm() {
+            if (customWrap) customWrap.style.display = '';
+            if (addWrap) addWrap.style.display = 'none';
+            if (btnRow) btnRow.style.display = 'none';
+        }
+        function showButtons() {
+            if (addWrap) addWrap.style.display = 'none';
+            if (customWrap) customWrap.style.display = 'none';
+            if (btnRow) btnRow.style.display = '';
+        }
+
+        if (addBtn) addBtn.addEventListener('click', showAliasForm);
+        if (customAddBtn) customAddBtn.addEventListener('click', showCustomForm);
+        if (cancelBtn) {
+            cancelBtn.addEventListener('click', function() {
+                showButtons();
+                resetAliasForm();
             });
         }
-        if (cancelBtn && addWrap && addBtn) {
-            cancelBtn.addEventListener('click', function() {
-                addWrap.style.display = 'none';
-                addBtn.style.display  = '';
+        if (customCancel) {
+            customCancel.addEventListener('click', function() {
+                showButtons();
+                resetCustomForm();
             });
         }
 
@@ -3916,18 +4194,111 @@ $(document).ready(function() {
             });
         }
 
+        // ── Searchable system award dropdown ──
+        var trigger   = gid('kn-admin-alias-trigger');
+        var dropdown  = gid('kn-admin-alias-dropdown');
+        var searchInp = gid('kn-admin-alias-search');
+        var listEl    = gid('kn-admin-alias-list');
+        var hiddenInp = gid('kn-admin-new-award-id');
+        var nameInp   = gid('kn-admin-new-award-name');
+        var labelSpan = trigger ? trigger.querySelector('.kn-admin-alias-label') : null;
+        var sysAwards = KnConfig.systemAwards || [];
+        var aliasOpen = false;
+
+        function buildAliasList(filter) {
+            if (!listEl) return;
+            listEl.innerHTML = '';
+            var lc = (filter || '').toLowerCase();
+            var count = 0;
+            sysAwards.forEach(function(sa) {
+                if (lc && sa.Name.toLowerCase().indexOf(lc) === -1) return;
+                var div = document.createElement('div');
+                div.className = 'kn-admin-alias-item';
+                div.textContent = sa.Name;
+                div.setAttribute('data-id', sa.AwardId);
+                div.addEventListener('click', function() {
+                    selectAlias(sa.AwardId, sa.Name);
+                });
+                listEl.appendChild(div);
+                count++;
+            });
+            if (count === 0) {
+                var empty = document.createElement('div');
+                empty.className = 'kn-admin-alias-empty';
+                empty.textContent = 'No matching awards';
+                listEl.appendChild(empty);
+            }
+        }
+
+        function selectAlias(id, name) {
+            if (hiddenInp) hiddenInp.value = id;
+            if (labelSpan) { labelSpan.textContent = name; labelSpan.style.color = ''; }
+            if (nameInp && !nameInp.value.trim()) nameInp.value = name;
+            closeAlias();
+        }
+
+        function openAlias() {
+            if (!dropdown || aliasOpen) return;
+            aliasOpen = true;
+            dropdown.style.display = '';
+            buildAliasList('');
+            if (searchInp) { searchInp.value = ''; searchInp.focus(); }
+        }
+
+        function closeAlias() {
+            if (!dropdown) return;
+            aliasOpen = false;
+            dropdown.style.display = 'none';
+        }
+
+        function resetAliasForm() {
+            if (hiddenInp) hiddenInp.value = '';
+            if (labelSpan) { labelSpan.textContent = 'Select a system award…'; labelSpan.style.color = ''; }
+            if (nameInp) nameInp.value = '';
+            gid('kn-admin-new-reign')   && (gid('kn-admin-new-reign').value = '0');
+            gid('kn-admin-new-month')   && (gid('kn-admin-new-month').value = '0');
+            gid('kn-admin-new-istitle') && (gid('kn-admin-new-istitle').checked = false);
+            gid('kn-admin-new-tclass')  && (gid('kn-admin-new-tclass').value = '0');
+            gid('kn-admin-new-tclass')  && (gid('kn-admin-new-tclass').disabled = true);
+            closeAlias();
+        }
+
+        if (trigger) {
+            trigger.addEventListener('click', function(e) {
+                e.preventDefault();
+                aliasOpen ? closeAlias() : openAlias();
+            });
+        }
+
+        if (searchInp) {
+            searchInp.addEventListener('input', function() {
+                buildAliasList(this.value);
+            });
+            searchInp.addEventListener('keydown', function(e) {
+                if (e.key === 'Escape') closeAlias();
+            });
+        }
+
+        // Close dropdown on outside click
+        document.addEventListener('click', function(e) {
+            if (aliasOpen && trigger && dropdown && !trigger.contains(e.target) && !dropdown.contains(e.target)) {
+                closeAlias();
+            }
+        });
+
+        // ── Save new award alias ──
         var saveNewBtn = gid('kn-admin-new-award-save');
         if (saveNewBtn) {
             saveNewBtn.addEventListener('click', function() {
                 clearFeedback('kn-admin-awards-feedback');
-                var awardId = parseInt((gid('kn-admin-new-award-id').value || '0'), 10);
-                var name    = (gid('kn-admin-new-award-name').value || '').trim();
+                var awardId = parseInt((hiddenInp ? hiddenInp.value : '0') || '0', 10);
+                var name    = (nameInp ? nameInp.value : '').trim();
                 var reign   = gid('kn-admin-new-reign').value;
                 var month   = gid('kn-admin-new-month').value;
                 var isTitle = gid('kn-admin-new-istitle').checked ? 1 : 0;
                 var tClass  = gid('kn-admin-new-tclass').value;
 
-                if (!awardId) { feedback('kn-admin-awards-feedback', 'Canonical Award ID is required.', false); return; }
+                if (!awardId) { feedback('kn-admin-awards-feedback', 'Please select a system award.', false); return; }
                 if (!name)    { feedback('kn-admin-awards-feedback', 'Award name is required.', false); return; }
 
                 saveNewBtn.disabled = true;
@@ -3942,12 +4313,63 @@ $(document).ready(function() {
                 }, function(r) {
                     saveNewBtn.disabled = false;
                     if (r && r.status === 0) {
-                        feedback('kn-admin-awards-feedback', 'Award created!', true);
+                        feedback('kn-admin-awards-feedback', 'Award alias created!', true);
                         setTimeout(function() { location.reload(); }, 900);
                     } else {
                         feedback('kn-admin-awards-feedback', (r && r.error) ? r.error : 'Create failed.', false);
                     }
                 }, 'json').fail(function() { saveNewBtn.disabled = false; feedback('kn-admin-awards-feedback', 'Request failed.', false); });
+            });
+        }
+
+        // ── Custom (kingdom-specific) award ──
+        var customIsTitleCb = gid('kn-admin-custom-istitle');
+        var customTClassInp = gid('kn-admin-custom-tclass');
+        if (customIsTitleCb && customTClassInp) {
+            customIsTitleCb.addEventListener('change', function() {
+                customTClassInp.disabled = !this.checked;
+            });
+        }
+
+        function resetCustomForm() {
+            gid('kn-admin-custom-name')    && (gid('kn-admin-custom-name').value = '');
+            gid('kn-admin-custom-reign')   && (gid('kn-admin-custom-reign').value = '0');
+            gid('kn-admin-custom-month')   && (gid('kn-admin-custom-month').value = '0');
+            gid('kn-admin-custom-istitle') && (gid('kn-admin-custom-istitle').checked = false);
+            gid('kn-admin-custom-tclass')  && (gid('kn-admin-custom-tclass').value = '0');
+            gid('kn-admin-custom-tclass')  && (gid('kn-admin-custom-tclass').disabled = true);
+        }
+
+        var saveCustomBtn = gid('kn-admin-custom-save');
+        if (saveCustomBtn) {
+            saveCustomBtn.addEventListener('click', function() {
+                clearFeedback('kn-admin-awards-feedback');
+                var name    = (gid('kn-admin-custom-name').value || '').trim();
+                var reign   = gid('kn-admin-custom-reign').value;
+                var month   = gid('kn-admin-custom-month').value;
+                var isTitle = gid('kn-admin-custom-istitle').checked ? 1 : 0;
+                var tClass  = gid('kn-admin-custom-tclass').value;
+
+                if (!name) { feedback('kn-admin-awards-feedback', 'Award name is required.', false); return; }
+
+                saveCustomBtn.disabled = true;
+                $.post(BASE_URL + 'setaward', {
+                    KingdomAwardId:   0,
+                    AwardId:          0,
+                    KingdomAwardName: name,
+                    ReignLimit:       reign,
+                    MonthLimit:       month,
+                    IsTitle:          isTitle,
+                    TitleClass:       tClass,
+                }, function(r) {
+                    saveCustomBtn.disabled = false;
+                    if (r && r.status === 0) {
+                        feedback('kn-admin-awards-feedback', 'Kingdom-specific award created!', true);
+                        setTimeout(function() { location.reload(); }, 900);
+                    } else {
+                        feedback('kn-admin-awards-feedback', (r && r.error) ? r.error : 'Create failed.', false);
+                    }
+                }, 'json').fail(function() { saveCustomBtn.disabled = false; feedback('kn-admin-awards-feedback', 'Request failed.', false); });
             });
         }
     }
@@ -4964,6 +5386,7 @@ $(document).ready(function() {
         if (suggestedPill) { suggestedPill.classList.add('pk-rank-selected'); input.value = suggested; }
     }
 
+    if (gid('pk-award-select')) awInitPicker(gid('pk-award-select'));
     gid('pk-award-select').addEventListener('change', function() {
         var awardId = this.value;
         var isCustom = this.options[this.selectedIndex] && this.options[this.selectedIndex].text.toLowerCase().indexOf('custom') >= 0;
@@ -4987,13 +5410,14 @@ $(document).ready(function() {
         if (term.length < 2) { gid('pk-award-player-results').classList.remove('pk-ac-open'); return; }
         clearTimeout(playerTimer);
         playerTimer = setTimeout(function() {
-            var url = UIR_JS + 'ParkAjax/park/' + PARK_ID + '/playersearch&scope=all&prioritize=1&q=' + encodeURIComponent(term);
+            var url = UIR_JS + 'ParkAjax/park/' + PARK_ID + '/playersearch&scope=all&prioritize=1&include_inactive=1&q=' + encodeURIComponent(term);
             fetch(url).then(function(r) { return r.json(); }).then(function(data) {
                 var el = gid('pk-award-player-results');
                 el.innerHTML = (data && data.length)
                     ? data.map(function(p) {
                         return '<div class="pk-ac-item" tabindex="-1" data-id="' + p.MundaneId + '" data-name="' + encodeURIComponent(p.Persona) + '">'
-                            + escHtml(p.Persona) + ' <span style="color:#a0aec0;font-size:11px">(' + escHtml(p.KAbbr||'') + ':' + escHtml(p.PAbbr||'') + ')</span></div>';
+                            + escHtml(p.Persona) + ' <span style="color:#a0aec0;font-size:11px">(' + escHtml(p.KAbbr||'') + ':' + escHtml(p.PAbbr||'') + ')</span>'
+                            + (p.Active === 0 ? ' <span style="color:#c53030;font-size:10px;font-weight:600">(Inactive)</span>' : '') + '</div>';
                     }).join('')
                     : '<div class="pk-ac-item" style="color:#a0aec0;cursor:default">No players found</div>';
                 pkFixedAcPosition(gid('pk-award-player-text'), el);
@@ -5041,13 +5465,14 @@ $(document).ready(function() {
         if (term.length < 2) { gid('pk-award-givenby-results').classList.remove('pk-ac-open'); return; }
         clearTimeout(givenByTimer);
         givenByTimer = setTimeout(function() {
-            var url = SEARCH_URL + '?Action=Search%2FPlayer&type=PERSONA&search=' + encodeURIComponent(term) + '&park_id=' + PkConfig.parkId + '&limit=6';
+            var url = UIR_JS + 'ParkAjax/park/' + PkConfig.parkId + '/playersearch&scope=all&prioritize=1&include_inactive=1&q=' + encodeURIComponent(term);
             fetch(url).then(function(r) { return r.json(); }).then(function(data) {
                 var el = gid('pk-award-givenby-results');
                 el.innerHTML = (data && data.length)
                     ? data.map(function(p) {
                         return '<div class="pk-ac-item" tabindex="-1" data-id="' + p.MundaneId + '" data-name="' + encodeURIComponent(p.Persona) + '">'
-                            + escHtml(p.Persona) + ' <span style="color:#a0aec0;font-size:11px">(' + escHtml(p.KAbbr||'') + ':' + escHtml(p.PAbbr||'') + ')</span></div>';
+                            + escHtml(p.Persona) + ' <span style="color:#a0aec0;font-size:11px">(' + escHtml(p.KAbbr||'') + ':' + escHtml(p.PAbbr||'') + ')</span>'
+                            + (p.Active === 0 ? ' <span style="color:#c53030;font-size:10px;font-weight:600">(Inactive)</span>' : '') + '</div>';
                     }).join('')
                     : '<div class="pk-ac-item" style="color:#a0aec0;cursor:default">No results</div>';
                 pkFixedAcPosition(gid('pk-award-givenby-text'), el);
@@ -5417,9 +5842,14 @@ $(document).ready(function() {
         if (suggestedPill) { suggestedPill.classList.add('pk-rank-selected'); input.value = suggested; }
     }
 
+    if (gid('pk-rec-award-select')) awInitPicker(gid('pk-rec-award-select'));
     gid('pk-rec-award-select').addEventListener('change', function() {
         buildRecRankPills(this.value);
         checkRequired();
+        var aid = parseInt(this.options[this.selectedIndex].getAttribute('data-award-id') || 0);
+        var desc = AWARD_DESCRIPTIONS[aid] || '';
+        var el = gid('pk-rec-award-desc');
+        if (el) { el.textContent = desc; el.style.display = desc ? '' : 'none'; }
     });
 
     // Player search
@@ -5430,13 +5860,14 @@ $(document).ready(function() {
         clearTimeout(playerTimer);
         if (term.length < 2) { gid('pk-rec-player-results').classList.remove('pk-ac-open'); return; }
         playerTimer = setTimeout(function() {
-            var url = UIR_JS + 'KingdomAjax/playersearch/' + PkConfig.kingdomId + '&q=' + encodeURIComponent(term);
+            var url = UIR_JS + 'KingdomAjax/playersearch/' + PkConfig.kingdomId + '&include_inactive=1&q=' + encodeURIComponent(term);
             fetch(url).then(function(r) { return r.json(); }).then(function(data) {
                 var el = gid('pk-rec-player-results');
                 el.innerHTML = (data && data.length)
                     ? data.map(function(p) {
                         return '<div class="pk-ac-item" tabindex="-1" data-id="' + p.MundaneId + '" data-name="' + encodeURIComponent(p.Persona) + '">'
-                            + escHtml(p.Persona) + ' <span style="color:#a0aec0;font-size:11px">(' + escHtml(p.KAbbr||'') + ':' + escHtml(p.PAbbr||'') + ')</span></div>';
+                            + escHtml(p.Persona) + ' <span style="color:#a0aec0;font-size:11px">(' + escHtml(p.KAbbr||'') + ':' + escHtml(p.PAbbr||'') + ')</span>'
+                            + (p.Active === 0 ? ' <span style="color:#c53030;font-size:10px;font-weight:600">(Inactive)</span>' : '') + '</div>';
                     }).join('')
                     : '<div class="pk-ac-item" style="color:#a0aec0;cursor:default">No players found</div>';
                 el.classList.add('pk-ac-open');

--- a/orkui/template/revised-frontend/script/revised.js
+++ b/orkui/template/revised-frontend/script/revised.js
@@ -365,7 +365,7 @@ function pnPageRange(current, total) {
 function pnSetPageSize(tableId, size) {
     var $table = $('#' + tableId);
     if (!$table.length) return;
-    $table.data('pagesize', parseInt(size));
+    $table.data('pagesize', size === 'all' ? 99999 : parseInt(size));
     pnPaginate($table, 1);
 }
 
@@ -654,7 +654,8 @@ if (PnConfig.recError) {
         p.classList.add('pn-rank-selected');
         input.value = p.dataset.rank;
     });
-    if (gid('pn-rec-award')) awInitPicker(gid('pn-rec-award'));
+    var _recAwardEl = document.getElementById('pn-rec-award');
+    if (_recAwardEl) awInitPicker(_recAwardEl);
     $('#pn-rec-award').on('change', function() {
         buildRecRankPills($(this).val());
         var aid = parseInt($(this).find(':selected').data('award-id') || 0);

--- a/orkui/template/revised-frontend/style/revised.css
+++ b/orkui/template/revised-frontend/style/revised.css
@@ -715,6 +715,13 @@
 	color: #4a5568;
 	margin-bottom: 4px;
 }
+.pn-rec-award-desc {
+	font-size: 12px;
+	color: #718096;
+	font-style: italic;
+	margin-top: 4px;
+	line-height: 1.4;
+}
 .pn-rec-field select,
 .pn-rec-field input[type="text"] {
 	width: 100%;
@@ -2649,6 +2656,7 @@
 	background: #f7fafc;
 	flex-wrap: nowrap;
 	overflow-x: auto;
+	overflow-y: hidden;
 }
 .pk-tab-nav li {
 	padding: 12px 18px;
@@ -3043,6 +3051,28 @@
 }
 .pk-player-card:hover .pk-player-stats { background: rgba(255,255,255,0.82); }
 .pk-player-stats span { display: block; }
+
+/* ---- Responsive: progressive tab label collapse (right → left) ---- */
+@media (max-width: 1200px) {
+	.pk-tab-nav li:nth-last-child(1) .pk-tab-label,
+	.pk-tab-nav li:nth-last-child(1) .pk-tab-count { display: none; }
+}
+@media (max-width: 1100px) {
+	.pk-tab-nav li:nth-last-child(2) .pk-tab-label,
+	.pk-tab-nav li:nth-last-child(2) .pk-tab-count { display: none; }
+}
+@media (max-width: 1000px) {
+	.pk-tab-nav li:nth-last-child(3) .pk-tab-label,
+	.pk-tab-nav li:nth-last-child(3) .pk-tab-count { display: none; }
+}
+@media (max-width: 920px) {
+	.pk-tab-nav li:nth-last-child(4) .pk-tab-label,
+	.pk-tab-nav li:nth-last-child(4) .pk-tab-count { display: none; }
+}
+@media (max-width: 850px) {
+	.pk-tab-nav li:nth-last-child(5) .pk-tab-label,
+	.pk-tab-nav li:nth-last-child(5) .pk-tab-count { display: none; }
+}
 
 /* ---- Responsive ---- */
 @media (max-width: 768px) {
@@ -4822,7 +4852,7 @@
 #kn-admin-overlay .kn-modal-close-btn:hover { color:#4a5568; }
 #kn-admin-overlay .kn-modal-body { padding:16px 20px; overflow-y:auto; flex:1; }
 #kn-admin-overlay .kn-modal-footer { padding:14px 20px; border-top:1px solid #e2e8f0; display:flex; align-items:center; justify-content:flex-end; flex-shrink:0; }
-.kn-admin-panel { border:1px solid #e2e8f0; border-radius:8px; margin-bottom:10px; overflow:hidden; }
+.kn-admin-panel { border:1px solid #e2e8f0; border-radius:8px; margin-bottom:16px; overflow:hidden; }
 .kn-admin-panel-hdr { width:100%; display:flex; align-items:center; justify-content:space-between; padding:11px 14px; background:#f7fafc; border:none; cursor:pointer; font-size:13px; font-weight:600; color:#4a5568; text-align:left; }
 .kn-admin-panel-hdr:hover { background:#edf2f7; }
 .kn-admin-chevron { font-size:11px; color:#a0aec0; transition:transform 0.2s; }
@@ -4857,13 +4887,15 @@
 .kn-admin-tnumeric { width:58px; padding:5px 6px; border:1px solid #e2e8f0; border-radius:4px; font-size:12px; text-align:center; box-sizing:border-box; }
 .kn-admin-tselect { padding:5px 4px; border:1px solid #e2e8f0; border-radius:4px; font-size:12px; background:#fff; }
 .kn-admin-tinput:focus, .kn-admin-tnumeric:focus, .kn-admin-tselect:focus { outline:none; border-color:#90cdf4; }
-.kn-admin-tdel { padding:3px 8px; background:none; border:1px solid #fc8181; color:#e53e3e; border-radius:4px; font-size:11px; cursor:pointer; white-space:nowrap; }
+.kn-admin-tdel { padding:4px 6px; background:none; border:1px solid #fc8181; color:#e53e3e; border-radius:4px; font-size:13px; cursor:pointer; line-height:1; }
 .kn-admin-tdel:hover { background:#fff5f5; }
 .kn-admin-tdel:disabled, .kn-admin-tsave:disabled { opacity:0.5; cursor:default; }
-.kn-admin-tsave { padding:3px 8px; background:none; border:1px solid #68d391; color:var(--kn-accent, #276749); border-radius:4px; font-size:11px; cursor:pointer; white-space:nowrap; }
+.kn-admin-tsave { padding:4px 6px; background:none; border:1px solid #68d391; color:#38a169; border-radius:4px; font-size:13px; cursor:pointer; line-height:1; }
 .kn-admin-tsave:hover { background:#f0fff4; }
-.kn-admin-awards-table .kn-admin-tinput { width:150px; }
-.kn-admin-awards-table .kn-admin-tnumeric { width:50px; }
+.kn-admin-awards-table .kn-admin-tinput { flex:1; min-width:120px; }
+.kn-admin-awards-table .kn-admin-tnumeric { width:54px; }
+.kn-admin-awards-table td:first-child { overflow:visible; position:relative; display:flex; align-items:center; gap:4px; }
+.kn-admin-awards-table td:nth-child(n+2) { white-space:nowrap; width:1%; }
 .kn-admin-config-row { display:flex; align-items:center; gap:12px; padding:8px 0; border-bottom:1px solid #f0f4f8; }
 .kn-admin-config-row:last-child { border-bottom:none; }
 .kn-admin-config-label { width:200px; flex-shrink:0; font-size:12px; font-weight:600; color:#4a5568; }
@@ -4873,8 +4905,28 @@
 .kn-admin-config-sublabel { font-size:11px; color:#a0aec0; margin-right:2px; }
 .kn-admin-add-award-wrap { margin-top:12px; padding:14px; background:#f7fafc; border:1px solid #e2e8f0; border-radius:8px; }
 .kn-admin-add-award-title { font-size:12px; font-weight:700; color:#4a5568; text-transform:uppercase; letter-spacing:0.04em; margin-bottom:10px; }
+.kn-admin-form-hint { font-size:12px; color:#718096; line-height:1.5; margin:0 0 12px 0; }
 .kn-admin-award-row-fields { display:flex; gap:10px; align-items:flex-end; flex-wrap:wrap; }
 .kn-admin-award-row-fields .kn-admin-field { margin-bottom:0; }
+
+/* ---- Alias award picker ---- */
+.kn-admin-alias-trigger { display:flex; align-items:center; justify-content:space-between; width:100%; padding:7px 10px; background:#fff; border:1.5px solid #e2e8f0; border-radius:6px; font-size:13px; color:#2d3748; cursor:pointer; text-align:left; min-height:36px; box-sizing:border-box; }
+.kn-admin-alias-trigger:hover { border-color:#90cdf4; }
+.kn-admin-alias-label { overflow:hidden; text-overflow:ellipsis; white-space:nowrap; flex:1; }
+.kn-admin-alias-dropdown { position:absolute; top:100%; left:0; right:0; z-index:120; background:#fff; border:1.5px solid #cbd5e0; border-radius:8px; box-shadow:0 8px 24px rgba(0,0,0,0.12); margin-top:4px; max-height:260px; display:flex; flex-direction:column; }
+.kn-admin-alias-search { padding:8px 10px; border:none; border-bottom:1px solid #e2e8f0; font-size:13px; outline:none; border-radius:8px 8px 0 0; box-sizing:border-box; width:100%; }
+.kn-admin-alias-list { overflow-y:auto; flex:1; max-height:220px; }
+.kn-admin-alias-item { padding:7px 12px; font-size:13px; color:#2d3748; cursor:pointer; border-bottom:1px solid #f7fafc; }
+.kn-admin-alias-item:hover { background:#ebf8ff; }
+.kn-admin-alias-item:last-child { border-bottom:none; }
+.kn-admin-alias-empty { padding:12px; font-size:12px; color:#a0aec0; text-align:center; font-style:italic; }
+.kn-admin-alias-hint { flex-shrink:0; color:#a0aec0; font-size:11px; cursor:help; position:relative; }
+.kn-admin-alias-hint:hover { color:#4299e1; }
+.kn-admin-alias-hint::after { content:attr(data-tip); position:absolute; bottom:calc(100% + 6px); left:0; background:#2d3748; color:#fff; font-size:11px; font-style:italic; white-space:nowrap; padding:4px 10px; border-radius:4px; pointer-events:none; opacity:0; transition:opacity 0s; z-index:500; }
+.kn-admin-alias-hint::before { content:''; position:absolute; bottom:calc(100% + 2px); left:4px; border:4px solid transparent; border-top-color:#2d3748; pointer-events:none; opacity:0; transition:opacity 0s; z-index:500; }
+.kn-admin-alias-hint:hover::after, .kn-admin-alias-hint:hover::before { opacity:1; }
+.kn-admin-award-add-btns { display:flex; gap:8px; flex-wrap:wrap; margin-top:10px; }
+.kn-admin-th-tip { cursor:help; }
 
 /* ---- Confirmation modal ---- */
 #kn-md-help-overlay, #pk-md-help-overlay, #ev-md-help-overlay, #un-md-help-overlay { position:fixed; inset:0; background:rgba(0,0,0,0.55); display:flex; align-items:center; justify-content:center; z-index:var(--z-help-overlay, 1300); opacity:0; pointer-events:none; visibility:hidden; transition:opacity 0.2s, visibility 0s 0.2s; }
@@ -5745,4 +5797,70 @@ table.dataTable.adm-table tbody tr.even:hover {
     transition-duration: 0.01ms !important;
     scroll-behavior: auto !important;
   }
+}
+
+/* =============================================
+   Searchable Award Dropdown
+   ============================================= */
+.aw-picker-trigger {
+	display: flex; align-items: center; justify-content: space-between;
+	width: 100%; padding: 7px 10px; background: #fff;
+	border: 1px solid #cbd5e0; border-radius: 4px;
+	cursor: pointer; font-size: 13px; color: #a0aec0; text-align: left;
+	transition: border-color 0.15s; box-sizing: border-box;
+}
+.aw-picker-trigger:hover { border-color: #a0aec0; }
+.aw-picker-trigger.aw-has-value { color: #2d3748; }
+.aw-picker-trigger.aw-has-value .aw-trigger-label { font-weight: 500; }
+
+.aw-dropdown {
+	position: fixed;
+	background: #fff;
+	border: 1px solid #cbd5e0;
+	border-radius: 6px;
+	box-shadow: 0 8px 24px rgba(0,0,0,0.15);
+	z-index: 100000;
+	max-height: 360px;
+	display: none;
+	flex-direction: column;
+}
+.aw-dropdown.aw-open { display: flex; }
+.aw-dropdown-search {
+	padding: 8px 10px 8px 30px;
+	border: none; border-bottom: 1px solid #e2e8f0;
+	font-size: 13px; outline: none; box-sizing: border-box;
+	border-radius: 6px 6px 0 0; width: 100%;
+}
+.aw-dropdown-search-wrap { position: relative; flex-shrink: 0; }
+.aw-dropdown-search-wrap i {
+	position: absolute; left: 10px; top: 50%; transform: translateY(-50%);
+	color: #a0aec0; font-size: 12px; pointer-events: none;
+}
+.aw-dropdown-body { overflow-y: auto; padding: 2px 0; flex: 1; }
+.aw-pick-group { padding-bottom: 2px; }
+.aw-pick-group-label {
+	font-size: 10px; font-weight: 700; text-transform: uppercase;
+	letter-spacing: 0.06em; color: #718096;
+	padding: 8px 12px 3px; position: sticky; top: 0;
+	background: #fff; z-index: 1; border-bottom: 1px solid #f0f0f0;
+}
+.aw-pick-item {
+	padding: 5px 12px 5px 18px; cursor: pointer;
+	transition: background 0.1s;
+}
+.aw-pick-item:hover { background: #f0fdfa; }
+.aw-pick-item:focus { background: #e6fffa; outline: none; }
+.aw-pick-item.aw-active {
+	background: #e6fffa; border-left: 3px solid #0891b2; padding-left: 15px;
+}
+.aw-pick-name { font-size: 13px; color: #2d3748; display: block; }
+.aw-pick-desc { font-size: 11px; color: #a0aec0; font-style: italic; line-height: 1.3; display: block; }
+.aw-pick-standalone { border-bottom: 1px solid #edf2f7; padding-bottom: 2px; margin-bottom: 2px; }
+.aw-pick-empty { padding: 16px 12px; text-align: center; color: #a0aec0; font-size: 13px; }
+
+@media (max-width: 600px) {
+	.aw-dropdown-search { font-size: 16px; padding: 10px 10px 10px 32px; }
+	.aw-pick-item { padding: 10px 12px 10px 18px; }
+	.aw-pick-item.aw-active { padding-left: 15px; }
+	.aw-pick-group-label { padding: 10px 12px 5px; }
 }

--- a/orkui/template/revised-frontend/style/revised.css
+++ b/orkui/template/revised-frontend/style/revised.css
@@ -1219,6 +1219,17 @@
 	-webkit-appearance: none;
 }
 .pn-pagesize-select:focus { border-color: #90cdf4; }
+/* Table toolbar (pagesize + search side by side) */
+.pn-table-toolbar {
+	display: flex;
+	align-items: center;
+	gap: 12px;
+	margin-bottom: 10px;
+}
+.pn-table-toolbar .pn-award-search-bar {
+	flex: 1;
+	min-width: 0;
+}
 /* Award search bar */
 .pn-award-search-bar {
 	position: relative;

--- a/orkui/template/revised-frontend/style/revised.css
+++ b/orkui/template/revised-frontend/style/revised.css
@@ -2258,7 +2258,6 @@
 .kn-ac-results.kn-ac-open { display:block; }
 #kn-award-overlay .kn-ac-results,
 #kn-rec-overlay .kn-ac-results {
-    position: fixed;
     z-index: var(--z-modal-top, 1200);
 }
 .kn-ac-item { padding:8px 12px; font-size:13px; cursor:pointer; color:#2d3748; border-bottom:1px solid #f7fafc; }

--- a/system/lib/ork3/class.Award.php
+++ b/system/lib/ork3/class.Award.php
@@ -44,7 +44,7 @@ class Award  extends Ork3 {
     } else if (isset($request['OfficerRole']) && $request['OfficerRole'] == 'Officers') {
       $officer_role_clause = " and officer_role != 'none'"; 
     } 
-		$sql = "select award_id, name, a.award_id, a.is_ladder, is_title, title_class, a.officer_role
+		$sql = "select award_id, name, a.award_id, a.is_ladder, is_title, title_class, a.officer_role, a.peerage
 					from " . DB_PREFIX . "award a 
 					where 1
 						$ladder_clause
@@ -67,7 +67,8 @@ class Award  extends Ork3 {
 					'IsLadder' => $r->is_ladder,
 					'IsTitle' => $r->is_title,
 					'TitleClass' => $r->title_class,
-          			'OfficerRole' => $r->officer_role
+          			'OfficerRole' => $r->officer_role,
+					'Peerage' => $r->peerage
 				);
 			}
 			$response['Status'] = Success();

--- a/system/lib/ork3/class.Kingdom.php
+++ b/system/lib/ork3/class.Kingdom.php
@@ -112,7 +112,7 @@ class Kingdom  extends Ork3 {
 		}
 		$sql = "select kingdomaward_id, ifnull(ka.name, a.name) as kingdom_awardname, ka.reign_limit, ka.month_limit, a.name as award_name, 
 						a.award_id, a.is_ladder, ifnull(a.is_title, ka.is_title) as is_title, ifnull(a.title_class, ka.title_class) as title_class,
-            a.officer_role
+            a.officer_role, a.peerage
 					from " . DB_PREFIX . "kingdomaward ka
 						left join " . DB_PREFIX . "award a on ka.award_id = a.award_id and ka.kingdom_id = '" . mysql_real_escape_string($request['KingdomId']) . "'
 					where 1
@@ -144,7 +144,8 @@ class Kingdom  extends Ork3 {
 					'IsLadder' => $r->is_ladder,
 					'IsTitle' => $r->is_title,
 					'TitleClass' => $r->title_class,
-					'OfficerRole' => $r->officer_role
+					'OfficerRole' => $r->officer_role,
+					'Peerage' => $r->peerage
 				);
 			}
 			$response['Status'] = Success();

--- a/system/lib/ork3/class.Report.php
+++ b/system/lib/ork3/class.Report.php
@@ -2585,4 +2585,126 @@ class Report  extends Ork3 {
 		);
 	}
 
+
+	public function GetPlayerStatusReconciliation($request) {
+		$key = Ork3::$Lib->ghettocache->key($request);
+		if (($cache = Ork3::$Lib->ghettocache->get(__CLASS__ . '.' . __FUNCTION__, $key, 120)) !== false)
+			return $cache;
+
+		$location = '';
+		if (valid_id($request['ParkId'])) {
+			$location = " and m.park_id = '" . mysql_real_escape_string($request['ParkId']) . "'";
+		} else if (valid_id($request['KingdomId'])) {
+			$location = " and m.kingdom_id = '" . mysql_real_escape_string($request['KingdomId']) . "'";
+		} else {
+			return array('Status' => InvalidParameter());
+		}
+
+		// Inactive players WITH a sign-in in the past 6 months
+		$sql_inactive_with_attendance = "
+			SELECT m.mundane_id, m.persona, m.given_name, m.surname,
+				p.park_id, p.name AS park_name,
+				k.kingdom_id, k.name AS kingdom_name,
+				MAX(a.date) AS last_signin,
+				COUNT(DISTINCT a.date) AS signin_count_6mo
+			FROM " . DB_PREFIX . "mundane m
+				INNER JOIN " . DB_PREFIX . "attendance a ON a.mundane_id = m.mundane_id
+					AND a.date >= DATE_SUB(CURDATE(), INTERVAL 6 MONTH)
+				LEFT JOIN " . DB_PREFIX . "park p ON p.park_id = m.park_id
+				LEFT JOIN " . DB_PREFIX . "kingdom k ON k.kingdom_id = m.kingdom_id
+			WHERE m.active = 0 AND m.suspended = 0 AND m.persona IS NOT NULL AND m.persona != '' $location
+			GROUP BY m.mundane_id
+			ORDER BY p.name, m.persona";
+
+		$this->db->Clear();
+		$r1 = $this->db->query($sql_inactive_with_attendance);
+		$inactive_with_attendance = array();
+		if ($r1 !== false && $r1->size() > 0) {
+			while ($r1->next()) {
+				$inactive_with_attendance[] = array(
+					'MundaneId'     => $r1->mundane_id,
+					'Persona'       => $r1->persona,
+					'GivenName'     => $r1->given_name,
+					'Surname'       => $r1->surname,
+					'ParkId'        => $r1->park_id,
+					'ParkName'      => $r1->park_name,
+					'KingdomId'     => $r1->kingdom_id,
+					'KingdomName'   => $r1->kingdom_name,
+					'LastSignIn'    => $r1->last_signin,
+					'SignInCount'   => $r1->signin_count_6mo,
+				);
+			}
+		}
+
+		// Active players with NO sign-in in the past 24 months
+		$sql_active_no_attendance = "
+			SELECT m.mundane_id, m.persona, m.given_name, m.surname,
+				p.park_id, p.name AS park_name,
+				k.kingdom_id, k.name AS kingdom_name,
+				m.park_member_since,
+				(SELECT MAX(a2.date) FROM " . DB_PREFIX . "attendance a2 WHERE a2.mundane_id = m.mundane_id) AS last_signin
+			FROM " . DB_PREFIX . "mundane m
+				LEFT JOIN " . DB_PREFIX . "park p ON p.park_id = m.park_id
+				LEFT JOIN " . DB_PREFIX . "kingdom k ON k.kingdom_id = m.kingdom_id
+			WHERE m.active = 1 AND m.suspended = 0 AND m.persona IS NOT NULL AND m.persona != '' $location
+				AND (m.park_member_since IS NULL OR m.park_member_since < DATE_SUB(CURDATE(), INTERVAL 24 MONTH))
+				AND NOT EXISTS (
+					SELECT 1 FROM " . DB_PREFIX . "attendance a
+					WHERE a.mundane_id = m.mundane_id
+						AND a.date >= DATE_SUB(CURDATE(), INTERVAL 24 MONTH)
+				)
+			ORDER BY p.name, m.persona";
+
+		$this->db->Clear();
+		$r2 = $this->db->query($sql_active_no_attendance);
+		$active_no_attendance = array();
+		if ($r2 !== false && $r2->size() > 0) {
+			while ($r2->next()) {
+				$active_no_attendance[] = array(
+					'MundaneId'     => $r2->mundane_id,
+					'Persona'       => $r2->persona,
+					'GivenName'     => $r2->given_name,
+					'Surname'       => $r2->surname,
+					'ParkId'        => $r2->park_id,
+					'ParkName'      => $r2->park_name,
+					'KingdomId'     => $r2->kingdom_id,
+					'KingdomName'   => $r2->kingdom_name,
+					'LastSignIn'    => $r2->last_signin,
+					'ParkMemberSince' => $r2->park_member_since,
+				);
+			}
+		}
+
+		$response = array(
+			'Status' => Success(),
+			'InactiveWithAttendance' => $inactive_with_attendance,
+			'ActiveNoAttendance' => $active_no_attendance,
+		);
+		return Ork3::$Lib->ghettocache->cache(__CLASS__ . '.' . __FUNCTION__, $key, $response);
+	}
+
+	public function SetPlayerActiveStatus($request) {
+		$requester_id = Ork3::$Lib->authorization->IsAuthorized($request['Token']);
+		if (!valid_id($requester_id)) return NoAuthorization();
+
+		$mundane_id = (int)$request['MundaneId'];
+		$active = (int)$request['Active'];
+		if (!$mundane_id || !\in_array($active, [0, 1])) return InvalidParameter();
+
+		$mundane = new yapo($this->db, DB_PREFIX . 'mundane');
+		$mundane->mundane_id = $mundane_id;
+		if (!$mundane->find()) return InvalidParameter('Player not found.');
+
+		// Auth check: requester must have AUTH_PARK + AUTH_CREATE on the player's park
+		if (!Ork3::$Lib->authorization->HasAuthority($requester_id, AUTH_PARK, $mundane->park_id, AUTH_CREATE)
+			&& !Ork3::$Lib->authorization->HasAuthority($requester_id, AUTH_KINGDOM, $mundane->kingdom_id, AUTH_EDIT)
+			&& !Ork3::$Lib->authorization->HasAuthority($requester_id, AUTH_ADMIN, 0, AUTH_EDIT)) {
+			return NoAuthorization();
+		}
+
+		$mundane->active = $active;
+		$mundane->save();
+		return Success();
+	}
+
 }

--- a/system/lib/ork3/class.SearchService.php
+++ b/system/lib/ork3/class.SearchService.php
@@ -307,19 +307,19 @@ class SearchService extends Ork3 {
 			case 'PERSONA': 
 				if (count($searchtokens) > 0)
 					$s = implode(' or ', array_map(function($t) { return "`persona` like '%" . mysql_real_escape_string($t) . "%'"; }, $searchtokens));
-			    	$order = "order by persona,surname,given_name";
+			    	$order = "order by m.active DESC, persona,surname,given_name";
                     $opt[] = "length(`persona`) > 0";
 				break;
 			case 'MUNDANE':
 				if (count($searchtokens) > 0)
 					$s = implode(' or ', array_map(function($t) { return "`given_name` like '%" . mysql_real_escape_string($t) . "%' or `surname` like '%" . mysql_real_escape_string($t) . "%'"; }, $searchtokens));
-				    $order = "order by surname,given_name";
+				    $order = "order by m.active DESC, surname,given_name";
                     $opt[] = "(length(`surname`) > 0 or length(`given_name`) > 0)";
 				break;
 			case 'USER':
 				if (count($searchtokens) > 0)
 					$s = implode(' or ', array_map(function($t) { return "`username` like '%" . mysql_real_escape_string($t) . "%'"; }, $searchtokens));
-			    	$order = "order by username,surname,given_name";
+			    	$order = "order by m.active DESC, username,surname,given_name";
                     $opt[] = "length(`username`) > 0";
 				break;
 			default:
@@ -342,7 +342,7 @@ class SearchService extends Ork3 {
 			$opt[] = "waivered =".($waivered?1:0);
 		}
 		$opt[] = "(m.kingdom_id != 15 AND (p.kingdom_id IS NULL OR p.kingdom_id != 15))";
-		$order = $order ?? '';
+		$order = $order ?? 'order by m.active DESC, persona';
 		$sql = "select 
 						`mundane_id`, m.`active`, `given_name`, `surname`, `other_name`, concat(`given_name`,' ',`surname`) as `mundane`, `username`, `persona`, p.park_id, k.kingdom_id, 
 						`restricted`, `suspended`, `suspended_at`, `suspended_until`, `waivered`, `company_id`, `penalty_box`, k.name as kingdom_name, p.name as park_name, p.abbreviation as p_abbr, k.abbreviation as k_abbr


### PR DESCRIPTION
## Summary
- **Award dropdown restructuring**: Categorized award picker with 8 groups (Ladder, Custom, Knighthoods, Masterhoods, Paragons, Noble Titles, Associate Titles, Other) with searchable type-to-filter, mobile bottom-sheet, and award descriptions
- **Kingdom award admin overhaul**: Replaced raw "Canonical Award ID" input with searchable "Add Award Alias" dropdown of system awards, added "Add Kingdom-Specific Award" form for kingdom-only awards (award_id=0), inline (?) alias hints with instant tooltips, icon-based save/delete buttons, explanatory instruction text for both forms
- **Award API enhancements**: Added `peerage` field to Award and Kingdom award API responses for proper categorization without DB migration
- **Player status reconciliation report**: New report for tracking player status reconciliation
- **Park tab bar responsive CSS**: Progressive label hiding right-to-left at breakpoints
- **Player awards/titles**: Show Rows toggle and secondary sort
- **Misc fixes**: Search and park ajax improvements

## Changes across layers
- **Backend** (`system/lib/ork3/`): `class.Award.php`, `class.Kingdom.php` — added peerage to SQL selects and response arrays; `class.Report.php` — new reconciliation report; `class.SearchService.php` — fixes
- **Models** (`orkui/model/`): `model.Award.php` — complete rewrite with 8-bucket award categorization; `model.Reports.php` — reconciliation model
- **Controllers** (`orkui/controller/`): `controller.Kingdom.php` — admin awards now include AwardId/AwardName/IsLadder + SystemAwards array; `controller.KingdomAjax.php` — allow AwardId=0 for kingdom-specific awards; `controller.Reports.php`, `controller.ParkAjax.php`, `controller.SearchAjax.php` — misc
- **Templates/JS/CSS**: Award picker IIFE, kingdom admin panel redesign, responsive styles, 6 picker initializations across player/kingdom/park pages

## Test plan
- [ ] Verify award dropdowns on player, kingdom, and park pages show categorized groups
- [ ] Test type-to-filter search in award picker
- [ ] Test mobile bottom-sheet behavior on small screens
- [ ] Open kingdom admin → Awards panel → verify existing awards show with (?) alias hints where names differ
- [ ] Test "Add Award Alias" → searchable dropdown → select → auto-fills name → save
- [ ] Test "Add Kingdom-Specific Award" → enter name → save (creates with award_id=0)
- [ ] Verify save (floppy icon) and delete (trash icon) work on existing awards
- [ ] Test park tab bar label hiding at various viewport widths
- [ ] Verify player awards/titles Show Rows toggle and sort

🤖 Generated with [Claude Code](https://claude.com/claude-code)