### PR TITLE
Feature: Add Voting Eligibility report and player badge

### DIFF
--- a/orkui/controller/controller.Player.php
+++ b/orkui/controller/controller.Player.php
@@ -373,6 +373,23 @@ class Controller_Player extends Controller {
 			$this->data['AwardRecommendations'] = is_array($recs) ? $recs : [];
 		}
 
+		// Voting eligibility badge — supported kingdoms only
+		$this->data['VotingEligible']         = false;
+		$this->data['VotingProvinceMode']      = false;
+		$this->data['VotingProvinceEligible']  = false;
+		$this->data['ActiveKnight']            = false;
+		$this->data['ActiveMember']            = false;
+		$_votingKingdoms = [31, 17, 10, 20, 25, 6, 38, 4, 27, 36, 14, 19, 3];
+		$_playerKingdomId = (int)($this->data['Player']['KingdomId'] ?? 0);
+		if (in_array($_playerKingdomId, $_votingKingdoms)) {
+			$_vr = $this->Reports->get_voting_eligible_for_player((int)$id, $_playerKingdomId);
+			$this->data['VotingEligible']        = !empty($_vr['Players'][0]['VotingEligible']);
+			$this->data['VotingProvinceMode']     = !empty($_vr['ProvinceMode']);
+			$this->data['VotingProvinceEligible'] = !empty($_vr['Players'][0]['ProvinceEligible']);
+			$this->data['ActiveKnight']           = !empty($_vr['Players'][0]['ActiveKnight']);
+		$this->data['ActiveMember']           = $_vr['Players'][0]['ActiveMember'] ?? false;
+		}
+
 		global $DB;
 		$DB->Clear();
 		$officerSql   = "SELECT o.role, o.park_id,

--- a/orkui/controller/controller.Reports.php
+++ b/orkui/controller/controller.Reports.php
@@ -512,6 +512,58 @@ class Controller_Reports extends Controller {
 		$this->data['page_title'] ="Suspended Player Roster";
 	}
 
+	public function voting_eligible($type = null) {
+		$_uid = isset($this->session->user_id) ? (int)$this->session->user_id : 0;
+		$_isOrkAdmin = $_uid > 0 && Ork3::$Lib->authorization->HasAuthority($_uid, AUTH_ADMIN, 0, AUTH_ADMIN);
+		if (!$_isOrkAdmin && (!in_array($type, ['Kingdom', 'Park']) || !valid_id($this->request->id))) {
+			header('Location: ' . UIR);
+			exit;
+		}
+
+		$this->data['page_title']  = 'Voting Eligible Players';
+		$this->data['report_type'] = $type;
+		$this->data['report_id']   = $this->request->id ?? null;
+		$this->template = 'Reports_voting_eligible.tpl';
+
+		// Resolve kingdom_id for the supported-kingdoms gate
+		$kingdom_config = $this->kingdom_config($type);
+		$kingdom_id = (int)($kingdom_config['KingdomInfo']['KingdomId'] ?? 0);
+
+		$supported = [31, 17, 10, 20, 25, 6, 38, 4, 27, 36, 14, 19, 3];
+		if (!in_array($kingdom_id, $supported)) {
+			$this->data['NotSupported'] = true;
+			return;
+		}
+
+		$result = $this->Reports->get_voting_eligible($type, $this->request->id);
+		$this->data['Players']               = $result['Players'] ?? [];
+		$this->data['AttendanceRequired']    = $result['AttendanceRequired'];
+		$this->data['MonthsWindow']          = $result['MonthsWindow'];
+		$this->data['MinMembershipMonths']   = $result['MinMembershipMonths'] ?? 0;
+		$this->data['ProvinceMode']        = $result['ProvinceMode']        ?? false;
+		$this->data['AttendanceMode']      = $result['AttendanceMode']      ?? 'weeks';
+		$this->data['WeekOffset']             = $result['WeekOffset']             ?? 0;
+		$this->data['KingdomEventBonus']      = $result['KingdomEventBonus']      ?? false;
+		$this->data['ActiveKnightThreshold']  = $result['ActiveKnightThreshold']  ?? 0;
+		$this->data['ActiveMemberThreshold']  = $result['ActiveMemberThreshold']  ?? 0;
+		$this->data['ExcludeOnline']          = $result['ExcludeOnline']          ?? false;
+		$this->data['HomeParkOnly']           = $result['HomeParkOnly']           ?? false;
+		$this->data['DaysWindow']             = $result['DaysWindow']             ?? 0;
+		$this->data['MinAge']                 = $result['MinAge']                 ?? 0;
+		$this->data['StartDate']              = $result['StartDate']              ?? '';
+		$this->data['DisplayStartDate']       = $result['DisplayStartDate']       ?? '';
+		$this->data['AllKingdoms']            = $result['AllKingdoms']            ?? false;
+		$this->data['MaxCreditsPerEvent']     = $result['MaxCreditsPerEvent']     ?? 0;
+		$this->data['MaxOutsideKingdomCredits'] = $result['MaxOutsideKingdomCredits'] ?? 0;
+		$this->data['MembershipMode']         = $result['MembershipMode']         ?? '';
+
+		if ($type === 'Park') {
+			$this->data['menu']['reports']['url'] = UIR . 'Park/profile/' . (int)$this->request->id . '&tab=reports';
+		} elseif ($type === 'Kingdom') {
+			$this->data['menu']['reports']['url'] = UIR . 'Kingdom/profile/' . (int)$this->request->id . '&tab=reports';
+		}
+	}
+
 	/**
 	 * Generate all expected period labels between two rounded dates.
 	 */

--- a/orkui/model/model.Reports.php
+++ b/orkui/model/model.Reports.php
@@ -267,6 +267,144 @@ class Model_Reports extends Model {
 		return false;
 	}
 
+	private function _voting_rules($kingdom_id) {
+		$rules = [
+			14 => [ // Celestial Kingdom — Contributing (7+ credits) or Active (12+ credits)
+				'AttendanceRequired'    => 7,
+				'MonthsWindow'          => 6,
+				'MinMembershipMonths'   => 0,
+				'AttendanceMode'        => 'count',
+				'ProvinceMode'          => false,
+				'ActiveMemberThreshold' => 12,
+				'AllKingdoms'           => true,
+			],
+			31 => [ // Nine Blades
+				'AttendanceRequired'  => 6,
+				'MonthsWindow'        => 6,
+				'MinMembershipMonths' => 6,
+				'AttendanceMode'      => 'weeks',
+				'ProvinceMode'        => false,
+			],
+			3 => [ // Iron Mountains — Mon–Sun weeks; 6-month membership required
+				'AttendanceRequired'  => 6,
+				'MonthsWindow'        => 6,
+				'MinMembershipMonths' => 6,
+				'AttendanceMode'      => 'weeks',
+				'ProvinceMode'        => false,
+			],
+			17 => [ // Crystal Groves
+				'AttendanceRequired'    => 6,
+				'MonthsWindow'          => 6,
+				'MinMembershipMonths'   => 6,
+				'AttendanceMode'        => 'count',
+				'ProvinceMode'          => true,
+				'KingdomEventBonus'     => true,
+			],
+			10 => [ // Rising Winds — membership age checked via first attendance date, not park join date
+				'AttendanceRequired'    => 7,
+				'MonthsWindow'          => 6,
+				'MinMembershipMonths'   => 6,
+				'AttendanceMode'        => 'days',
+				'ProvinceMode'          => false,
+				'MembershipMode'        => 'first_attendance',
+				'WeekSnap'              => true,
+			],
+			25 => [ // Viridian Outlands
+				'AttendanceRequired'    => 6,
+				'MonthsWindow'          => 6,
+				'MinMembershipMonths'   => 0,
+				'AttendanceMode'        => 'days',
+				'ProvinceMode'          => false,
+				'WeekSnap'              => true,
+			],
+			20 => [ // Northern Lights — online attendance excluded
+				'AttendanceRequired'    => 6,
+				'MonthsWindow'          => 6,
+				'MinMembershipMonths'   => 0,
+				'AttendanceMode'        => 'days',
+				'ProvinceMode'          => false,
+				'ExcludeOnline'         => true,
+				'WeekSnap'              => true,
+			],
+			36 => [ // Northreach — 180-day window, 12 weeks; age 14+ (not auto-checked, no DOB in DB)
+				'AttendanceRequired'    => 12,
+				'MonthsWindow'          => 0,
+				'DaysWindow'            => 180,
+				'MinMembershipMonths'   => 0,
+				'AttendanceMode'        => 'weeks',
+				'ProvinceMode'          => false,
+				'MinAge'                => 14,
+			],
+			27 => [ // Polaris — Sun–Sat week; 3-month home chapter membership required
+				'AttendanceRequired'    => 6,
+				'MonthsWindow'          => 6,
+				'MinMembershipMonths'   => 3,
+				'AttendanceMode'        => 'weeks',
+				'WeekOffset'            => 6,
+				'ProvinceMode'          => false,
+			],
+			38 => [ // 13 Roads
+				'AttendanceRequired'    => 6,
+				'MonthsWindow'          => 6,
+				'MinMembershipMonths'   => 0,
+				'AttendanceMode'        => 'days',
+				'ProvinceMode'          => false,
+				'WeekSnap'              => true,
+			],
+			4 => [ // Goldenvale — home park sign-ins; 1 kingdom event counts toward the 6
+				'AttendanceRequired'    => 6,
+				'MonthsWindow'          => 6,
+				'MinMembershipMonths'   => 0,
+				'AttendanceMode'        => 'count',
+				'ProvinceMode'          => false,
+				'HomeParkOnly'          => true,
+				'KingdomEventBonus'     => true,
+				'WeekSnap'              => true,
+			],
+			6 => [ // Emerald Hills — Tue–Mon week; Active Knight = voting eligible + 8 raw sign-ins
+				'AttendanceRequired'    => 6,
+				'MonthsWindow'          => 6,
+				'MinMembershipMonths'   => 6,
+				'AttendanceMode'        => 'weeks',
+				'WeekOffset'            => 1,
+				'ProvinceMode'          => false,
+				'ActiveKnightThreshold' => 8,
+			],
+			19 => [ // Tal Dagore — 8 credits/6mo; max 2 from outside kingdom; multi-credit events capped at 2
+				'AttendanceRequired'      => 8,
+				'MonthsWindow'            => 6,
+				'MinMembershipMonths'     => 3,
+				'AttendanceMode'          => 'count',
+				'ProvinceMode'            => false,
+				'MaxCreditsPerEvent'      => 2,
+				'MaxOutsideKingdomCredits'=> 2,
+			],
+		];
+		return $rules[$kingdom_id] ?? null;
+	}
+
+	function get_voting_eligible($type, $id) {
+		$kingdom_id = $type === 'Kingdom' ? (int)$id : 0;
+		$park_id    = $type === 'Park'    ? (int)$id : 0;
+		if ($type === 'Park' && $park_id && !$kingdom_id) {
+			$park = new APIModel('Park');
+			$kingdom_id = (int)$park->GetParkKingdomId($park_id);
+		}
+		$rules = $this->_voting_rules($kingdom_id) ?? [];
+		return $this->Report->GetVotingEligible(array_merge($rules, [
+			'KingdomId' => $kingdom_id,
+			'ParkId'    => $park_id,
+		]));
+	}
+
+	function get_voting_eligible_for_player($mundane_id, $kingdom_id) {
+		$rules = $this->_voting_rules((int)$kingdom_id) ?? [];
+		return $this->Report->GetVotingEligible(array_merge($rules, [
+			'KingdomId' => (int)$kingdom_id,
+			'MundaneId' => (int)$mundane_id,
+		]));
+	}
+
 	function get_kingdom_parks($kingdom_id) {
 		$kingdom = new APIModel('Kingdom');
 		$r = $kingdom->GetParks(array('KingdomId' => $kingdom_id));

--- a/orkui/template/default/Reports_voting_eligible.tpl
+++ b/orkui/template/default/Reports_voting_eligible.tpl
@@ -1,0 +1,561 @@
+<?php
+/* ── Pre-compute stats ────────────────────────────────────── */
+$total_eligible          = 0;
+$total_province_eligible = 0;
+$total_active_knights    = 0;
+$total_active            = 0;
+$unique_parks            = [];
+
+if (!empty($NotSupported)) {
+	$report_title = $page_title ?? 'Voting Eligible Players';
+} else {
+	$Players             = $Players ?? [];
+	$AttendanceRequired    = $AttendanceRequired    ?? 6;
+	$MonthsWindow          = $MonthsWindow          ?? 6;
+	$MinMembershipMonths   = $MinMembershipMonths   ?? 6;
+	$ProvinceMode          = $ProvinceMode          ?? false;
+	$AttendanceMode      = $AttendanceMode      ?? 'weeks';
+	$WeekOffset          = $WeekOffset          ?? 0;
+	$KingdomEventBonus       = $KingdomEventBonus       ?? false;
+	$ActiveKnightThreshold   = $ActiveKnightThreshold   ?? 0;
+	$ActiveMemberThreshold   = $ActiveMemberThreshold   ?? 0;
+	$ExcludeOnline           = $ExcludeOnline           ?? false;
+	$HomeParkOnly            = $HomeParkOnly            ?? false;
+	$DaysWindow              = $DaysWindow              ?? 0;
+	$MinAge                  = $MinAge                  ?? 0;
+	$AllKingdoms             = $AllKingdoms             ?? false;
+	$MaxCreditsPerEvent      = $MaxCreditsPerEvent      ?? 0;
+	$MaxOutsideKingdomCredits= $MaxOutsideKingdomCredits?? 0;
+	$MembershipMode          = $MembershipMode          ?? '';
+	$MemberSinceLabel        = $MembershipMode === 'first_attendance' ? 'First Attendance' : 'Member Since';
+	// Window label for column headers (e.g. "6mo" or "180d") and phrase for descriptions.
+	$WindowLabel  = $DaysWindow > 0 ? $DaysWindow . 'd'      : $MonthsWindow . 'mo';
+	$WindowPhrase = $DaysWindow > 0 ? $DaysWindow . ' days'  : $MonthsWindow . ' months';
+	$AttendanceLabel     = $HomeParkOnly ? 'Park Sign-ins' : ($AttendanceMode === 'count' ? 'Sign-ins' : ($AttendanceMode === 'days' ? 'Days' : 'Weeks'));
+	// Human-readable week period label (e.g. "Mon–Sun" or "Tue–Mon")
+	$_days = ['Mon','Tue','Wed','Thu','Fri','Sat','Sun'];
+	$_startDay = $_days[$WeekOffset % 7];
+	$_endDay   = $_days[($WeekOffset + 6) % 7];
+	$WeekPeriodLabel = $_startDay . '–' . $_endDay;
+	// Attendance window date span
+	$_fmt_span_date = function($ts, $weekOffset) {
+		$d    = (int)date('j', $ts);
+		if ($d % 10 == 1 && $d % 100 != 11)      $sfx = 'st';
+		elseif ($d % 10 == 2 && $d % 100 != 12)  $sfx = 'nd';
+		elseif ($d % 10 == 3 && $d % 100 != 13)  $sfx = 'rd';
+		else                                       $sfx = 'th';
+		$week = (int)date('W', $ts - $weekOffset * 86400);
+		return date('D M ', $ts) . $d . $sfx . date(', Y', $ts) . ' Week ' . $week;
+	};
+	// DisplayStartDate: raw date for header (e.g. actual 180-day mark for DaysWindow).
+	// StartDate: SQL-snapped date (may differ for DaysWindow+weeks — snapped to week start).
+	$StartDate        = $StartDate        ?? '';
+	$DisplayStartDate = $DisplayStartDate ?? $StartDate;
+	$_display_ts = !empty($DisplayStartDate) ? strtotime($DisplayStartDate)
+	             : ($DaysWindow > 0 ? strtotime("-{$DaysWindow} days") : strtotime('-' . $MonthsWindow . ' months'));
+	$AttendanceSpan = 'Attendance from ' . $_fmt_span_date($_display_ts, $WeekOffset)
+	                . ' to ' . $_fmt_span_date(time(), $WeekOffset);
+	$total_active_members = 0;
+	foreach ($Players as $p) {
+		$total_active++;
+		if (!empty($p['VotingEligible'])) $total_eligible++;
+		if ($ProvinceMode && !empty($p['ProvinceEligible'])) $total_province_eligible++;
+		if ($ActiveKnightThreshold > 0 && !empty($p['ActiveKnight'])) $total_active_knights++;
+		if ($ActiveMemberThreshold > 0 && !empty($p['ActiveMember'])) $total_active_members++;
+		if (!empty($p['ParkId'])) $unique_parks[$p['ParkId']] = true;
+	}
+	$report_title = $page_title ?? 'Voting Eligible Players';
+}
+
+/* Scope chip */
+$scope_label = '';
+$scope_link  = '';
+$scope_icon  = 'fa-globe';
+if (!empty($Players)) {
+	$first = reset($Players);
+	if (isset($this->__session->park_id) && !empty($this->__session->park_id)) {
+		$scope_label = $first['ParkName'] ?? '';
+		$scope_link  = UIR . 'Park/profile/' . (int)$this->__session->park_id;
+		$scope_icon  = 'fa-tree';
+	} elseif (isset($this->__session->kingdom_id) && !empty($this->__session->kingdom_id)) {
+		$scope_label = $first['KingdomName'] ?? '';
+		$scope_link  = UIR . 'Kingdom/profile/' . (int)$this->__session->kingdom_id;
+		$scope_icon  = 'fa-chess-rook';
+	}
+}
+?>
+
+<link rel="stylesheet" href="https://cdn.datatables.net/1.13.8/css/jquery.dataTables.min.css">
+<link rel="stylesheet" href="https://cdn.datatables.net/buttons/2.4.2/css/buttons.dataTables.min.css">
+<link rel="stylesheet" href="<?=HTTP_TEMPLATE?>default/style/reports.css?v=<?=filemtime(__DIR__.'/style/reports.css')?>">
+
+<style>
+.rp-table-area table.dataTable tbody tr.rp-row-eligible > td { background-color: #f0fff4; }
+.rp-table-area table.dataTable tbody tr.rp-row-eligible:hover > td { background-color: #e6ffed; }
+.rp-table-area table.dataTable tbody tr.rp-row-active-member > td { background-color: #ebf8ff; }
+.rp-table-area table.dataTable tbody tr.rp-row-active-member:hover > td { background-color: #dbeafe; }
+.rp-check { color: #276749; font-weight: 600; }
+.rp-cross { color: #c53030; font-weight: 600; }
+.rp-warn  { color: #c05621; font-weight: 600; }
+.rp-not-supported {
+	background: #f7fafc; border: 1px solid #e2e8f0; border-radius: 8px;
+	padding: 40px 32px; text-align: center; color: #718096; margin: 24px 0;
+}
+.rp-not-supported i { font-size: 2rem; margin-bottom: 12px; display: block; color: #a0aec0; }
+.rp-not-supported h3 { margin: 0 0 8px; color: #4a5568; font-size: 1.1rem; }
+.rp-not-supported p  { margin: 0; font-size: 0.9rem; }
+</style>
+
+<div class="rp-root">
+
+	<!-- ── Header ─────────────────────────────────────────── -->
+	<div class="rp-header">
+		<div class="rp-header-left">
+			<div class="rp-header-icon-title">
+				<i class="fas fa-vote-yea rp-header-icon"></i>
+				<h1 class="rp-header-title"><?=htmlspecialchars($report_title)?></h1>
+			</div>
+<?php if ($scope_label) : ?>
+			<div class="rp-header-scope">
+				<a class="rp-scope-chip" href="<?=$scope_link?>">
+					<i class="fas <?=$scope_icon?>"></i>
+					<?=htmlspecialchars($scope_label)?>
+				</a>
+			</div>
+<?php endif; ?>
+		</div>
+<?php if (empty($NotSupported)) : ?>
+		<div class="rp-header-actions">
+			<button class="rp-btn-ghost rp-btn-export"><i class="fas fa-download"></i> Export CSV</button>
+			<button class="rp-btn-ghost rp-btn-print"><i class="fas fa-print"></i> Print</button>
+		</div>
+<?php endif; ?>
+	</div>
+
+<?php if (!empty($NotSupported)) : ?>
+
+	<div class="rp-not-supported">
+		<i class="fas fa-info-circle"></i>
+		<h3>Not Available for This Kingdom</h3>
+		<p>Voting eligibility reporting has not been configured for this kingdom.</p>
+	</div>
+
+<?php else : ?>
+
+	<!-- ── Context strip ──────────────────────────────────── -->
+	<div class="rp-context">
+		<i class="fas fa-info-circle rp-context-icon"></i>
+		<span>
+			<span style="display:block;font-size:0.85em;opacity:0.75;margin-bottom:4px;"><?=$AttendanceSpan?></span>
+			<?php if ($ProvinceMode): ?>
+			Eligibility requires: signed waiver &bull; current dues<?=$MinMembershipMonths > 0 ? ' &bull; chapter membership for at least ' . $MinMembershipMonths . ' months' . ($MembershipMode === 'first_attendance' ? ' (using first attendance in Kingdom)' : '') : ''?>.
+				<strong>Kingdom:</strong> <?=$AttendanceRequired?>+ sign-ins anywhere in the Kingdom in the last <?=$WindowPhrase?><?=$KingdomEventBonus ? ' (attending a Kingdom-sponsored event counts as +1, once)' : ''?>.
+				<strong>Provincial:</strong> <?=$AttendanceRequired?>+ sign-ins at home park in the last <?=$WindowPhrase?>. Provincial eligibility implies Kingdom eligibility.
+			<?php elseif ($HomeParkOnly): ?>
+			Eligibility requires: signed waiver &bull; current dues &bull; <?=$AttendanceRequired?>+ sign-ins at home park in the last <?=$WindowPhrase?><?=$KingdomEventBonus ? ' (attending a Kingdom-sponsored event counts as +1, once)' : ''?><?=$MinMembershipMonths > 0 ? ' &bull; chapter membership for at least ' . $MinMembershipMonths . ' months' . ($MembershipMode === 'first_attendance' ? ' (using first attendance in Kingdom)' : '') : ''?>.
+			<?php else: ?>
+			<?php if ($ActiveMemberThreshold > 0): ?>
+			Requires signed waiver &bull; current dues &bull; <?=$AttendanceRequired?>+ <?=$AttendanceMode === 'days' ? 'calendar days' : ($AttendanceMode === 'count' ? 'sign-ins' : $WeekPeriodLabel . ' attendance weeks')?> in the last <?=$WindowPhrase?> <?=$AllKingdoms ? 'at any Amtgard event' : 'anywhere in the Kingdom'?> = <strong>Contributing Member</strong>. <?=$ActiveMemberThreshold?>+ = <strong>Active Member</strong>.
+			<?php elseif ($MaxOutsideKingdomCredits > 0): ?>
+			Eligibility requires: signed waiver &bull; current dues &bull; <?=$AttendanceRequired?>+ attendance credits in the last <?=$WindowPhrase?> (at most <?=$MaxOutsideKingdomCredits?> credits from outside the Kingdom<?=$MaxCreditsPerEvent > 0 ? '; multi-credit events capped at ' . $MaxCreditsPerEvent . ' credits per event' : ''?>)<?=$MinMembershipMonths > 0 ? ' &bull; province membership for at least ' . $MinMembershipMonths . ' months' : ''?>.
+			<?php else: ?>
+			Eligibility requires: signed waiver &bull; current dues &bull; <?=$AttendanceRequired?>+ distinct <?=$AttendanceMode === 'days' ? 'calendar days' : ($AttendanceMode === 'count' ? 'sign-ins' : $WeekPeriodLabel . ' attendance weeks')?> in the last <?=$WindowPhrase?> (anywhere in the Kingdom)<?=$MinMembershipMonths > 0 ? ' &bull; chapter membership for at least ' . $MinMembershipMonths . ' months' . ($MembershipMode === 'first_attendance' ? ' (using first attendance in Kingdom)' : '') : ''?>.<?php if ($ExcludeOnline): ?> Events that include "Online" in the event name are not included in attendance.<?php endif; ?><?php if ($ActiveKnightThreshold > 0): ?> <strong>Active Knight</strong> additionally requires being a Knight with <?=$ActiveKnightThreshold?>+ total sign-ins in the same period.<?php endif; ?><?php if ($MinAge > 0): ?> <strong>Note:</strong> Players must also be <?=$MinAge?>+ years of age — this cannot be checked automatically and must be verified separately.<?php endif; ?>
+			<?php endif; ?>
+			<?php endif; ?>
+		</span>
+	</div>
+
+	<!-- ── Stats row ──────────────────────────────────────── -->
+	<div class="rp-stats-row">
+		<div class="rp-stat-card">
+			<div class="rp-stat-icon"><i class="fas fa-vote-yea"></i></div>
+			<div class="rp-stat-number"><?=$total_eligible?></div>
+			<div class="rp-stat-label"><?=$ActiveMemberThreshold > 0 ? 'Contributing+' : ($ProvinceMode ? 'Kingdom Eligible' : 'Eligible Voters')?></div>
+		</div>
+<?php if ($ActiveMemberThreshold > 0) : ?>
+		<div class="rp-stat-card">
+			<div class="rp-stat-icon"><i class="fas fa-star"></i></div>
+			<div class="rp-stat-number"><?=$total_active_members?></div>
+			<div class="rp-stat-label">Active Members</div>
+		</div>
+<?php endif; ?>
+<?php if ($ProvinceMode) : ?>
+		<div class="rp-stat-card">
+			<div class="rp-stat-icon"><i class="fas fa-map-marker-alt"></i></div>
+			<div class="rp-stat-number"><?=$total_province_eligible?></div>
+			<div class="rp-stat-label">Province Eligible</div>
+		</div>
+<?php endif; ?>
+<?php if ($ActiveKnightThreshold > 0) : ?>
+		<div class="rp-stat-card">
+			<div class="rp-stat-icon"><i class="fas fa-chess-knight"></i></div>
+			<div class="rp-stat-number"><?=$total_active_knights?></div>
+			<div class="rp-stat-label">Active Knights</div>
+		</div>
+<?php endif; ?>
+		<div class="rp-stat-card">
+			<div class="rp-stat-icon"><i class="fas fa-users"></i></div>
+			<div class="rp-stat-number"><?=$total_active?></div>
+			<div class="rp-stat-label">Active Players</div>
+		</div>
+<?php if (!isset($this->__session->park_id)) : ?>
+		<div class="rp-stat-card">
+			<div class="rp-stat-icon"><i class="fas fa-tree"></i></div>
+			<div class="rp-stat-number"><?=count($unique_parks)?></div>
+			<div class="rp-stat-label">Parks Represented</div>
+		</div>
+<?php endif; ?>
+		<div class="rp-stat-card">
+			<div class="rp-stat-icon"><i class="fas fa-percentage"></i></div>
+			<div class="rp-stat-number"><?=($total_active > 0 ? round(100 * $total_eligible / $total_active) : 0)?>%</div>
+			<div class="rp-stat-label">Eligibility Rate</div>
+		</div>
+	</div>
+
+	<!-- ── Body: sidebar + table ──────────────────────────── -->
+	<div class="rp-body">
+
+		<!-- Sidebar -->
+		<div class="rp-sidebar">
+
+			<div class="rp-filter-card">
+				<div class="rp-filter-card-header">
+					<i class="fas fa-filter"></i> Filters
+				</div>
+				<div class="rp-filter-card-body">
+					<div class="rp-filter-pills" id="ve-filter-pills">
+						<span class="rp-filter-pill" data-filter="eligible">Eligible Only</span>
+						<span class="rp-filter-pill" data-filter="not-eligible">Non-Eligible Only</span>
+<?php if ($ActiveKnightThreshold > 0) : ?>
+						<span class="rp-filter-pill" data-filter="active-knight">Active Knights Only</span>
+<?php endif; ?>
+					</div>
+				</div>
+			</div>
+
+			<div class="rp-filter-card">
+				<div class="rp-filter-card-header">
+					<i class="fas fa-table"></i> Column Guide
+				</div>
+				<div class="rp-filter-card-body">
+<?php if (!isset($this->__session->park_id)) : ?>
+					<div class="rp-col-guide-item">
+						<span class="rp-col-guide-name">Park</span>
+						<span class="rp-col-guide-desc">The player's home park.</span>
+					</div>
+<?php endif; ?>
+					<div class="rp-col-guide-item">
+						<span class="rp-col-guide-name">Persona</span>
+						<span class="rp-col-guide-desc">Links to the player's profile.</span>
+					</div>
+<?php if ($ProvinceMode) : ?>
+					<div class="rp-col-guide-item">
+						<span class="rp-col-guide-name">Kingdom</span>
+						<span class="rp-col-guide-desc">Eligible to vote in kingdom-wide matters. Requires <?=$AttendanceRequired?>+ sign-ins anywhere in the Kingdom in the last <?=$WindowPhrase?>, plus waiver, dues, and chapter membership age.</span>
+					</div>
+					<div class="rp-col-guide-item">
+						<span class="rp-col-guide-name">Province</span>
+						<span class="rp-col-guide-desc">Eligible to vote in home-park (provincial) matters. Requires <?=$AttendanceRequired?>+ sign-ins at home park in the last <?=$WindowPhrase?>. Province eligibility implies Kingdom eligibility.</span>
+					</div>
+<?php else : ?>
+					<div class="rp-col-guide-item">
+						<span class="rp-col-guide-name">Eligible</span>
+						<span class="rp-col-guide-desc">All criteria met.</span>
+					</div>
+<?php endif; ?>
+<?php if ($ActiveKnightThreshold > 0) : ?>
+					<div class="rp-col-guide-item">
+						<span class="rp-col-guide-name">Active Knight</span>
+						<span class="rp-col-guide-desc">Voting eligible + <?=$ActiveKnightThreshold?>+ total sign-ins in the last <?=$WindowPhrase?>. Amber shows count when close but not yet there.</span>
+					</div>
+<?php endif; ?>
+					<div class="rp-col-guide-item">
+						<span class="rp-col-guide-name">Waiver</span>
+						<span class="rp-col-guide-desc">Whether a signed waiver is on file.</span>
+					</div>
+					<div class="rp-col-guide-item">
+						<span class="rp-col-guide-name">Dues</span>
+						<span class="rp-col-guide-desc">Current dues status and expiry date.</span>
+					</div>
+<?php if ($ProvinceMode) : ?>
+					<div class="rp-col-guide-item">
+						<span class="rp-col-guide-name">Kingdom Sign-ins (<?=$WindowLabel?>)</span>
+						<span class="rp-col-guide-desc">Total sign-ins anywhere in the Kingdom in the last <?=$WindowPhrase?><?=$KingdomEventBonus ? '. Attending a Kingdom-sponsored event counts as +1 (once, regardless of how many events attended)' : ''?>. Needs <?=$AttendanceRequired?>+.</span>
+					</div>
+					<div class="rp-col-guide-item">
+						<span class="rp-col-guide-name">Home Park Sign-ins (<?=$WindowLabel?>)</span>
+						<span class="rp-col-guide-desc">Sign-ins at the player's home park in the last <?=$WindowPhrase?>. Needs <?=$AttendanceRequired?>+ for Provincial eligibility.</span>
+					</div>
+<?php elseif ($HomeParkOnly) : ?>
+					<div class="rp-col-guide-item">
+						<span class="rp-col-guide-name"><?=$AttendanceLabel?> (<?=$WindowLabel?>)</span>
+						<span class="rp-col-guide-desc">Sign-ins at the player's home park in the last <?=$WindowPhrase?><?=$KingdomEventBonus ? '. Attending a Kingdom-sponsored event counts as +1 (once)' : ''?>. Needs <?=$AttendanceRequired?>+.</span>
+					</div>
+<?php else : ?>
+					<div class="rp-col-guide-item">
+						<span class="rp-col-guide-name"><?=$AttendanceLabel?> (<?=$WindowLabel?>)</span>
+						<span class="rp-col-guide-desc"><?=$AttendanceMode === 'count' ? 'Total sign-ins' : ($AttendanceMode === 'days' ? 'Distinct calendar days attended' : 'Distinct ' . $WeekPeriodLabel . ' weeks attended')?> <?=$AllKingdoms ? 'at any Amtgard event' : 'anywhere in the Kingdom'?> in the last <?=$WindowPhrase?>. Needs <?=$AttendanceRequired?>+.</span>
+					</div>
+<?php endif; ?>
+<?php if ($HomeParkOnly && $KingdomEventBonus) : ?>
+					<div class="rp-col-guide-item">
+						<span class="rp-col-guide-name">KE Credit</span>
+						<span class="rp-col-guide-desc">Whether the player attended at least one Kingdom-sponsored event in the period. Counts as +1 toward the <?=$AttendanceRequired?> required sign-ins.</span>
+					</div>
+<?php endif; ?>
+<?php if ($MaxOutsideKingdomCredits > 0) : ?>
+					<div class="rp-col-guide-item">
+						<span class="rp-col-guide-name">Outside Credits</span>
+						<span class="rp-col-guide-desc">Attendance credits earned outside the Kingdom. At most <?=$MaxOutsideKingdomCredits?> of these count toward the <?=$AttendanceRequired?> required<?=$MaxCreditsPerEvent > 0 ? '. Events (multi-session) are capped at ' . $MaxCreditsPerEvent . ' credits each' : ''?>. Shown in amber when the cap is reached.</span>
+					</div>
+<?php endif; ?>
+					<div class="rp-col-guide-item">
+						<span class="rp-col-guide-name"><?=$MemberSinceLabel?></span>
+						<span class="rp-col-guide-desc"><?=$MembershipMode === 'first_attendance' ? 'Date of first attendance in the Kingdom.' : 'Date first registered.'?><?=$MinMembershipMonths > 0 ? ' Must be ' . $MinMembershipMonths . '+ months ago' . ($MembershipMode === 'first_attendance' ? ' (using first attendance in Kingdom).' : '.') : ''?></span>
+					</div>
+				</div>
+			</div>
+
+		</div><!-- /rp-sidebar -->
+
+		<!-- Table area -->
+		<div class="rp-table-area">
+			<div id="ve-loading" style="text-align:center;padding:40px 0;">
+				<i class="fas fa-spinner fa-spin fa-2x" style="color:#999;"></i>
+			</div>
+			<div id="ve-table-wrap" style="opacity:0;">
+			<table id="ve-report-table" class="display" style="width:100%">
+				<thead>
+					<tr>
+<?php if (!isset($this->__session->park_id)) : ?>
+						<th>Park</th>
+<?php endif; ?>
+						<th>Persona</th>
+<?php if ($ProvinceMode) : ?>
+						<th>Kingdom</th>
+						<th>Province</th>
+<?php elseif ($ActiveMemberThreshold > 0) : ?>
+						<th>Member Tier</th>
+<?php else : ?>
+						<th>Eligible</th>
+<?php endif; ?>
+<?php if ($ActiveKnightThreshold > 0) : ?>
+						<th>Active Knight</th>
+<?php endif; ?>
+						<th>Waiver</th>
+						<th>Dues</th>
+<?php if ($ProvinceMode) : ?>
+						<th>Kingdom Sign-ins (<?=$WindowLabel?>)</th>
+						<th>Home Park Sign-ins (<?=$WindowLabel?>)</th>
+<?php else : ?>
+						<th><?=$AttendanceLabel?> (<?=$WindowLabel?>)</th>
+<?php endif; ?>
+<?php if ($HomeParkOnly && $KingdomEventBonus) : ?>
+						<th>KE Credit</th>
+<?php endif; ?>
+<?php if ($MaxOutsideKingdomCredits > 0) : ?>
+						<th>Outside Credits</th>
+<?php endif; ?>
+						<th><?=$MemberSinceLabel?></th>
+					</tr>
+				</thead>
+				<tbody>
+<?php foreach ($Players as $p) :
+	$rowClass   = !empty($p['Suspended']) ? 'rp-row-suspended'
+	            : (!empty($p['ActiveMember']) ? 'rp-row-active-member'
+	            : (!empty($p['VotingEligible']) ? 'rp-row-eligible' : ''));
+	$waiverHtml = $p['Waivered']
+		? '<span class="rp-check"><i class="fas fa-check"></i> Yes</span>'
+		: '<span class="rp-cross"><i class="fas fa-times"></i> No</span>';
+
+	if ($p['DuesPaid']) {
+		$duesDisplay = $p['DuesUntil'] === '9999-12-31'
+			? '<span class="rp-check"><i class="fas fa-check"></i> For Life</span>'
+			: '<span class="rp-check"><i class="fas fa-check"></i> Until ' . htmlspecialchars($p['DuesUntil']) . '</span>';
+	} else {
+		$duesDisplay = '<span class="rp-cross"><i class="fas fa-times"></i> No</span>';
+	}
+
+	$attNum   = (int)$p['AttCount'];
+	$attReq   = (int)$AttendanceRequired;
+	if ($attNum >= $attReq) {
+		$attHtml = '<span class="rp-check">' . $attNum . '</span>';
+	} elseif ($attNum >= $attReq - 2) {
+		$attHtml = '<span class="rp-warn">' . $attNum . '</span>';
+	} else {
+		$attHtml = '<span class="rp-cross">' . $attNum . '</span>';
+	}
+
+	if ($ProvinceMode) {
+		$parkAttNum = (int)($p['ParkAttCount'] ?? 0);
+		if ($parkAttNum >= $attReq) {
+			$parkAttHtml = '<span class="rp-check">' . $parkAttNum . '</span>';
+		} elseif ($parkAttNum >= $attReq - 2) {
+			$parkAttHtml = '<span class="rp-warn">' . $parkAttNum . '</span>';
+		} else {
+			$parkAttHtml = '<span class="rp-cross">' . $parkAttNum . '</span>';
+		}
+	}
+
+	$memberSince = $p['MemberSince'] ?? '';
+	if (!$memberSince || $memberSince === '0000-00-00') {
+		$memberHtml = '<span class="rp-check">Unknown</span>';
+	} elseif (!$p['MembershipOk']) {
+		$memberHtml = '<span class="rp-cross">' . htmlspecialchars($memberSince) . '</span>';
+	} else {
+		$memberHtml = htmlspecialchars($memberSince);
+	}
+
+	if ($ProvinceMode) {
+		$kingdomEligibleHtml  = !empty($p['KingdomEligible'])
+			? '<span class="rp-check"><i class="fas fa-check-circle"></i> Yes</span>'
+			: '<span style="color:#a0aec0;"><i class="fas fa-times-circle"></i> No</span>';
+		$provinceEligibleHtml = !empty($p['ProvinceEligible'])
+			? '<span class="rp-check"><i class="fas fa-check-circle"></i> Yes</span>'
+			: '<span style="color:#a0aec0;"><i class="fas fa-times-circle"></i> No</span>';
+	} elseif ($ActiveMemberThreshold > 0) {
+		if (!empty($p['ActiveMember'])) {
+			$eligibleHtml = '<span class="rp-check" style="color:#2b6cb0;"><i class="fas fa-star"></i> Active</span>';
+		} elseif (!empty($p['VotingEligible'])) {
+			$eligibleHtml = '<span class="rp-check"><i class="fas fa-check-circle"></i> Contributing</span>';
+		} else {
+			$eligibleHtml = '<span style="color:#a0aec0;"><i class="fas fa-times-circle"></i> —</span>';
+		}
+	} else {
+		$eligibleHtml = !empty($p['VotingEligible'])
+			? '<span class="rp-check"><i class="fas fa-check-circle"></i> Yes</span>'
+			: '<span style="color:#a0aec0;"><i class="fas fa-times-circle"></i> No</span>';
+	}
+
+	if ($ActiveKnightThreshold > 0) {
+		$rawCount  = (int)($p['RawAttCount'] ?? 0);
+		$akReq     = (int)$ActiveKnightThreshold;
+		$isKnight  = !empty($p['IsKnight']);
+		if (!empty($p['ActiveKnight'])) {
+			$activeKnightHtml = '<span class="rp-check"><i class="fas fa-chess-knight"></i> Yes</span>';
+		} elseif ($isKnight && !empty($p['VotingEligible']) && $rawCount >= $akReq - 2) {
+			// Knight, voting eligible, but just short on raw sign-ins — show progress
+			$activeKnightHtml = '<span class="rp-warn"><i class="fas fa-chess-knight"></i> ' . $rawCount . '/' . $akReq . '</span>';
+		} elseif (!$isKnight) {
+			$activeKnightHtml = '<span style="color:#a0aec0;">—</span>';
+		} else {
+			$activeKnightHtml = '<span style="color:#a0aec0;"><i class="fas fa-times-circle"></i> No</span>';
+		}
+	}
+?>
+				<tr class="<?=$rowClass?>"
+				data-eligible="<?=!empty($p['VotingEligible'])?'1':'0'?>"
+				data-waivered="<?=$p['Waivered']?'1':'0'?>"
+				data-dues="<?=$p['DuesPaid']?'1':'0'?>"
+				data-att="<?=(int)$p['AttCount']?>"
+				data-suspended="<?=!empty($p['Suspended'])?'1':'0'?>"
+				data-active-knight="<?=!empty($p['ActiveKnight'])?'1':'0'?>">
+<?php if (!isset($this->__session->park_id)) : ?>
+					<td><a href='<?=UIR.'Park/profile/'.$p['ParkId']?>'><?=htmlspecialchars($p['ParkName'])?></a></td>
+<?php endif; ?>
+					<td>
+						<a href='<?=UIR.'Player/profile/'.$p['MundaneId']?>'><?=htmlspecialchars($p['Persona'])?></a>
+<?php if (!empty($p['Suspended'])) :
+	$_until = $p['SuspendedUntil'] ?? '';
+	$_until_str = ($_until && $_until !== '0000-00-00') ? ' until ' . htmlspecialchars($_until) : '';
+?>
+						<span style="font-size:11px;font-weight:600;color:#c53030;margin-left:6px;"><i class="fas fa-ban"></i> Suspended<?=$_until_str?></span>
+<?php endif; ?>
+					</td>
+<?php if ($ProvinceMode) : ?>
+					<td><?=$kingdomEligibleHtml?></td>
+					<td><?=$provinceEligibleHtml?></td>
+<?php else : ?>
+					<td><?=$eligibleHtml?></td>
+<?php endif; ?>
+<?php if ($ActiveKnightThreshold > 0) : ?>
+					<td><?=$activeKnightHtml?></td>
+<?php endif; ?>
+					<td><?=$waiverHtml?></td>
+					<td><?=$duesDisplay?></td>
+<?php if ($ProvinceMode) : ?>
+					<td><?=$attHtml?></td>
+					<td><?=$parkAttHtml?></td>
+<?php else : ?>
+					<td><?=$attHtml?></td>
+<?php endif; ?>
+<?php if ($HomeParkOnly && $KingdomEventBonus) : ?>
+					<td><?= !empty($p['KingdomEventCredit']) ? '<span class="rp-check"><i class="fas fa-check"></i> Yes</span>' : '<span style="opacity:0.4">—</span>' ?></td>
+<?php endif; ?>
+<?php if ($MaxOutsideKingdomCredits > 0) : ?>
+					<?php $_outCr = (int)($p['OutsideCredits'] ?? 0); ?>
+					<td<?= $_outCr >= $MaxOutsideKingdomCredits ? ' style="color:#b7791f;font-weight:600;"' : '' ?>><?= $_outCr ?> / <?=$MaxOutsideKingdomCredits?></td>
+<?php endif; ?>
+					<td><?=$memberHtml?></td>
+				</tr>
+<?php endforeach; ?>
+				</tbody>
+			</table>
+			</div><!-- /ve-table-wrap -->
+		</div><!-- /rp-table-area -->
+
+	</div><!-- /rp-body -->
+
+<?php endif; ?>
+
+</div><!-- /rp-root -->
+
+
+<script src="https://cdn.datatables.net/1.13.8/js/jquery.dataTables.min.js"></script>
+<script src="https://cdn.datatables.net/buttons/2.4.2/js/dataTables.buttons.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/jszip/3.10.1/jszip.min.js"></script>
+<script src="https://cdn.datatables.net/buttons/2.4.2/js/buttons.html5.min.js"></script>
+<script src="https://cdn.datatables.net/buttons/2.4.2/js/buttons.print.min.js"></script>
+
+<?php if (empty($NotSupported)) : ?>
+<script>
+$(function() {
+	var activeFilter = null;
+
+	$.fn.dataTable.ext.search.push(function(settings, data, dataIndex) {
+		if (settings.nTable.id !== 've-report-table') return true;
+		if (!activeFilter) return true;
+		var $tr = $(settings.aoData[dataIndex].nTr);
+		if (activeFilter === 'eligible')      return $tr.data('eligible') == 1;
+		if (activeFilter === 'not-eligible')  return $tr.data('eligible') == 0;
+		if (activeFilter === 'active-knight') return $tr.data('active-knight') == 1;
+		return true;
+	});
+
+	var table = $('#ve-report-table').DataTable({
+		dom: 'lfrtip',
+		buttons: [
+			{ extend: 'csv',   filename: '<?=addslashes($report_title)?>', exportOptions: { columns: ':visible' } },
+			{ extend: 'print', exportOptions: { columns: ':visible' } }
+		],
+		columnDefs: [
+			{ targets: [0], responsivePriority: 1 }
+		],
+		pageLength: 50,
+		lengthMenu: [[25, 50, 100, -1], [25, 50, 100, 'All']],
+		order: [[0, 'asc']],
+		scrollX: true,
+		initComplete: function() {
+			$('#ve-loading').hide();
+			$('#ve-table-wrap').css('opacity', 1);
+		}
+	});
+
+	$('#ve-filter-pills .rp-filter-pill').on('click', function() {
+		var filter = $(this).data('filter');
+		if (activeFilter === filter) {
+			activeFilter = null;
+			$(this).removeClass('active');
+		} else {
+			activeFilter = filter;
+			$('#ve-filter-pills .rp-filter-pill').removeClass('active');
+			$(this).addClass('active');
+		}
+		table.draw();
+	});
+
+	$('.rp-btn-export').on('click', function() { table.button(0).trigger(); });
+	$('.rp-btn-print' ).on('click', function() { table.button(1).trigger(); });
+});
+</script>
+<?php endif; ?>

--- a/orkui/template/revised-frontend/Kingdomnew_index.tpl
+++ b/orkui/template/revised-frontend/Kingdomnew_index.tpl
@@ -616,6 +616,7 @@
 							<li><a href="<?= UIR ?>Reports/suspended/Kingdom&id=<?= $kingdom_id ?>">Suspended</a></li>
 							<li><a href="<?= UIR ?>Reports/active_duespaid/Kingdom&id=<?= $kingdom_id ?>">Player Attendance</a></li>
 							<li><a href="<?= UIR ?>Reports/active_waivered_duespaid/Kingdom&id=<?= $kingdom_id ?>">Waivered Attendance</a></li>
+							<?php if (in_array((int)$kingdom_id, [3, 4, 6, 10, 14, 17, 19, 20, 25, 27, 31, 36, 38])): ?><li><a href="<?= UIR ?>Reports/voting_eligible/Kingdom&id=<?= $kingdom_id ?>">Voting Eligible</a></li><?php endif; ?>
 							<li><a href="<?= UIR ?>Reports/reeve/Kingdom&id=<?= $kingdom_id ?>">Reeve Qualified</a></li>
 							<li><a href="<?= UIR ?>Reports/corpora/Kingdom&id=<?= $kingdom_id ?>">Corpora Qualified</a></li>
 							<li><a href="<?= UIR ?>Reports/player_status_reconciliation/Kingdom&id=<?= $kingdom_id ?>">Player Status Reconciliation</a></li>

--- a/orkui/template/revised-frontend/Parknew_index.tpl
+++ b/orkui/template/revised-frontend/Parknew_index.tpl
@@ -980,6 +980,7 @@
 							<li><a href="<?= UIR ?>Reports/suspended/Park&id=<?= $park_id ?>">Suspended Players</a></li>
 							<li><a href="<?= UIR ?>Reports/active_duespaid/Park&id=<?= $park_id ?>">Player Attendance</a></li>
 							<li><a href="<?= UIR ?>Reports/active_waivered_duespaid/Park&id=<?= $park_id ?>">Waivered Attendance</a></li>
+							<?php if (in_array((int)$kingdom_id, [3, 4, 6, 10, 14, 17, 19, 20, 25, 27, 31, 36, 38])): ?><li><a href="<?= UIR ?>Reports/voting_eligible/Park&id=<?= $park_id ?>">Voting Eligible</a></li><?php endif; ?>
 							<li><a href="<?= UIR ?>Reports/reeve&KingdomId=<?= $kingdom_id ?>&ParkId=<?= $park_id ?>">Reeve Qualified</a></li>
 							<li><a href="<?= UIR ?>Reports/corpora&KingdomId=<?= $kingdom_id ?>&ParkId=<?= $park_id ?>">Corpora Qualified</a></li>
 							<li><a href="<?= UIR ?>Reports/player_status_reconciliation/Park&id=<?= $park_id ?>">Player Status Reconciliation</a></li>

--- a/orkui/template/revised-frontend/Playernew_index.tpl
+++ b/orkui/template/revised-frontend/Playernew_index.tpl
@@ -330,6 +330,18 @@
 				<?php else: ?>
 					<span class="pn-badge pn-badge-gray"><i class="fas fa-receipt"></i> No Dues on File</span>
 				<?php endif; ?>
+				<?php if (!empty($VotingEligible)): ?>
+					<span class="pn-badge pn-badge-blue"><i class="fas fa-vote-yea"></i> Voting Eligible<?php
+						if (!empty($VotingProvinceMode)):
+							?> <span class="pn-badge-sub"><?= !empty($VotingProvinceEligible) ? 'Province &amp; Kingdom' : 'Kingdom' ?></span><?php
+						elseif (!empty($ActiveKnight)):
+							?> <span class="pn-badge-sub">Active Knight</span><?php
+						elseif ($ActiveMember === true):
+							?> <span class="pn-badge-sub">Active Member</span><?php
+						elseif ($ActiveMember === false && isset($ActiveMember)):
+							?> <span class="pn-badge-sub">Contributing</span><?php
+						endif; ?></span>
+				<?php endif; ?>
 				<?php if (!empty($OfficerRoles)): ?>
 					<?php foreach ($OfficerRoles as $office): ?>
 						<span class="pn-badge pn-badge-gold"><i class="fas fa-crown"></i> <?= htmlspecialchars($office['entity_type']) ?> <?= htmlspecialchars($office['role']) ?></span>

--- a/orkui/template/revised-frontend/style/revised.css
+++ b/orkui/template/revised-frontend/style/revised.css
@@ -121,6 +121,7 @@
 .pn-badge-purple { background: #e9d8fd; color: #553c9a; }
 .pn-badge-gold   { background: #fefcbf; color: #744210; }
 .pn-badge-yellow { background: #fef08a; color: #92400e; }
+.pn-badge-sub    { opacity: 0.7; font-weight: 400; margin-left: 4px; text-transform: none; letter-spacing: 0; }
 
 .pn-suspended-detail {
 	color: rgba(255,255,255,0.8);

--- a/system/lib/ork3/class.Report.php
+++ b/system/lib/ork3/class.Report.php
@@ -2742,4 +2742,334 @@ class Report  extends Ork3 {
 		return Success();
 	}
 
+	public function GetVotingEligible($request) {
+		$kingdom_id     = (int)($request['KingdomId'] ?? 0);
+		$park_id        = valid_id($request['ParkId'] ?? 0)     ? (int)$request['ParkId']              : 0;
+		$mundane_id     = valid_id($request['MundaneId'] ?? 0)  ? (int)$request['MundaneId']           : 0;
+		$att_req        = isset($request['AttendanceRequired'])  ? (int)$request['AttendanceRequired']  : 6;
+		$months_win     = isset($request['MonthsWindow'])        ? (int)$request['MonthsWindow']        : 6;
+		$min_mem_mo     = isset($request['MinMembershipMonths']) ? (int)$request['MinMembershipMonths'] : 6;
+		$att_mode           = $request['AttendanceMode'] ?? 'weeks';
+		if (!in_array($att_mode, ['count', 'days', 'weeks'])) $att_mode = 'weeks';
+		$week_offset             = isset($request['WeekOffset'])             ? (int)$request['WeekOffset']             : 0;
+		$province_mode           = !empty($request['ProvinceMode']);
+		$kingdom_evt_bonus       = !empty($request['KingdomEventBonus']);
+		$active_knight_threshold  = isset($request['ActiveKnightThreshold'])  ? (int)$request['ActiveKnightThreshold']  : 0;
+		$active_member_threshold  = isset($request['ActiveMemberThreshold'])  ? (int)$request['ActiveMemberThreshold']  : 0;
+		$exclude_online           = !empty($request['ExcludeOnline']);
+		$all_kingdoms             = !empty($request['AllKingdoms']); // count attendance from any kingdom
+		$days_window             = isset($request['DaysWindow'])              ? (int)$request['DaysWindow']              : 0;
+		$min_age                 = isset($request['MinAge'])                  ? (int)$request['MinAge']                  : 0;
+		$max_credits_per_event   = isset($request['MaxCreditsPerEvent'])      ? (int)$request['MaxCreditsPerEvent']      : 0;
+		$max_outside_kingdom_creds = isset($request['MaxOutsideKingdomCredits']) ? (int)$request['MaxOutsideKingdomCredits'] : 0;
+		$week_snap               = !empty($request['WeekSnap']); // snap window start to week boundary even in non-weeks modes
+		$membership_mode         = $request['MembershipMode'] ?? 'park_member_since'; // 'first_attendance' uses MIN(attendance.date) within the kingdom
+
+		// Compute start date.
+		// display_start_date: shown in the report header (raw date for DaysWindow, snapped for MonthsWindow).
+		// start_date: used in SQL — always snapped to week start when att_mode=weeks so the full
+		//   starting week is included (e.g. 180d back lands on Sat → SQL starts Mon of that week).
+		if (!empty($request['StartDate'])) {
+			$start_date = $display_start_date = mysql_real_escape_string($request['StartDate']);
+		} else {
+			$_raw_ts         = $days_window > 0 ? strtotime("-{$days_window} days")
+			                                    : strtotime("-{$months_win} months");
+			$display_start_date = date('Y-m-d', $_raw_ts);
+			// Snap SQL start to the first day of the Amtgard week when counting weeks,
+			// or when WeekSnap=true (kingdoms that count sign-ins/days but align their
+			// window to the week boundary for consistency with the Amtgard calendar).
+			if ($att_mode === 'weeks' || $week_snap) {
+				$_week_start_iso = $week_offset + 1;                    // 1=Mon, 2=Tue, 7=Sun …
+				$_dow            = (int)date('N', $_raw_ts);             // 1=Mon … 7=Sun
+				$_days_back      = (($_dow - $_week_start_iso) + 7) % 7;
+				$start_date      = date('Y-m-d', $_raw_ts - $_days_back * 86400);
+				// For MonthsWindow kingdoms, show the snapped week-start in the header so the
+				// "Attendance from" date matches exactly what the SQL counts from.
+				// DaysWindow kingdoms keep display=raw (exact N-day mark) with SQL=snapped.
+				if ($days_window === 0) {
+					$display_start_date = $start_date;
+				}
+			} else {
+				$start_date = $display_start_date;
+			}
+		}
+
+		// If only ParkId given, derive kingdom from the park record
+		if (!$kingdom_id && $park_id) {
+			$pr = $this->db->query("SELECT kingdom_id FROM " . DB_PREFIX . "park WHERE park_id = $park_id LIMIT 1");
+			if ($pr && $pr->size() > 0) { $pr->next(); $kingdom_id = (int)$pr->kingdom_id; }
+		}
+		if (!$kingdom_id) return ['Players' => [], 'AttendanceRequired' => $att_req, 'MonthsWindow' => $months_win, 'MinMembershipMonths' => $min_mem_mo, 'ProvinceMode' => $province_mode];
+
+		$park_clause    = $park_id    ? " AND m.park_id    = $park_id"    : '';
+		$mundane_clause = $mundane_id ? " AND m.mundane_id = $mundane_id" : '';
+
+		// Online exclusion: LEFT JOIN event + park inside attendance subqueries, filter out
+		// rows where the event name or park name contains 'Online' (case-insensitive).
+		$online_join   = '';
+		$online_clause = '';
+		if ($exclude_online) {
+			$online_join   = "LEFT JOIN " . DB_PREFIX . "event   _oe ON _oe.event_id = a.event_id AND a.event_id != 0
+					LEFT JOIN " . DB_PREFIX . "park    _op ON _op.park_id  = a.park_id";
+			// NULL-safe: a.park_id = 0 (kingdom events) yields NULL park name — allow those through.
+			// Only exclude when we can positively confirm 'Online' is in the name.
+			$online_clause = "AND (_oe.name IS NULL OR _oe.name NOT LIKE '%Online%')
+					AND (_op.name IS NULL OR _op.name NOT LIKE '%Online%')";
+		}
+
+		$home_park_only = !empty($request['HomeParkOnly']);
+
+		// HomeParkOnly: attendance subquery counts only sign-ins at the player's home park.
+		// Requires joining ork_mundane inside the subquery to access each player's park_id.
+		// Compatible with KingdomEventBonus (kingdom events count as +1 regardless of home park).
+		$home_park_join = $home_park_only
+			? "JOIN " . DB_PREFIX . "mundane mp ON mp.mundane_id = a.mundane_id"
+			: '';
+
+		// Attendance subquery expression.
+		// KingdomEventBonus: kingdom-sponsored events (ork_event.park_id = 0) count as at most +1.
+		// Extra columns to select alongside att_count in the attendance subquery (comma-prefixed).
+		$att_extra_cols = '';
+
+		if ($home_park_only && $kingdom_evt_bonus) {
+			// Home-park sign-ins + capped kingdom event bonus.
+			// Also emit a separate kingdom_evt_credit column (0 or 1) for display in the report.
+			$att_expr = "COUNT(CASE WHEN a.park_id = mp.park_id THEN 1 END)"
+			          . " + SIGN(SUM(CASE WHEN kve.event_id IS NOT NULL AND kve.park_id = 0 THEN 1 ELSE 0 END))";
+			$att_extra_cols = ", SIGN(SUM(CASE WHEN kve.event_id IS NOT NULL AND kve.park_id = 0 THEN 1 ELSE 0 END)) AS kingdom_evt_credit";
+		} elseif ($home_park_only) {
+			$att_expr = "COUNT(CASE WHEN a.park_id = mp.park_id THEN 1 END)";
+		} elseif ($kingdom_evt_bonus) {
+			// Regular sign-ins (parkday or park-hosted event) + kingdom event bonus (capped at 1).
+			// SIGN() returns 1 if any kingdom events were attended, 0 otherwise.
+			$att_expr = "COUNT(CASE WHEN a.event_id = 0 OR kve.event_id IS NULL OR kve.park_id != 0 THEN 1 END)"
+			          . " + SIGN(SUM(CASE WHEN kve.event_id IS NOT NULL AND kve.park_id = 0 THEN 1 ELSE 0 END))";
+		} elseif ($att_mode === 'count') {
+			$att_expr = "COUNT(*)";
+		} elseif ($att_mode === 'days') {
+			$att_expr = "COUNT(DISTINCT a.date)";
+		} elseif ($week_offset > 0) {
+			// Non-Monday week start: shift date back by offset days so the custom start day
+			// aligns with Monday, then use Monday-start ISO yearweek (mode 3).
+			// e.g. offset=1 → Tuesday-start; YEARWEEK handles year boundaries correctly.
+			$att_expr = "COUNT(DISTINCT YEARWEEK(DATE_SUB(a.date, INTERVAL $week_offset DAY), 3))";
+		} else {
+			// Monday-start: use pre-computed columns (fastest)
+			$att_expr = "COUNT(DISTINCT CONCAT(a.date_year, '-', a.date_week3))";
+		}
+
+		// Pre-build the att LEFT JOIN clause. Two paths:
+		// 1. Outside-credit-cap (e.g. Tal Dagore): nested UNION ALL subquery tracks in/out kingdom
+		//    credits separately, applies per-event cap and outside-kingdom credit ceiling.
+		// 2. Standard path: single-level GROUP BY with att_expr.
+		// Both produce the same att alias with att_count; path 1 also emits outside_credits_raw.
+		$att_select_extra = '';
+		if ($max_outside_kingdom_creds > 0) {
+			$_per_evt = $max_credits_per_event > 0 ? "LEAST(COUNT(*), $max_credits_per_event)" : "COUNT(*)";
+			// Use COALESCE(a.kingdom_id, $kingdom_id) so that attendance rows with NULL kingdom_id
+			// are treated as in-kingdom, preventing NULL propagation in SUM() arithmetic.
+			$att_join_clause = "LEFT JOIN (
+					SELECT mundane_id,
+					       SUM(in_credits) + LEAST(SUM(out_credits), $max_outside_kingdom_creds) AS att_count,
+					       SUM(out_credits) AS outside_credits_raw
+					FROM (
+					    SELECT a.mundane_id,
+					           $_per_evt * (COALESCE(a.kingdom_id, $kingdom_id) = $kingdom_id) AS in_credits,
+					           $_per_evt * (COALESCE(a.kingdom_id, $kingdom_id) != $kingdom_id) AS out_credits
+					    FROM " . DB_PREFIX . "attendance a
+					    WHERE a.event_id IS NOT NULL AND a.event_id != 0
+					      AND a.date >= '$start_date'
+					    GROUP BY a.mundane_id, a.event_id, a.kingdom_id
+					    UNION ALL
+					    SELECT a.mundane_id,
+					           (COALESCE(a.kingdom_id, $kingdom_id) = $kingdom_id) AS in_credits,
+					           (COALESCE(a.kingdom_id, $kingdom_id) != $kingdom_id) AS out_credits
+					    FROM " . DB_PREFIX . "attendance a
+					    WHERE (a.event_id = 0 OR a.event_id IS NULL)
+					      AND a.date >= '$start_date'
+					) att_inner
+					GROUP BY mundane_id
+				) att ON att.mundane_id = m.mundane_id";
+			$att_select_extra = ', COALESCE(att.outside_credits_raw, 0) AS outside_credits_raw';
+		} else {
+			// Standard path — resolve inline PHP expressions into variables first
+			// so the att_join_clause string contains only PHP variable interpolations.
+			$_kve_join_sql  = $kingdom_evt_bonus
+				? "LEFT JOIN " . DB_PREFIX . "event kve ON kve.event_id = a.event_id AND a.event_id != 0"
+				: '';
+			$_att_where_kw  = $all_kingdoms ? "1=1" : "a.kingdom_id = $kingdom_id";
+			$att_join_clause = "LEFT JOIN (
+					SELECT a.mundane_id, $att_expr AS att_count $att_extra_cols
+					FROM " . DB_PREFIX . "attendance a
+					$home_park_join
+					$_kve_join_sql
+					$online_join
+					WHERE $_att_where_kw
+					  AND a.date >= '$start_date'
+					  $online_clause
+					GROUP BY a.mundane_id
+				) att ON att.mundane_id = m.mundane_id";
+		}
+
+		// Park-level attendance subquery (province mode only)
+		$province_join   = '';
+		$province_select = '';
+		if ($province_mode) {
+			$province_join = "
+				LEFT JOIN (
+					SELECT a.mundane_id, COUNT(*) AS park_att_count
+					FROM " . DB_PREFIX . "attendance a
+					JOIN " . DB_PREFIX . "mundane mp ON mp.mundane_id = a.mundane_id AND mp.park_id = a.park_id
+					$online_join
+					WHERE " . ($all_kingdoms ? "1=1" : "a.kingdom_id = $kingdom_id") . "
+					  AND a.date >= '$start_date'
+					  $online_clause
+					GROUP BY a.mundane_id
+				) patt ON patt.mundane_id = m.mundane_id
+			";
+			$province_select = ", COALESCE(patt.park_att_count, 0) AS park_att_count";
+		}
+
+		// Active Knight: secondary raw sign-in count (always COUNT(*)) used for kingdoms
+		// that have a higher-tier eligibility based on total attendances.
+		$knight_join   = '';
+		$knight_select = '';
+		if ($active_knight_threshold > 0) {
+			$knight_join = "
+				LEFT JOIN (
+					SELECT a.mundane_id, COUNT(*) AS raw_att_count
+					FROM " . DB_PREFIX . "attendance a
+					$online_join
+					WHERE " . ($all_kingdoms ? "1=1" : "a.kingdom_id = $kingdom_id") . "
+					  AND a.date >= '$start_date'
+					  $online_clause
+					GROUP BY a.mundane_id
+				) katt ON katt.mundane_id = m.mundane_id
+			";
+			$knight_select = "
+				, COALESCE(katt.raw_att_count, 0) AS raw_att_count
+				, CASE WHEN EXISTS (
+					SELECT 1 FROM " . DB_PREFIX . "awards ma
+					JOIN " . DB_PREFIX . "award aw ON aw.award_id = ma.award_id
+					WHERE ma.mundane_id = m.mundane_id
+					  AND aw.peerage = 'Knight'
+					  AND (ma.revoked = 0 OR ma.revoked IS NULL)
+				) THEN 1 ELSE 0 END AS is_knight
+			";
+		}
+
+		$sql = "
+			SELECT
+				m.mundane_id, m.persona, m.waivered, m.park_member_since,
+				m.suspended, m.suspended_until,
+				p.park_id, p.name AS park_name,
+				k.kingdom_id, k.name AS kingdom_name,
+				COALESCE(att.att_count, 0) AS att_count
+				$att_select_extra
+				" . ($home_park_only && $kingdom_evt_bonus ? ", COALESCE(att.kingdom_evt_credit, 0) AS kingdom_evt_credit" : "") . "
+				" . ($membership_mode === 'first_attendance' ? ", (SELECT MIN(a.date) FROM " . DB_PREFIX . "attendance a WHERE a.mundane_id = m.mundane_id AND a.kingdom_id = $kingdom_id) AS first_att_date" : "") . "
+				$province_select
+				$knight_select,
+				CASE WHEN EXISTS (
+					SELECT 1 FROM " . DB_PREFIX . "dues d
+					WHERE d.mundane_id = m.mundane_id
+					  AND d.kingdom_id = $kingdom_id
+					  AND d.revoked != 1
+					  AND (d.dues_until >= CURDATE() OR d.dues_for_life = 1)
+				) THEN 1 ELSE 0 END AS dues_paid,
+				(SELECT CASE WHEN MAX(d.dues_for_life) = 1 THEN '9999-12-31'
+				             ELSE MAX(d.dues_until) END
+				 FROM " . DB_PREFIX . "dues d
+				 WHERE d.mundane_id = m.mundane_id
+				   AND d.kingdom_id = $kingdom_id
+				   AND d.revoked != 1
+				   AND (d.dues_until >= CURDATE() OR d.dues_for_life = 1)
+				) AS dues_until
+			FROM " . DB_PREFIX . "mundane m
+				JOIN " . DB_PREFIX . "park    p ON p.park_id    = m.park_id
+				JOIN " . DB_PREFIX . "kingdom k ON k.kingdom_id = m.kingdom_id
+				$att_join_clause
+				$province_join
+				$knight_join
+			WHERE m.kingdom_id = $kingdom_id
+			  AND m.active = 1
+			  AND p.active = 'Active'
+			  AND att.att_count IS NOT NULL
+			  $park_clause
+			  $mundane_clause
+			ORDER BY p.name, m.persona
+		";
+
+		$r = $this->db->query($sql);
+		$response = ['Players' => [], 'AttendanceRequired' => $att_req, 'MonthsWindow' => $months_win,
+		             'MinMembershipMonths' => $min_mem_mo, 'ProvinceMode' => $province_mode,
+		             'AttendanceMode' => $att_mode, 'WeekOffset' => $week_offset,
+		             'KingdomEventBonus' => $kingdom_evt_bonus,
+		             'ActiveKnightThreshold' => $active_knight_threshold,
+		             'ActiveMemberThreshold' => $active_member_threshold,
+		             'ExcludeOnline' => $exclude_online,
+		             'HomeParkOnly' => $home_park_only,
+		             'DaysWindow' => $days_window,
+		             'MinAge' => $min_age,
+		             'StartDate' => $start_date,
+		             'DisplayStartDate' => $display_start_date,
+		             'AllKingdoms' => $all_kingdoms,
+		             'MaxCreditsPerEvent' => $max_credits_per_event,
+		             'MaxOutsideKingdomCredits' => $max_outside_kingdom_creds,
+		             'MembershipMode' => $membership_mode];
+		if ($r !== false && $r->size() > 0) {
+			while ($r->next()) {
+				$_member_date    = $membership_mode === 'first_attendance' ? $r->first_att_date : $r->park_member_since;
+				$membership_ok   = empty($_member_date) || $_member_date === '0000-00-00'
+					|| strtotime($_member_date) <= strtotime("-{$min_mem_mo} months");
+				$suspended       = (int)$r->suspended === 1;
+				$att_count       = (int)$r->att_count;
+				$base_ok         = !$suspended && $r->waivered == 1 && $r->dues_paid == 1 && $membership_ok;
+				$kingdom_eligible = $base_ok && $att_count >= $att_req;
+
+				$row = [
+					'MundaneId'       => (int)$r->mundane_id,
+					'Persona'         => $r->persona,
+					'ParkId'          => (int)$r->park_id,
+					'ParkName'        => $r->park_name,
+					'KingdomId'       => (int)$r->kingdom_id,
+					'KingdomName'     => $r->kingdom_name,
+					'Waivered'        => (int)$r->waivered,
+					'DuesPaid'        => (int)$r->dues_paid,
+					'DuesUntil'       => $r->dues_until,
+					'AttCount'        => $att_count,
+					'MemberSince'     => $membership_mode === 'first_attendance' ? $r->first_att_date : $r->park_member_since,
+					'MembershipOk'    => $membership_ok,
+					'Suspended'       => $suspended,
+					'SuspendedUntil'  => $r->suspended_until,
+					'KingdomEligible'    => $kingdom_eligible,
+					'VotingEligible'     => $kingdom_eligible,
+					'KingdomEventCredit' => $home_park_only && $kingdom_evt_bonus ? (int)$r->kingdom_evt_credit : null,
+					'OutsideCredits'     => $max_outside_kingdom_creds > 0 ? (int)$r->outside_credits_raw : null,
+					'ActiveMember'       => $active_member_threshold > 0 ? ($base_ok && $att_count >= $active_member_threshold) : null,
+					'ActiveKnight'       => false,
+				];
+				if ($active_knight_threshold > 0) {
+					$raw_att_count        = (int)$r->raw_att_count;
+					$is_knight            = (int)$r->is_knight === 1;
+					$row['RawAttCount']   = $raw_att_count;
+					$row['IsKnight']      = $is_knight;
+					$row['ActiveKnight']  = $is_knight && $kingdom_eligible && $raw_att_count >= $active_knight_threshold;
+				}
+
+				if ($province_mode) {
+					$park_att_count      = (int)$r->park_att_count;
+					$province_eligible   = $base_ok && $park_att_count >= $att_req;
+					$row['ParkAttCount']       = $park_att_count;
+					$row['ProvinceEligible']   = $province_eligible;
+					// Province implies kingdom (park attendance is a subset of kingdom attendance),
+					// so VotingEligible stays kingdom_eligible — the broader right.
+				}
+
+				$response['Players'][] = $row;
+			}
+		}
+		return $response;
+	}
+
 }


### PR DESCRIPTION
## Summary

- Adds \`Reports/voting_eligible\` endpoint showing which active players meet voting eligibility criteria, with per-criterion pass/fail colouring, CSV/print export, and filter pills
- Supports 13 kingdoms, each with configurable rules (attendance windows, week/day/count modes, dues, waiver, membership age, outside-kingdom credit caps)
- Eligible players in supported kingdoms get a **Voting Eligible** badge on their player profile page
- Report links added to Kingdom and Park pages for supported kingdoms

## Supported Kingdoms & Rules

| Kingdom | ID | Mode | Requirement | Notes |
|---|---|---|---|---|
| Nine Blades | 31 | weeks | 6 weeks / 6 mo | Mon–Sun; 6-month membership |
| Iron Mountains | 3 | weeks | 6 weeks / 6 mo | Mon–Sun; 6-month membership |
| Emerald Hills | 6 | weeks | 6 weeks / 6 mo | Tue–Mon; 6-month kingdom residency |
| Rising Winds | 10 | days | 7 days / 6 mo | Membership = first attendance in kingdom |
| Northreach | 36 | weeks | 12 weeks / 180 days | No membership requirement; min age 14 |
| Polaris | 27 | weeks | 6 weeks / 6 mo | Sun–Sat; 3-month home chapter membership |
| Celestial Kingdom | 14 | count | 7 sign-ins / 6 mo | Counts all kingdoms; 12+ = Active Member tier |
| Crystal Groves | 17 | count | 6 sign-ins / 6 mo | Province mode; kingdom event bonus |
| Tal Dagore | 19 | count | 8 credits / 6 mo | Max 2 credits/event; max 2 outside-kingdom credits |
| Goldenvale | 4 | count | 6 sign-ins / 6 mo | Home park only; kingdom event bonus |
| Northern Lights | 20 | days | 6 days / 6 mo | Excludes online events |
| Viridian Outlands | 25 | days | 6 days / 6 mo | |
| 13 Roads | 38 | days | 6 days / 6 mo | |

## Test plan

- [ ] `Reports/voting_eligible/Kingdom&id=31` — table loads, eligible rows have green indicator
- [ ] `Reports/voting_eligible/Kingdom&id=2` (unsupported) — shows "not configured" message
- [ ] `Reports/voting_eligible/Park&id=<park_in_31>` — filtered to that park's players
- [ ] Player profile in Kingdom 31 meeting all criteria → blue "Voting Eligible" badge
- [ ] Player profile in Kingdom 31 not meeting criteria → no badge
- [ ] Player profile outside supported kingdoms → no badge
- [ ] CSV export includes all columns
- [ ] Tal Dagore: per-event cap (max 2) and outside-kingdom cap (max 2) applied correctly
- [ ] Rising Winds: membership age uses first attendance date in kingdom, not park_member_since
- [ ] Active Players count matches \`SELECT COUNT(*) FROM ork_mundane WHERE kingdom_id=X AND active=1\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)