### PR TITLE
Enhancement: Login redirect, scoped attendance search, award rec fixes

### DIFF
--- a/orkui/controller/controller.Login.php
+++ b/orkui/controller/controller.Login.php
@@ -10,6 +10,12 @@ class Controller_Login extends Controller {
 
 	public function index($action = null) {
 		$this->template = '../revised-frontend/Login_index.tpl';
+		if (!empty($_GET['return'])) {
+			$_ret = trim($_GET['return']);
+			if ($_ret !== '' && strncasecmp($_ret, 'Login', 5) !== 0) {
+				$this->session->location = $_ret;
+			}
+		}
 		if (($_GET['msg'] ?? '') === 'session_replaced') {
 			$this->data['session_message'] = 'You were logged in from another device or browser. Please log in again.';
 		}
@@ -32,7 +38,8 @@ class Controller_Login extends Controller {
 
 		if ((strlen($this->request->username) > 0 && strlen($this->request->password) > 0) && ($r = $this->Login->login($this->request->username, $this->request->password)) === true) {
 			if ($this->session->location == null) {
-				header('Location: ' . UIR);
+				$uid = (int)$this->session->user_id;
+				header('Location: ' . UIR . ($uid > 0 ? 'Player/profile/' . $uid : ''));
 			} else {
 				//$this->session->location = null;
 				header('Location: ' . UIR . $this->session->location);
@@ -110,7 +117,13 @@ class Controller_Login extends Controller {
 			$this->session->user_name = $result['UserName'];
 			$this->session->token = $result['Token'];
 			$this->session->timeout = $result['Timeout'];
-			header('Location: ' . UIR);
+			if (!empty($this->session->location)) {
+				$_dest = $this->session->location;
+				header('Location: ' . UIR . $_dest);
+			} else {
+				$uid = (int)$this->session->user_id;
+				header('Location: ' . UIR . ($uid > 0 ? 'Player/profile/' . $uid : ''));
+			}
 		} else {
 			$this->data['error'] = $result['Status']['Error'];
 			$this->data['detail'] = $result['Status']['Detail'];

--- a/orkui/controller/controller.Player.php
+++ b/orkui/controller/controller.Player.php
@@ -314,7 +314,7 @@ class Controller_Player extends Controller {
 							header('Location: ' . UIR . "Login/login/Player/profile/$id");
 						} else {
 							$msg = urlencode($r['Error'] . ': ' . $r['Detail']);
-							header('Location: ' . UIR . "Player/profile/{$id}?rec_error={$msg}");
+							header('Location: ' . UIR . "Player/profile/{$id}&rec_error={$msg}");
 						}
 						exit;
 					case 'deleterecommendation':

--- a/orkui/controller/controller.PlayerAjax.php
+++ b/orkui/controller/controller.PlayerAjax.php
@@ -123,6 +123,21 @@ class Controller_PlayerAjax extends Controller {
 				? json_encode(['status' => 0])
 				: json_encode(['status' => $r['Status'], 'error' => ($r['Error'] ?? 'Error') . ': ' . ($r['Detail'] ?? '')]);
 
+		} elseif ($action === 'reactivateaward') {
+			$awards_id = (int)($_POST['AwardsId'] ?? 0);
+			if (!valid_id($awards_id)) {
+				echo json_encode(['status' => 1, 'error' => 'Invalid award ID.']);
+				exit;
+			}
+			$r = $this->Player->reactivate_player_award([
+				'Token'       => $this->session->token,
+				'AwardsId'    => $awards_id,
+				'RecipientId' => $player_id,
+			]);
+			echo ($r['Status'] == 0)
+				? json_encode(['status' => 0])
+				: json_encode(['status' => $r['Status'], 'error' => ($r['Error'] ?? 'Error') . ': ' . ($r['Detail'] ?? '')]);
+
 		} elseif ($action === 'addnote') {
 			$note     = trim($_POST['Note']         ?? '');
 			$desc     = trim($_POST['Description']  ?? '');

--- a/orkui/model/model.Player.php
+++ b/orkui/model/model.Player.php
@@ -64,6 +64,12 @@ class Model_Player extends Model {
 		return $r;
 	}
 
+	function reactivate_player_award($request) {
+		$r = $this->Player->ReactivateAward($request);
+		if ($r['Status']['Status'] == 0) $this->bust_player_details_cache($request);
+		return $r;
+	}
+
 	function add_note($request) {
 		return $this->Player->AddNote($request);
 	}

--- a/orkui/template/default/default.theme
+++ b/orkui/template/default/default.theme
@@ -191,7 +191,7 @@
 				<!-- SVG injected by JS -->
 			</button>
 <?php if ($this->__session->token == null) : ?>
-			<a href='<?=UIR;?>Login' class='nav-login-btn'><i class='fas fa-sign-in-alt'></i> Login</a>
+			<a href='<?=UIR;?>Login&return=<?=urlencode($_REQUEST['Route'] ?? '')?>' class='nav-login-btn'><i class='fas fa-sign-in-alt'></i> Login</a>
 <?php else : ?>
 <?php
 	$__navUid      = (int)$this->__session->user_id;

--- a/orkui/template/revised-frontend/Eventnew_index.tpl
+++ b/orkui/template/revised-frontend/Eventnew_index.tpl
@@ -264,6 +264,14 @@ html[data-theme="dark"] #ev-rsvp-credits {
 }
 html[data-theme="dark"] #ev-rsvp-table thead th label { color: var(--ork-text-muted) !important; }
 html[data-theme="dark"] .ev-rsvp-th-tip { background: var(--ork-text, #e2e8f0); color: var(--ork-bg, #1a202c); }
+
+/* Attendance player-search scoped autocomplete */
+.ev-att-form .ev-pn-field { position: relative; }
+.ev-att-form #ev-PlayerName-results { position: fixed; top: 0; left: 0; right: auto; width: 320px; max-height: 360px; margin: 0; }
+.ev-ac-section { padding: 4px 10px; font-size: 11px; font-weight: 700; letter-spacing: .04em; color: #718096; background: #f7fafc; text-transform: uppercase; border-bottom: 1px solid #e2e8f0; }
+.ev-ac-empty { padding: 8px 12px; font-size: 13px; color: #a0aec0; cursor: default; }
+html[data-theme="dark"] .ev-ac-section { color: var(--ork-text-muted); background: var(--ork-bg-secondary); border-bottom-color: var(--ork-border); }
+html[data-theme="dark"] .ev-ac-empty { color: var(--ork-text-muted); }
 </style>
 
 <?php // ---- HERO ---- ?>
@@ -581,13 +589,14 @@ html[data-theme="dark"] .ev-rsvp-th-tip { background: var(--ork-text, #e2e8f0); 
 					<h4><i class="fas fa-plus-circle" style="margin-right:6px;color:#276749"></i>Add Attendance</h4>
 					<form method="post" id="ev-attendance-form" action="<?= UIR ?>EventAjax/add_attendance/<?= $eventId ?>/<?= $detailId ?>" onsubmit="evHandleAttendanceSubmit(this); return false;">
 						<div class="ev-form-row">
-							<div class="ev-form-field">
+							<div class="ev-form-field ev-pn-field">
 								<label>Player</label>
 								<input type="text" id="ev-PlayerName" name="PlayerName" style="width:200px"
 									value="<?= htmlspecialchars($attendanceForm['PlayerName'] ?? '') ?>"
 									autocomplete="off" placeholder="Search players…">
 								<input type="hidden" id="ev-MundaneId" name="MundaneId"
 									value="<?= (int)($attendanceForm['MundaneId'] ?? 0) ?>">
+								<div class="kn-ac-results" id="ev-PlayerName-results"></div>
 							</div>
 							<div class="ev-form-field">
 								<label>Class</label>
@@ -1104,7 +1113,9 @@ var EvConfig = {
 	eventId:    <?= $eventId ?>,
 	detailId:   <?= $detailId ?>,
 	eventName:  <?= json_encode($info['Name'] ?? 'Event') ?>,
-	eventDate:  <?= json_encode($eventStart ? date('Y-m-d', strtotime($eventStart)) : '') ?>
+	eventDate:  <?= json_encode($eventStart ? date('Y-m-d', strtotime($eventStart)) : '') ?>,
+	parkId:     <?= (int)($atParkId ?: $parkId) ?>,
+	kingdomId:  <?= (int)$kingdomId ?>
 };
 </script>
 <?php if ($canManage): ?>

--- a/orkui/template/revised-frontend/Playernew_index.tpl
+++ b/orkui/template/revised-frontend/Playernew_index.tpl
@@ -1272,6 +1272,7 @@ html[data-theme="dark"] .pn-persona { color: #fff !important; background: transp
 								<th data-sorttype="date">Revoked On</th>
 								<th data-sorttype="text">Revoked By</th>
 								<th data-sorttype="text">Reason</th>
+								<th class="pn-nosort"></th>
 							</tr>
 						</thead>
 						<tbody>
@@ -1283,6 +1284,9 @@ html[data-theme="dark"] .pn-persona { color: #fff !important; background: transp
 								<td class="pn-col-nowrap"><?= ($rev['RevokedAt'] && $rev['RevokedAt'] !== '0000-00-00') ? $rev['RevokedAt'] : '' ?></td>
 								<td class="pn-col-nowrap"><?= htmlspecialchars($rev['RevokedBy'] ?? '') ?></td>
 								<td><?= htmlspecialchars($rev['Revocation'] ?? '') ?></td>
+								<td class="pn-col-nowrap">
+									<button class="pn-btn pn-btn-sm pn-reactivate-btn" data-awards-id="<?= (int)$rev['AwardsId'] ?>" title="Reactivate this award"><i class="fas fa-undo"></i> Reactivate</button>
+								</td>
 							</tr>
 							<?php endforeach; ?>
 						</tbody>
@@ -1425,6 +1429,7 @@ html[data-theme="dark"] .pn-persona { color: #fff !important; background: transp
 								<th data-sorttype="date">Revoked On</th>
 								<th data-sorttype="text">Revoked By</th>
 								<th data-sorttype="text">Reason</th>
+								<th class="pn-nosort"></th>
 							</tr>
 						</thead>
 						<tbody>
@@ -1436,6 +1441,9 @@ html[data-theme="dark"] .pn-persona { color: #fff !important; background: transp
 								<td class="pn-col-nowrap"><?= ($rev['RevokedAt'] && $rev['RevokedAt'] !== '0000-00-00') ? $rev['RevokedAt'] : '' ?></td>
 								<td class="pn-col-nowrap"><?= htmlspecialchars($rev['RevokedBy'] ?? '') ?></td>
 								<td><?= htmlspecialchars($rev['Revocation'] ?? '') ?></td>
+								<td class="pn-col-nowrap">
+									<button class="pn-btn pn-btn-sm pn-reactivate-btn" data-awards-id="<?= (int)$rev['AwardsId'] ?>" title="Reactivate this title"><i class="fas fa-undo"></i> Reactivate</button>
+								</td>
 							</tr>
 							<?php endforeach; ?>
 						</tbody>

--- a/orkui/template/revised-frontend/Playernew_index.tpl
+++ b/orkui/template/revised-frontend/Playernew_index.tpl
@@ -2323,6 +2323,7 @@ html[data-theme="dark"] .pn-persona { color: #fff !important; background: transp
 					<div class="pn-rank-pills-wrap" id="pn-rec-rank-pills"></div>
 					<input type="hidden" name="Rank" id="pn-rec-rank-val" value="" />
 				</div>
+				<div class="pn-form-error" id="pn-rec-warn" style="margin-top:4px"></div>
 				<div class="pn-rec-field">
 					<label for="pn-rec-reason">Reason <span class="required-indicator">*</span></label>
 					<input type="text" name="Reason" id="pn-rec-reason" maxlength="400" placeholder="Why should this player receive this award?" />
@@ -2340,7 +2341,9 @@ html[data-theme="dark"] .pn-persona { color: #fff !important; background: transp
 
 <?php
 // Build KingdomAwardId => max rank held by this player (for ladder award pre-fill)
-$playerAwardRanks = array();
+// and the set of KingdomAwardIds the player already holds (for title duplicate detection)
+$playerAwardRanks        = array();
+$playerHeldKingdomAwardIds = array();
 if (is_array($Details['Awards'])) {
 	foreach ($Details['Awards'] as $a) {
 		$aid  = (int)$a['AwardId'];
@@ -2350,8 +2353,13 @@ if (is_array($Details['Awards'])) {
 				$playerAwardRanks[$aid] = $rank;
 			}
 		}
+		$kaid = (int)($a['KingdomAwardId'] ?? 0);
+		if ($kaid > 0) {
+			$playerHeldKingdomAwardIds[$kaid] = true;
+		}
 	}
 }
+$playerHeldKingdomAwardIds = array_keys($playerHeldKingdomAwardIds);
 ?>
 
 <!-- =============================================
@@ -2395,6 +2403,7 @@ var PnConfig = {
 	canManageAwards:<?= !empty($canManageAwards) ? 'true' : 'false' ?>,
 	classList:      <?= json_encode(array_values(array_map(function($c) { return ['ClassId' => (int)$c['ClassId'], 'ClassName' => $c['ClassName'], 'Credits' => (float)($c['Credits'] ?? 0), 'Reconciled' => (int)($c['Reconciled'] ?? 0)]; }, $classList ?? []))) ?>,
 	awardRanks:     <?= json_encode($playerAwardRanks) ?>,
+	heldKingdomAwardIds: <?= json_encode($playerHeldKingdomAwardIds) ?>,
 	awardOptHTML:   <?= json_encode('<option value="">Select award...</option>' . ($AwardOptions ?? '')) ?>,
 	officerOptHTML: <?= json_encode('<option value="">Select title...</option>' . ($OfficerOptions ?? '')) ?>,
 	preloadOfficers:<?= json_encode($PreloadOfficers ?? []) ?>,

--- a/orkui/template/revised-frontend/script/revised.js
+++ b/orkui/template/revised-frontend/script/revised.js
@@ -708,6 +708,60 @@ if (PnConfig.recError) {
         }
     });
 
+    // Classify a rec-form award <option>: 'ladder' | 'custom' | 'title' | 'none'
+    function pnRecAwardCategory(opt) {
+        if (!opt || !opt.value) return 'none';
+        if (opt.getAttribute('data-is-ladder') === '1') return 'ladder';
+        var parent = opt.parentElement;
+        if (!parent || parent.tagName !== 'OPTGROUP') return 'custom';
+        return 'title';
+    }
+    function pnRecSelectedOpt() {
+        var sel = document.getElementById('pn-rec-award');
+        if (!sel) return null;
+        return sel.options[sel.selectedIndex] || null;
+    }
+    function pnRecHeldRankForSelected() {
+        var opt = pnRecSelectedOpt();
+        if (!opt) return 0;
+        var baseAwardId = parseInt(opt.getAttribute('data-award-id'), 10) || 0;
+        return (PnConfig.awardRanks && PnConfig.awardRanks[baseAwardId]) || 0;
+    }
+    function pnRecWarnEl() { return document.getElementById('pn-rec-warn'); }
+    function pnRecShowWarn(msg) {
+        var w = pnRecWarnEl(); if (!w) return;
+        w.textContent = msg;
+        w.style.display = 'block';
+    }
+    function pnRecHideWarn() {
+        var w = pnRecWarnEl(); if (!w) return;
+        w.textContent = '';
+        w.style.display = 'none';
+    }
+    function pnRecRefreshWarn() {
+        var opt = pnRecSelectedOpt();
+        var cat = pnRecAwardCategory(opt);
+        if (cat === 'ladder') {
+            var held = pnRecHeldRankForSelected();
+            var chosen = parseInt(($('#pn-rec-rank-val').val() || '0'), 10);
+            if (held > 0 && chosen > 0 && chosen <= held) {
+                pnRecShowWarn('The player already has this award at or above the rank selected. Please select rank ' + (held + 1) + ' or higher to continue.');
+            } else {
+                pnRecHideWarn();
+            }
+        } else if (cat === 'title') {
+            var kaid = parseInt(opt.value, 10) || 0;
+            var held = (PnConfig.heldKingdomAwardIds || []).indexOf(kaid) !== -1;
+            if (held) {
+                pnRecShowWarn('The player already has this title. Are you sure you wish to continue?');
+            } else {
+                pnRecHideWarn();
+            }
+        } else {
+            pnRecHideWarn();
+        }
+    }
+
     // Submit with validation
     $('#pn-rec-submit').on('click', function() {
         var award  = $('#pn-rec-award').val();
@@ -717,6 +771,19 @@ if (PnConfig.recError) {
             return;
         }
         $('#pn-rec-error').hide();
+
+        // Block ladder submissions where rank is at or below current rank held.
+        var opt = pnRecSelectedOpt();
+        if (pnRecAwardCategory(opt) === 'ladder') {
+            var held = pnRecHeldRankForSelected();
+            var chosen = parseInt(($('#pn-rec-rank-val').val() || '0'), 10);
+            if (held > 0 && chosen > 0 && chosen <= held) {
+                pnRecShowWarn('The player already has this award at or above the rank selected. Please select rank ' + (held + 1) + ' or higher to continue.');
+                return;
+            }
+        }
+        // Title duplicates: warning is informational, submission proceeds.
+
         $('#pn-rec-submit').prop('disabled', true).text('Submitting…');
         $('#pn-recommend-form').submit();
     });
@@ -771,6 +838,7 @@ if (PnConfig.recError) {
         this.querySelectorAll('.pn-rank-pill').forEach(function(x) { x.classList.remove('pn-rank-selected'); });
         p.classList.add('pn-rank-selected');
         input.value = p.dataset.rank;
+        pnRecRefreshWarn();
     });
     var _recAwardEl = document.getElementById('pn-rec-award');
     if (_recAwardEl) {
@@ -783,6 +851,7 @@ if (PnConfig.recError) {
         var desc = AWARD_DESCRIPTIONS[aid] || '';
         var el = document.getElementById('pn-rec-award-desc');
         if (el) { el.textContent = desc; el.style.display = desc ? '' : 'none'; }
+        pnRecRefreshWarn();
     });
 
     // ---- Rec dismiss button (player page) ----
@@ -6499,44 +6568,123 @@ $(document).ready(function() {
             return ids;
         }
 
-        $('#ev-PlayerName').autocomplete({
-            source: function(req, res) {
-                var attended = evAttendedIds();
-                $.getJSON(EvConfig.httpService + 'Search/SearchService.php',
-                    { Action: 'Search/Player', type: 'all', search: req.term, limit: 15 },
-                    function(data) {
-                        res($.map(data, function(v) {
-                            if (attended[parseInt(v.MundaneId, 10)]) return null;
-                            var abbr = evAttAbbr(v);
-                            return { label: v.Persona + (abbr ? ' — ' + abbr : ''), name: v.Persona, value: v.MundaneId + '|' + v.PenaltyBox, suspended: !!(v.PenaltyBox || v.Suspended) };
-                        }));
-                    });
-            },
-            focus:  function(e,ui) { if (ui.item) $('#ev-PlayerName').val(ui.item.name); return false; },
-            delay: 250, minLength: 2,
-            select: function(e,ui) {
-                $('#ev-PlayerName').val(ui.item.name);
-                $('#ev-MundaneId').val(ui.item.value.split('|')[0]);
-                evUpdateAddBtn();
-                return false;
-            },
-            change: function(e,ui) { if(!ui.item) { $('#ev-MundaneId').val(''); evUpdateAddBtn(); } return false; }
-        });
-        $('#ev-PlayerName').on('input', function() {
-            if (!$(this).val()) { $('#ev-MundaneId').val(''); evUpdateAddBtn(); }
-        });
-        var _evAcWidget = $('#ev-PlayerName').data('autocomplete');
-        if (_evAcWidget) _evAcWidget._renderItem = function(ul, item) {
-            var a = $('<a>');
-            if (item.suspended) {
-                a.addClass('pk-att-ac-suspended').html(
-                    '<i class="fas fa-ban" style="margin-right:5px;font-size:11px"></i>' + $('<span>').text(item.label).html()
-                );
-            } else {
-                a.text(item.label);
+        // Scoped player-search autocomplete (park members > kingdom members > everyone else)
+        var evPnInput   = document.getElementById('ev-PlayerName');
+        var evPnHidden  = document.getElementById('ev-MundaneId');
+        var evPnResults = document.getElementById('ev-PlayerName-results');
+        var evPnTimer   = null;
+        var evPnSeq     = 0;
+
+        function evPnRenderItem(p, attended, seen) {
+            if (attended[p.MundaneId] || seen[p.MundaneId]) return '';
+            seen[p.MundaneId] = true;
+            var abbr = (p.KAbbr || '') + ':' + (p.PAbbr || '');
+            var tags = '';
+            if (p.Suspended) tags += ' <span style="color:#c53030;font-size:10px;font-weight:600;margin-left:4px">(Banned)</span>';
+            if (p.Active === 0) tags += ' <span style="color:#c53030;font-size:10px;font-weight:600;margin-left:4px">(Inactive)</span>';
+            return '<div class="kn-ac-item" tabindex="-1" data-id="' + p.MundaneId + '" data-name="' + encodeURIComponent(p.Persona || '') + '">'
+                + escHtml(p.Persona || '') + ' <span style="color:#a0aec0;font-size:11px">— ' + escHtml(abbr) + '</span>' + tags + '</div>';
+        }
+
+        function evPnRenderSection(label, items, attended, seen) {
+            var itemHtml = '';
+            (items || []).forEach(function(p) { itemHtml += evPnRenderItem(p, attended, seen); });
+            if (!itemHtml) return '';
+            return '<div class="ev-ac-section">' + escHtml(label) + '</div>' + itemHtml;
+        }
+
+        function evPnBuildGroups(term) {
+            var kid = parseInt(EvConfig.kingdomId, 10) || 0;
+            var pid = parseInt(EvConfig.parkId, 10) || 0;
+            var base = EvConfig.uir + 'KingdomAjax/playersearch/' + kid;
+            var q = '&include_inactive=1&include_suspended=1&q=' + encodeURIComponent(term);
+            if (pid > 0 && kid > 0) {
+                return [
+                    { label: 'Park Members',     url: base + '&scope=own&park_id=' + pid + q },
+                    { label: 'Kingdom Members',  url: base + '&scope=own' + q },
+                    { label: 'Everyone Else',    url: base + '&scope=exclude' + q }
+                ];
             }
-            return $('<li></li>').data('item.autocomplete', item).append(a).appendTo(ul);
-        };
+            if (kid > 0) {
+                return [
+                    { label: 'Kingdom Members',  url: base + '&scope=own' + q },
+                    { label: 'Everyone Else',    url: base + '&scope=exclude' + q }
+                ];
+            }
+            return [ { label: 'All Players', url: base + '&scope=all' + q } ];
+        }
+
+        function evPnPosition() {
+            if (!evPnInput || !evPnResults) return;
+            var r = evPnInput.getBoundingClientRect();
+            evPnResults.style.top  = (r.bottom + 2) + 'px';
+            evPnResults.style.left = r.left + 'px';
+        }
+
+        function evPnOpen() {
+            evPnPosition();
+            evPnResults.classList.add('kn-ac-open');
+        }
+
+        function evPnSearch(term) {
+            var groups = evPnBuildGroups(term);
+            if (!groups.length) return;
+            var seq = ++evPnSeq;
+            Promise.all(groups.map(function(g) {
+                return fetch(g.url).then(function(r) { return r.json(); }).catch(function() { return []; });
+            })).then(function(resultsArr) {
+                if (seq !== evPnSeq) return;
+                var attended = evAttendedIds();
+                var seen = {};
+                var html = '';
+                groups.forEach(function(g, i) {
+                    html += evPnRenderSection(g.label, resultsArr[i], attended, seen);
+                });
+                if (!html) html = '<div class="ev-ac-empty">No players found</div>';
+                evPnResults.innerHTML = html;
+                evPnOpen();
+            });
+        }
+
+        if (evPnInput && evPnResults) {
+            evPnInput.addEventListener('input', function() {
+                evPnHidden.value = '';
+                evUpdateAddBtn();
+                var term = this.value.trim();
+                if (term.length < 2) {
+                    evPnResults.classList.remove('kn-ac-open');
+                    return;
+                }
+                clearTimeout(evPnTimer);
+                evPnTimer = setTimeout(function() { evPnSearch(term); }, AUTOCOMPLETE_DEBOUNCE_MS);
+            });
+
+            evPnResults.addEventListener('click', function(e) {
+                var item = e.target.closest('.kn-ac-item[data-id]');
+                if (!item) return;
+                evPnInput.value  = decodeURIComponent(item.dataset.name);
+                evPnHidden.value = item.dataset.id;
+                evPnResults.classList.remove('kn-ac-open');
+                evUpdateAddBtn();
+            });
+
+            document.addEventListener('click', function(e) {
+                if (e.target !== evPnInput && !evPnResults.contains(e.target)) {
+                    evPnResults.classList.remove('kn-ac-open');
+                }
+            });
+
+            if (typeof acKeyNav === 'function') {
+                acKeyNav(evPnInput, evPnResults, 'kn-ac-open', '.kn-ac-item');
+            }
+
+            window.addEventListener('scroll', function() {
+                if (evPnResults.classList.contains('kn-ac-open')) evPnPosition();
+            }, true);
+            window.addEventListener('resize', function() {
+                if (evPnResults.classList.contains('kn-ac-open')) evPnPosition();
+            });
+        }
     });
 
     // ---- Hero dominant-color tint ----

--- a/orkui/template/revised-frontend/script/revised.js
+++ b/orkui/template/revised-frontend/script/revised.js
@@ -6598,6 +6598,12 @@ $(document).ready(function() {
             var pid = parseInt(EvConfig.parkId, 10) || 0;
             var base = EvConfig.uir + 'KingdomAjax/playersearch/' + kid;
             var q = '&include_inactive=1&include_suspended=1&q=' + encodeURIComponent(term);
+            // When an abbreviation prefix (e.g. "kcg: miller") is present, the server
+            // ignores scope/park_id and filters by abbreviation instead — use a single
+            // group so results aren't falsely labelled as "Park Members".
+            if (/^[a-z0-9]{2,3}:[a-z0-9*]{0,3}\s+\S/i.test(term)) {
+                return [ { label: 'Players', url: base + '&scope=all' + q } ];
+            }
             if (pid > 0 && kid > 0) {
                 return [
                     { label: 'Park Members',     url: base + '&scope=own&park_id=' + pid + q },
@@ -6652,6 +6658,8 @@ $(document).ready(function() {
                 evUpdateAddBtn();
                 var term = this.value.trim();
                 if (term.length < 2) {
+                    clearTimeout(evPnTimer);
+                    ++evPnSeq;
                     evPnResults.classList.remove('kn-ac-open');
                     return;
                 }

--- a/orkui/template/revised-frontend/script/revised.js
+++ b/orkui/template/revised-frontend/script/revised.js
@@ -9486,6 +9486,49 @@ function setupPronounPicker(cfg) {
                 btn.textContent = 'Revoke Award';
             });
         });
+
+        // Reactivate a revoked award/title — two-click confirm, no modal.
+        $(document).on('click', '.pn-reactivate-btn', function(e) {
+            e.preventDefault();
+            var btn = this;
+            var awardsId = parseInt(btn.getAttribute('data-awards-id'), 10) || 0;
+            if (!awardsId) return;
+            if (!btn.dataset.confirm) {
+                btn.dataset.confirm = '1';
+                btn._origHtml = btn.innerHTML;
+                btn.innerHTML = '<i class="fas fa-check"></i> Confirm Reactivate?';
+                btn._confirmTimer = setTimeout(function() {
+                    btn.dataset.confirm = '';
+                    if (btn._origHtml) btn.innerHTML = btn._origHtml;
+                }, 3000);
+                return;
+            }
+            clearTimeout(btn._confirmTimer);
+            btn.disabled = true;
+            btn.innerHTML = '<i class="fas fa-spinner fa-spin"></i> Reactivating...';
+            fetch(PnConfig.uir + 'PlayerAjax/player/' + PnConfig.playerId + '/reactivateaward', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+                body: 'AwardsId=' + encodeURIComponent(awardsId),
+            })
+            .then(function(r) { return r.json(); })
+            .then(function(data) {
+                if (data.status === 0) {
+                    location.reload();
+                } else {
+                    alert(data.error || 'Error reactivating award.');
+                    btn.disabled = false;
+                    btn.dataset.confirm = '';
+                    if (btn._origHtml) btn.innerHTML = btn._origHtml;
+                }
+            })
+            .catch(function() {
+                alert('Request failed. Please try again.');
+                btn.disabled = false;
+                btn.dataset.confirm = '';
+                if (btn._origHtml) btn.innerHTML = btn._origHtml;
+            });
+        });
     });
 })();
 

--- a/system/lib/ork3/class.Player.php
+++ b/system/lib/ork3/class.Player.php
@@ -405,6 +405,7 @@ class Player extends Ork3 {
 				$response['Awards'][] = array(
 						'AwardsId' => $r->awards_id,
 						'AwardId' => $r->award_id,
+						'KingdomAwardId' => $r->kingdomaward_id,
 						'MundaneId' => $r->mundane_id,
 						'Rank' => $r->rank,
 						'Date' => $r->date,

--- a/system/lib/ork3/class.Player.php
+++ b/system/lib/ork3/class.Player.php
@@ -1404,6 +1404,37 @@ class Player extends Ork3 {
 		}
 	}
 
+	public function ReactivateAward($request) {
+		$mundane_id = Ork3::$Lib->authorization->IsAuthorized($request['Token']);
+		$awards = new yapo($this->db, DB_PREFIX . 'awards');
+		$awards->clear();
+		$awards->awards_id = $request['AwardsId'];
+		if (valid_id($request['AwardsId']) && $awards->find() && $mundane_id > 0) {
+			// Must be a currently revoked award with a valid original recipient on file.
+			if ((int)$awards->revoked !== 1 || !valid_id($awards->stripped_from)) {
+				return InvalidParameter('That award is not currently revoked.');
+			}
+			$recipient = $this->player_info($awards->stripped_from);
+			if (!Ork3::$Lib->authorization->HasAuthority($mundane_id, AUTH_PARK, $recipient['ParkId'], AUTH_CREATE)) {
+				return NoAuthorization();
+			}
+
+			Ork3::$Lib->dangeraudit->audit(__CLASS__ . "::" . __FUNCTION__, $request, 'Player', $awards->stripped_from, $this->get_award($awards));
+
+			$awards->mundane_id    = $awards->stripped_from;
+			$awards->stripped_from = 0;
+			$awards->revoked       = 0;
+			$awards->revoked_at    = null;
+			$awards->revocation    = null;
+			$awards->revoked_by_id = 0;
+			$awards->save();
+
+			return Success($awards->awards_id);
+		} else {
+			return InvalidParameter();
+		}
+	}
+
 	public function UpdateAward($request) {
 		$mundane_id = Ork3::$Lib->authorization->IsAuthorized($request['Token']);
 		$awards = new yapo($this->db, DB_PREFIX . 'awards');

--- a/system/lib/ork3/class.Player.php
+++ b/system/lib/ork3/class.Player.php
@@ -1675,37 +1675,51 @@ class Player extends Ork3 {
             return InvalidParameter();
         }
 
-		// Check for existing award rank
+		// Custom awards (is_ladder = 0 AND is_title = 0) allow unlimited duplicates
+		// and unlimited recommendations — skip both dedup checks entirely.
+		$isCustomAward = false;
+		$this->db->clear();
+		$awardMeta = $this->db->query("SELECT is_ladder, is_title FROM " . DB_PREFIX . "award WHERE award_id = " . (int)$request['AwardId'] . " LIMIT 1");
+		if ($awardMeta && $awardMeta->next()) {
+			$isCustomAward = ((int)$awardMeta->is_ladder === 0 && (int)$awardMeta->is_title === 0);
+		}
+
+		// Check for existing award rank (ladder awards only — custom awards and
+		// titles have rank = 0 and may legitimately be held multiple times).
 		$check_rank = 0;
 		if (trimlen($request['Rank']) > 0) {
 			$check_rank = $request['Rank'];
 		}
-		$existingAward = new yapo($this->db, DB_PREFIX . 'awards');
-		$existingAward->clear();
-		$existingAward->kingdomaward_id = $request['KingdomAwardId'];
-		$existingAward->mundane_id = $request['MundaneId'];
-		$existingAward->rank = $check_rank;
-		$existingAward->find();
-		if ($existingAward->awards_id) {
-			return InvalidParameter('They already have that award.');
+		if ($check_rank > 0) {
+			$existingAward = new yapo($this->db, DB_PREFIX . 'awards');
+			$existingAward->clear();
+			$existingAward->kingdomaward_id = $request['KingdomAwardId'];
+			$existingAward->mundane_id = $request['MundaneId'];
+			$existingAward->rank = $check_rank;
+			$existingAward->find();
+			if ($existingAward->awards_id) {
+				return InvalidParameter('They already have that award.');
+			}
 		}
 
-		// Check for duplicates
-		$dupeRec = new yapo($this->db, DB_PREFIX . 'recommendations');
-		$dupeRec->clear();
-		$dupeRec->kingdomaward_id = $request['KingdomAwardId'];
-		$dupeRec->mundane_id = $request['MundaneId'];
-		$dupeRec->recommended_by_id = $mundane_id;
-		if (trimlen($request['Rank']) > 0) {
-			$dupeRec->rank = $request['Rank'];
-		} else {
-			$dupeRec->rank = 0;
-		}
-		if ($dupeRec->find()) do {
-			if (!$dupeRec->deleted_at) {
-				return InvalidParameter('You already recommended that award and level.');
+		// Check for duplicate recommendations from the same user (skipped for custom awards).
+		if (!$isCustomAward) {
+			$dupeRec = new yapo($this->db, DB_PREFIX . 'recommendations');
+			$dupeRec->clear();
+			$dupeRec->kingdomaward_id = $request['KingdomAwardId'];
+			$dupeRec->mundane_id = $request['MundaneId'];
+			$dupeRec->recommended_by_id = $mundane_id;
+			if (trimlen($request['Rank']) > 0) {
+				$dupeRec->rank = $request['Rank'];
+			} else {
+				$dupeRec->rank = 0;
 			}
-		} while ($dupeRec->next());
+			if ($dupeRec->find()) do {
+				if (!$dupeRec->deleted_at) {
+					return InvalidParameter('You already recommended that award and level.');
+				}
+			} while ($dupeRec->next());
+		}
 
 		if (valid_id($mundane_id)) {
 			$awardRec = new yapo($this->db, DB_PREFIX . 'recommendations');
@@ -1718,6 +1732,9 @@ class Player extends Ork3 {
 			$awardRec->recommended_by_id = $mundane_id;
 			$awardRec->reason = $request['Reason'];
 			$awardRec->save();
+			if (isset(Ork3::$Lib->ghettocache->memcache)) {
+				Ork3::$Lib->ghettocache->memcache->flush();
+			}
 			return Success('Recommendation Added!');
 		} else {
 			return NoAuthorization();
@@ -1743,6 +1760,9 @@ class Player extends Ork3 {
 					$awardRec->deleted_by = $request['RequestedBy'];
 					$awardRec->deleted_at = date('Y-m-d H:i:s');
 					$awardRec->save();
+					if (isset(Ork3::$Lib->ghettocache->memcache)) {
+						Ork3::$Lib->ghettocache->memcache->flush();
+					}
 					return Success('Recommendation Removed!');
 				} else {
 					return InvalidParameter('Only the giver, recipient, or Admin may delete a recommendation.');

--- a/system/lib/ork3/class.Report.php
+++ b/system/lib/ork3/class.Report.php
@@ -437,15 +437,17 @@ class Report  extends Ork3 {
 		}
 
 		$sql = "select
-			a.peerage, ifnull(ka.name, a.name) as award_name, 
-			m.persona, 
-			recs.date_recommended, 
+			a.peerage, ifnull(ka.name, a.name) as award_name,
+			a.is_ladder as a_is_ladder,
+			a.is_title  as a_is_title,
+			m.persona,
+			recs.date_recommended,
 			m.mundane_id,
 			m.park_id,
 			m.kingdom_id,
 			p.name as park_name,
 			k.name as kingdom_name,
-			recs.rank, 
+			recs.rank,
 			rbi.mundane_id as recommended_by_id, rbi.persona as recommended_by_persona,
 			recs.recommendations_id,
 			recs.award_id,
@@ -493,7 +495,11 @@ class Report  extends Ork3 {
 						'KingdomId' => $r->kingdom_id,
 						'ParkName' => $r->park_name,
 						'KingdomName' => $r->kingdom_name,
-						'AlreadyHas' => ($r->kacount > 0 || $r->awcount > 0),
+						// Custom awards (base Award with is_ladder=0 AND is_title=0) can legitimately
+						// be held many times, so they must never be filtered out as "already has".
+						'AlreadyHas' => ((int)$r->a_is_ladder === 0 && (int)$r->a_is_title === 0)
+							? false
+							: ($r->kacount > 0 || $r->awcount > 0),
 						'CurrentRank' => ($r->kacount > 0 || $r->awcount > 0) ? (int)$r->player_ka_rank : null,
 						'CurrentRankDate' => ($r->kacount > 0 || $r->awcount > 0) ? $r->player_ka_date : null,
 					);


### PR DESCRIPTION
## Summary

Four grouped changes that were bundled on the same misc-fixes branch.

### Login redirect
- The global nav **Login** link now passes the current route as a `return` param so that, after login, the user lands back on the page they started from.
- If the user logs in from the **home page** (no `return` context), they are redirected to their **own player profile** instead of the kingdom list.
- Applied to both the password login flow and the Amtgard IDP OAuth callback.

### Event attendance player search
- Replaced the jQuery UI autocomplete with the project's custom `kn-ac-results` dropdown pattern.
- Results are grouped by scope:
  - **Park event:** Park Members → Kingdom Members → Everyone Else.
  - **Kingdom event:** Kingdom Members → Everyone Else.
- The dropdown was being clipped by `.ev-tabs { overflow: hidden }` — it now uses `position: fixed` with JS-computed placement plus scroll/resize listeners so it stays anchored and isn't truncated.

### Award recommendation validation
- **Ladder awards:** inline red warning when the selected rank is at or below the rank the player already holds; submit is blocked until a higher rank is chosen.
- **Titles:** inline red warning when the player already holds the title (*"The player already has this title. Are you sure you wish to continue?"*) — informational only, submission is allowed.
- **Custom awards** (base `is_ladder = 0 AND is_title = 0`): no prevention of any kind. Backend dedup checks and report-level filtering are both bypassed for custom awards, so a player can receive an unlimited number of custom awards / custom titles.
- Fixed the broken error-redirect URL so the `rec_error` query param appends correctly (`?rec_error=` was colliding with `?Route=` — now uses `&rec_error=`).
- Memcached is flushed on successful add/delete of a recommendation so the profile's Recommendations tab refreshes immediately.

### Reactivate revoked awards / titles
- New **Reactivate** button on each row in the Revoked Awards and Revoked Titles tables on the player profile. For undoing accidental revocations.
- Backend `ReactivateAward()` requires the same authority as `RevokeAward` (`AUTH_PARK` / `AUTH_CREATE`) against the original recipient's park (recovered from `stripped_from`). Clears revoked flags, restores `mundane_id`, writes a danger-audit entry, busts the player-details cache.
- AJAX endpoint: `POST PlayerAjax/player/{id}/reactivateaward` with `AwardsId`.
- UI: two-click confirm pattern — first click morphs the button to *"Confirm Reactivate?"*, auto-reverts after 3 seconds; second click fires the request.

## Test plan
- [ ] Log out, navigate to any profile (player/park/kingdom/event), click **Login**, sign in with password → lands back on the profile.
- [ ] Log out, navigate to home page, click **Login** → lands on own player profile.
- [ ] Log out, navigate to profile, sign in via **Amtgard IDP** → lands back on the profile.
- [ ] On a park event's Attendance tab, type in the player search → see Park / Kingdom / Everyone-Else sections; dropdown extends fully below the form, not clipped.
- [ ] On a kingdom event (no park), verify Kingdom / Everyone-Else sections appear.
- [ ] Recommend a ladder award at a rank at-or-below current → inline warning, submit blocked.
- [ ] Recommend a title the player already has → inline warning, submit succeeds.
- [ ] Recommend multiple copies of the same custom award → no errors, all appear on the profile.
- [ ] On a player with revoked awards/titles, click **Reactivate** → confirm prompt appears; click again → award returns to the live list.
- [ ] Confirm a user without park-CREATE authority cannot reactivate (server-side denies the AJAX call).