### PR TITLE
Enhancement: Misc fixes — player roster perf, award rec validation, officer routing, events load-more

### DIFF
--- a/db-migrations/2026-05-07-awards-stripped-from-revoked-index.sql
+++ b/db-migrations/2026-05-07-awards-stripped-from-revoked-index.sql
@@ -1,0 +1,21 @@
+-- Index for player profile revoked awards/titles queries — 2026-05-07
+--
+-- Problem: controller.Player.php fires two queries per admin profile load
+-- against ork_awards filtered by (stripped_from, revoked) and ordered by
+-- (revoked_at DESC, date DESC). ork_awards had no index on stripped_from or
+-- revoked, so each query did a full table scan (~385k rows) plus a filesort,
+-- showing up in the processlist as "Creating sort index" at ~1s each.
+--
+-- This composite index covers the WHERE filter and the ORDER BY: stripped_from
+-- + revoked narrow to a handful of rows; revoked_at + date sit in index order
+-- so MariaDB scans the index backward to satisfy DESC, DESC without sorting.
+--
+-- Result: EXPLAIN went from type=ALL / 385,477 rows / Using filesort to
+-- type=ref / 1 row / Using where (no filesort). Two seconds removed from
+-- every admin profile load.
+--
+-- Safe to run on live production: CREATE INDEX ... IF NOT EXISTS uses online
+-- DDL in MariaDB 10.x+ and does not block reads or writes during build.
+
+CREATE INDEX IF NOT EXISTS idx_awards_stripped_revoked_dates
+    ON ork_awards (stripped_from, revoked, revoked_at, date);

--- a/orkservice/Search/SearchService.registration.php
+++ b/orkservice/Search/SearchService.registration.php
@@ -85,7 +85,8 @@ $server->Register(
 						array( 'limit','request',true,'int',true ),
 						array( 'kingdom_id','request',true,'int',true ),
 						array( 'park_id','request',true,'int',true ),
-						array( 'waivered','request',true,'int',true )
+						array( 'waivered','request',true,'int',true ),
+						array( 'token','request',true,'string',true )
 					)
 			)
 	);

--- a/orkui/controller/controller.Kingdom.php
+++ b/orkui/controller/controller.Kingdom.php
@@ -285,10 +285,16 @@ class Controller_Kingdom extends Controller {
 					MAX(a.date) AS last_signin,
 					SUM(a.date >= DATE_SUB(CURDATE(), INTERVAL 6 MONTH)) AS signin_count
 				FROM ork_attendance a
-				INNER JOIN ork_park kp ON kp.park_id = a.park_id AND kp.kingdom_id = {$kid}
+				INNER JOIN ork_mundane mm
+					ON mm.mundane_id = a.mundane_id
+				   AND mm.suspended = 0 AND mm.active = 1
+				WHERE a.kingdom_id = {$kid}
 				GROUP BY a.mundane_id
 			) sub ON sub.mundane_id = m.mundane_id
-			LEFT JOIN ork_attendance la ON la.mundane_id = m.mundane_id AND la.date = sub.last_signin
+			LEFT JOIN ork_attendance la
+				ON la.mundane_id = m.mundane_id
+			   AND la.date       = sub.last_signin
+			   AND la.kingdom_id = {$kid}
 			LEFT JOIN ork_class c ON la.class_id = c.class_id
 			LEFT JOIN ork_officer o ON o.mundane_id = m.mundane_id AND o.park_id = m.park_id
 			WHERE m.suspended = 0 AND m.active = 1

--- a/orkui/controller/controller.Kingdom.php
+++ b/orkui/controller/controller.Kingdom.php
@@ -245,13 +245,29 @@ class Controller_Kingdom extends Controller {
 				'IsParkEvent'    => (int)$evtResult->park_id > 0,
 			];
 		}
+		// HasMore: not just a window cap — actually check if any events exist past this window.
+		$hasMore = false;
+		if ($window < 10) {
+			$_nextStart = $endMonths;
+			$DB->Clear();
+			$_more = $DB->DataSet(
+				"SELECT 1 FROM ork_event_calendardetail cd
+				 JOIN ork_event e ON e.event_id = cd.event_id
+				 WHERE e.kingdom_id = {$kid}
+				   AND cd.event_start >  DATE_ADD(NOW(), INTERVAL {$_nextStart} MONTH)
+				   AND cd.event_start <= DATE_ADD(NOW(), INTERVAL 120 MONTH)
+				 LIMIT 1"
+			);
+			$hasMore = ($_more && $_more->Size() > 0);
+		}
+
 		header('Content-Type: application/json');
 		echo json_encode([
 			'Window'           => $window,
 			'StartMonths'      => $startMonths,
 			'EndMonths'        => $endMonths,
 			'Count'            => count($events),
-			'HasMore'          => $window < 10,
+			'HasMore'          => $hasMore,
 			'FallbackHeraldry' => $fallbackHeraldry,
 			'Uir'              => UIR,
 			'Events'           => $events,
@@ -270,30 +286,36 @@ class Controller_Kingdom extends Controller {
 			exit();
 		}
 		global $DB;
+		// last_signin = player's MOST RECENT sign-in anywhere — drives the year bucket so active
+		// travelers don't appear "lost" on their home kingdom roster.
+		// signin_count = overall 6-month count (matches the bucket's "anywhere" semantic).
+		// last_signin_in_kingdom drives the la JOIN so the "last class" we display is from
+		// in-kingdom attendance (most relevant to the kingdom page).
 		$kpSql = "SELECT m.mundane_id, m.persona, m.has_image, m.has_heraldry, m.restricted,
-				COALESCE(m.given_name, '')               AS given_name,
-				COALESCE(m.surname, '')                  AS surname,
-				COALESCE(sub.last_signin, '1970-01-01') AS last_signin,
-				COALESCE(sub.signin_count, 0)           AS signin_count,
-				c.name                                  AS last_class,
-				hp.name                                 AS park_name,
+				COALESCE(m.given_name, '')                          AS given_name,
+				COALESCE(m.surname, '')                             AS surname,
+				COALESCE(sub.last_signin, '1970-01-01')             AS last_signin,
+				COALESCE(sub.signin_count, 0)                       AS signin_count,
+				c.name                                              AS last_class,
+				hp.name                                             AS park_name,
 				GROUP_CONCAT(DISTINCT o.role ORDER BY o.role SEPARATOR ', ') AS officer_roles
 			FROM ork_mundane m
 			INNER JOIN ork_park hp ON hp.park_id = m.park_id AND hp.kingdom_id = {$kid}
 			LEFT JOIN (
 				SELECT a.mundane_id,
 					MAX(a.date) AS last_signin,
+					MAX(CASE WHEN a.kingdom_id = {$kid} THEN a.date END) AS last_signin_in_kingdom,
 					SUM(a.date >= DATE_SUB(CURDATE(), INTERVAL 6 MONTH)) AS signin_count
 				FROM ork_attendance a
 				INNER JOIN ork_mundane mm
 					ON mm.mundane_id = a.mundane_id
+				   AND mm.kingdom_id = {$kid}
 				   AND mm.suspended = 0 AND mm.active = 1
-				WHERE a.kingdom_id = {$kid}
 				GROUP BY a.mundane_id
 			) sub ON sub.mundane_id = m.mundane_id
 			LEFT JOIN ork_attendance la
 				ON la.mundane_id = m.mundane_id
-			   AND la.date       = sub.last_signin
+			   AND la.date       = sub.last_signin_in_kingdom
 			   AND la.kingdom_id = {$kid}
 			LEFT JOIN ork_class c ON la.class_id = c.class_id
 			LEFT JOIN ork_officer o ON o.mundane_id = m.mundane_id AND o.park_id = m.park_id
@@ -313,16 +335,16 @@ class Controller_Kingdom extends Controller {
 				$imgUrl  = $hasImg ? HTTP_PLAYER_IMAGE    . Common::resolve_image_ext(DIR_PLAYER_IMAGE,    $midPad) : ($hasHer ? $herUrl : null);
 				$mn = ((int)$r->restricted === 0) ? trim($r->given_name . ' ' . $r->surname) : '';
 				$players[] = [
-					'id'          => $mid,
-					'persona'     => $r->persona,
-					'mundaneName' => $mn,
-					'parkName'    => $r->park_name,
-					'signinCount' => (int)$r->signin_count,
-					'lastSignin'  => $r->last_signin,
-					'lastClass'   => $r->last_class,
-					'officerRoles'=> $r->officer_roles,
-					'avatarUrl'   => $imgUrl,
-					'heraldryUrl' => $herUrl,
+					'id'           => $mid,
+					'persona'      => $r->persona,
+					'mundaneName'  => $mn,
+					'parkName'     => $r->park_name,
+					'signinCount'  => (int)$r->signin_count,
+					'lastSignin'   => $r->last_signin,
+					'lastClass'    => $r->last_class,
+					'officerRoles' => $r->officer_roles,
+					'avatarUrl'    => $imgUrl,
+					'heraldryUrl'  => $herUrl,
 				];
 			}
 		}
@@ -442,6 +464,20 @@ class Controller_Kingdom extends Controller {
 			}
 		}
 		$this->data['event_summary'] = $eventSummary;
+
+		// Hide the "Load more" button when there are no events past the initial 12-month window.
+		// events_more iterates 12-month windows up to 120 months out, so any cd in (12, 120]
+		// months means at least one click would yield results.
+		$DB->Clear();
+		$moreRes = $DB->DataSet(
+			"SELECT 1 FROM ork_event_calendardetail cd
+			 JOIN ork_event e ON e.event_id = cd.event_id
+			 WHERE e.kingdom_id = {$kid}
+			   AND cd.event_start >  DATE_ADD(NOW(), INTERVAL 12 MONTH)
+			   AND cd.event_start <= DATE_ADD(NOW(), INTERVAL 120 MONTH)
+			 LIMIT 1"
+		);
+		$this->data['HasMoreEvents'] = ($moreRes && $moreRes->Size() > 0);
 
 		$pdSql = "
 			SELECT pd.parkday_id, pd.park_id, pd.recurrence, pd.week_day,

--- a/orkui/controller/controller.Kingdom.php
+++ b/orkui/controller/controller.Kingdom.php
@@ -197,6 +197,68 @@ class Controller_Kingdom extends Controller {
 		exit();
 	}
 
+	public function events_more($kingdom_id = null) {
+		$kingdom_id = preg_replace('/[^0-9]/', '', $kingdom_id);
+		$kid = (int)$kingdom_id;
+		$window = isset($_GET['window']) ? (int)$_GET['window'] : 1;
+		if ($window < 1) $window = 1;
+		if ($window > 10) $window = 10;
+		$startMonths = $window * 12;
+		$endMonths   = $startMonths + 12;
+
+		global $DB;
+		$evtSql = "
+			SELECT e.event_id, e.name, e.park_id, p.name AS park_name, p.abbreviation AS park_abbr,
+			       cd.event_start, cd.event_calendardetail_id AS next_detail_id, e.has_heraldry,
+			       (SELECT COUNT(*) FROM ork_event_rsvp WHERE event_calendardetail_id = cd.event_calendardetail_id AND status = 'going') AS rsvp_going,
+			       (SELECT COUNT(*) FROM ork_event_rsvp WHERE event_calendardetail_id = cd.event_calendardetail_id AND status = 'interested') AS rsvp_interested
+			FROM ork_event e
+			LEFT JOIN ork_park p ON p.park_id = e.park_id
+			JOIN ork_event_calendardetail cd ON cd.event_id = e.event_id
+			    AND cd.event_start >  DATE_ADD(NOW(), INTERVAL {$startMonths} MONTH)
+			    AND cd.event_start <= DATE_ADD(NOW(), INTERVAL {$endMonths} MONTH)
+			WHERE e.kingdom_id = {$kid}
+			ORDER BY cd.event_start, p.name, e.name";
+		$DB->Clear();
+		$evtResult = $DB->DataSet($evtSql);
+		$events = [];
+		$fallbackHeraldry = HTTP_EVENT_HERALDRY . '00000.jpg';
+		while ($evtResult && $evtResult->Next()) {
+			$eid = (int)($evtResult->event_id ?? 0);
+			if (!$eid) continue;
+			$start = $evtResult->event_start;
+			$events[] = [
+				'EventId'        => $eid,
+				'Name'           => $evtResult->name,
+				'ParkName'       => $evtResult->park_name,
+				'NextDate'       => $start,
+				'NextDateText'   => ($start && $start !== '0000-00-00 00:00:00' && $start !== '0000-00-00')
+					? date('M j, Y', strtotime($start)) : '',
+				'NextDetailId'   => (int)$evtResult->next_detail_id,
+				'HasHeraldry'    => (int)$evtResult->has_heraldry,
+				'HeraldryUrl'    => ((int)$evtResult->has_heraldry === 1)
+					? HTTP_EVENT_HERALDRY . Common::resolve_image_ext(DIR_EVENT_HERALDRY, sprintf('%05d', $eid))
+					: $fallbackHeraldry,
+				'ParkAbbr'       => $evtResult->park_abbr,
+				'RsvpGoing'      => (int)$evtResult->rsvp_going,
+				'RsvpInterested' => (int)$evtResult->rsvp_interested,
+				'IsParkEvent'    => (int)$evtResult->park_id > 0,
+			];
+		}
+		header('Content-Type: application/json');
+		echo json_encode([
+			'Window'           => $window,
+			'StartMonths'      => $startMonths,
+			'EndMonths'        => $endMonths,
+			'Count'            => count($events),
+			'HasMore'          => $window < 10,
+			'FallbackHeraldry' => $fallbackHeraldry,
+			'Uir'              => UIR,
+			'Events'           => $events,
+		]);
+		exit();
+	}
+
 	public function players_json($kingdom_id = null) {
 		session_write_close(); // release session lock so navigation is not blocked
 		$kingdom_id = preg_replace('/[^0-9]/', '', $kingdom_id);

--- a/orkui/controller/controller.Park.php
+++ b/orkui/controller/controller.Park.php
@@ -156,6 +156,12 @@ class Controller_Park extends Controller
 		$parkPlayers = Ork3::$Lib->ghettocache->get(__CLASS__ . '.park_players', $pkRosterCacheKey, 1200);
 		if ($parkPlayers === false) {
 			$parkPlayers = [];
+			// last_signin = player's MOST RECENT sign-in anywhere — drives the year bucket so
+			// home-park members who've drifted to other parks aren't shown as lost.
+			// signin_count = overall 6-month count (matches the bucket's "anywhere" semantic).
+			// last_signin_at_park drives the la JOIN for last class and the "here X" annotation
+			// shown on the card to identify members who've drifted away.
+			// LEFT JOIN sub (was INNER JOIN) so home-park members who never signed in are still listed.
 			$rosterSql = "
 			SELECT
 				m.mundane_id,
@@ -165,26 +171,28 @@ class Controller_Park extends Controller
 				m.restricted,
 				COALESCE(m.given_name, '') AS given_name,
 				COALESCE(m.surname, '')    AS surname,
-				sub.last_signin,
+				COALESCE(sub.last_signin, '1970-01-01')         AS last_signin,
+				COALESCE(sub.last_signin_at_park, '1970-01-01') AS last_signin_at_park,
 				COUNT(DISTINCT a6.date) AS signin_count,
 				c.name AS last_class,
 				GROUP_CONCAT(DISTINCT o.role ORDER BY o.role SEPARATOR ', ') AS officer_roles
 			FROM ork_mundane m
-			INNER JOIN (
-				SELECT a.mundane_id, MAX(a.date) AS last_signin
+			LEFT JOIN (
+				SELECT a.mundane_id,
+					MAX(a.date) AS last_signin,
+					MAX(CASE WHEN a.park_id = {$pid} THEN a.date END) AS last_signin_at_park
 				FROM ork_attendance a
 				INNER JOIN ork_mundane mm
 					ON mm.mundane_id = a.mundane_id
+				   AND mm.park_id = {$pid}
 				   AND mm.suspended = 0 AND mm.active = 1
-				WHERE a.park_id = {$pid}
 				GROUP BY a.mundane_id
 			) sub ON sub.mundane_id = m.mundane_id
 			LEFT JOIN ork_attendance a6 ON a6.mundane_id = m.mundane_id
-				AND a6.park_id = {$pid}
 				AND a6.date >= DATE_SUB(CURDATE(), INTERVAL 6 MONTH)
 			LEFT JOIN ork_attendance la ON la.mundane_id = m.mundane_id
 				AND la.park_id = {$pid}
-				AND la.date = sub.last_signin
+				AND la.date    = sub.last_signin_at_park
 			LEFT JOIN ork_class c ON la.class_id = c.class_id
 			LEFT JOIN ork_officer o ON o.mundane_id = m.mundane_id AND o.park_id = {$pid}
 			WHERE m.park_id = {$pid}
@@ -198,15 +206,16 @@ class Controller_Park extends Controller
 				do {
 					$mn = ((int)$rosterResult->restricted === 0) ? trim($rosterResult->given_name . ' ' . $rosterResult->surname) : '';
 					$parkPlayers[] = [
-						'MundaneId'    => (int)$rosterResult->mundane_id,
-						'Persona'      => $rosterResult->persona,
-						'MundaneName'  => $mn,
-						'HasImage'     => (int)$rosterResult->has_image > 0,
-						'HasHeraldry'  => (int)$rosterResult->has_heraldry > 0,
-						'SigninCount'  => (int)$rosterResult->signin_count,
-						'LastSignin'   => $rosterResult->last_signin,
-						'LastClass'    => $rosterResult->last_class,
-						'OfficerRoles' => $rosterResult->officer_roles,
+						'MundaneId'        => (int)$rosterResult->mundane_id,
+						'Persona'          => $rosterResult->persona,
+						'MundaneName'      => $mn,
+						'HasImage'         => (int)$rosterResult->has_image > 0,
+						'HasHeraldry'      => (int)$rosterResult->has_heraldry > 0,
+						'SigninCount'      => (int)$rosterResult->signin_count,
+						'LastSignin'       => $rosterResult->last_signin,
+						'LastSigninAtPark' => $rosterResult->last_signin_at_park,
+						'LastClass'        => $rosterResult->last_class,
+						'OfficerRoles'     => $rosterResult->officer_roles,
 					];
 				} while ($rosterResult->Next());
 			}

--- a/orkui/controller/controller.Park.php
+++ b/orkui/controller/controller.Park.php
@@ -171,10 +171,13 @@ class Controller_Park extends Controller
 				GROUP_CONCAT(DISTINCT o.role ORDER BY o.role SEPARATOR ', ') AS officer_roles
 			FROM ork_mundane m
 			INNER JOIN (
-				SELECT mundane_id, MAX(date) AS last_signin
-				FROM ork_attendance
-				WHERE park_id = {$pid}
-				GROUP BY mundane_id
+				SELECT a.mundane_id, MAX(a.date) AS last_signin
+				FROM ork_attendance a
+				INNER JOIN ork_mundane mm
+					ON mm.mundane_id = a.mundane_id
+				   AND mm.suspended = 0 AND mm.active = 1
+				WHERE a.park_id = {$pid}
+				GROUP BY a.mundane_id
 			) sub ON sub.mundane_id = m.mundane_id
 			LEFT JOIN ork_attendance a6 ON a6.mundane_id = m.mundane_id
 				AND a6.park_id = {$pid}

--- a/orkui/controller/controller.Player.php
+++ b/orkui/controller/controller.Player.php
@@ -313,8 +313,8 @@ class Controller_Player extends Controller {
 						} elseif ($r['Status'] == 5) {
 							header('Location: ' . UIR . "Login/login/Player/profile/$id");
 						} else {
-							$msg = urlencode($r['Error'] . ': ' . $r['Detail']);
-							header('Location: ' . UIR . "Player/profile/{$id}&rec_error={$msg}");
+							$msg = urlencode(!empty($r['Detail']) ? $r['Detail'] : $r['Error']);
+							header('Location: ' . UIR . "Player/profile/{$id}?rec_error={$msg}");
 						}
 						exit;
 					case 'deleterecommendation':

--- a/orkui/controller/controller.Search.php
+++ b/orkui/controller/controller.Search.php
@@ -10,6 +10,9 @@ class Controller_Search extends Controller {
 		if ($_uid > 0 && valid_id($this->session->park_id) && Ork3::$Lib->authorization->HasAuthority($_uid, AUTH_PARK, (int)$this->session->park_id, AUTH_EDIT)) {
 			$this->data['menu']['admin'] = array( 'url' => UIR.'Admin/park/'.$this->session->park_id, 'display' => 'Admin Panel <i class="fas fa-cog"></i>', 'no-crumb' => 'no-crumb' );
 		}
+		// Expose the auth token so the search-results JS can pass it to the SOAP service
+		// (admins use it to bypass the restricted-name gate in Search/Player).
+		$this->data['Token'] = $this->session->token ?? '';
 	}
 	
 	public function index($id=null) {

--- a/orkui/controller/controller.SearchAjax.php
+++ b/orkui/controller/controller.SearchAjax.php
@@ -102,10 +102,21 @@ class Controller_SearchAjax extends Controller {
 		// narrow by kingdom/park if abbreviation prefix was parsed
 		$activeClause    = $includeInactive ? '1' : 'm.active = 1';
 		$suspendedClause = $includeInactive ? '1' : 'm.suspended = 0';
+		// ORK admins bypass the restricted-name gate so they can find players by mundane info
+		// for support/moderation. Non-admins continue to only see restricted-name matches when
+		// the player has not opted in to restricted privacy.
+		// HasAuthority() runs yapo internally which sets $DB->Data with bound parameters;
+		// clear them after so the next raw $DB->DataSet() doesn't try to bind them.
+		$_searchUid     = isset($this->session->user_id) ? (int)$this->session->user_id : 0;
+		$isOrkAdmin     = $_searchUid > 0 && Ork3::$Lib->authorization->HasAuthority($_searchUid, AUTH_ADMIN, null, null);
+		$DB->Clear();
+		$mundaneClause  = $isOrkAdmin
+			? "OR m.given_name LIKE '%{$term}%' OR m.surname LIKE '%{$term}%'"
+			: "OR (m.restricted = 0 AND (m.given_name LIKE '%{$term}%' OR m.surname LIKE '%{$term}%'))";
 		$playerWhere = "{$suspendedClause} AND {$activeClause} AND LENGTH(m.persona) > 0
 			  AND (m.persona LIKE '%{$term}%'
 			    OR m.username LIKE '%{$term}%'
-			    OR (m.restricted = 0 AND (m.given_name LIKE '%{$term}%' OR m.surname LIKE '%{$term}%')))";
+			    {$mundaneClause})";
 		if ($filterPid > 0)           { $playerWhere .= " AND m.park_id = {$filterPid}"; }
 		elseif ($filterKid > 0)       { $playerWhere .= " AND m.kingdom_id = {$filterKid}"; }
 		$playerOrder = valid_id($pid)

--- a/orkui/index.php
+++ b/orkui/index.php
@@ -5,6 +5,27 @@ define( 'UIR', HTTP_UI_REMOTE . 'index.php?Route=' );
 
 ini_set("error_reporting", E_ALL & ~E_DEPRECATED & ~E_NOTICE & ~E_WARNING);
 
+if ( isset($_REQUEST['Route']) && $_REQUEST['Route'] === 'Health' ) {
+    $ok = false;
+    try {
+        $r = $DB->query("SELECT 1 AS ok");
+        $ok = ( $r && $r->size() > 0 );
+    } catch (Throwable $e) {
+        $ok = false;
+    }
+    http_response_code( $ok ? 200 : 503 );
+    if ( $_SERVER['REQUEST_METHOD'] !== 'HEAD' ) {
+        header('Content-Type: text/plain');
+        echo $ok ? "OK\n" : "DB UNAVAILABLE\n";
+    }
+    exit;
+}
+
+if ( $_SERVER['REQUEST_METHOD'] === 'HEAD' ) {
+    http_response_code(200);
+    exit;
+}
+
 /***********************************************
  * Simple MVC Site
  *

--- a/orkui/model/model.Award.php
+++ b/orkui/model/model.Award.php
@@ -94,7 +94,11 @@ class Model_Award extends Model {
                 if (empty($items)) continue;
                 $options .= "<optgroup label='" . htmlspecialchars($label, ENT_QUOTES) . "'>";
                 foreach ($items as $award) {
-                    $options .= "<option value='" . htmlspecialchars($award['KingdomAwardId'], ENT_QUOTES) . "'>" . htmlspecialchars($award['KingdomAwardName'], ENT_QUOTES) . "</option>";
+                    $extra = '';
+                    if ($label === 'Masterhoods') {
+                        $extra = " data-award-id='" . htmlspecialchars((int)($award['AwardId'] ?? 0), ENT_QUOTES) . "' data-peerage='Master'";
+                    }
+                    $options .= "<option value='" . htmlspecialchars($award['KingdomAwardId'], ENT_QUOTES) . "'{$extra}>" . htmlspecialchars($award['KingdomAwardName'], ENT_QUOTES) . "</option>";
                 }
                 $options .= "</optgroup>";
             }

--- a/orkui/model/model.Player.php
+++ b/orkui/model/model.Player.php
@@ -59,6 +59,30 @@ class Model_Player extends Model {
 		Ork3::$Lib->ghettocache->bust('Model_Player.fetch_player_details', $key);
 	}
 
+	// Bust the kingdom + park roster caches for the player's current home.
+	// Roster JSON is cached for 20 minutes and was previously never invalidated when a
+	// player's name, persona, or restricted flag changed — leading to stale rosters
+	// (e.g. a restricted player still showed up in client-side searches by mundane name
+	// for up to 20 minutes after the toggle).
+	private function bust_player_roster_caches($request) {
+		$mundane_id = (int)($request['RecipientId'] ?? $request['MundaneId'] ?? 0);
+		if (!$mundane_id) return;
+		global $DB;
+		$DB->Clear();
+		$rs = $DB->DataSet("SELECT kingdom_id, park_id FROM " . DB_PREFIX . "mundane WHERE mundane_id = $mundane_id LIMIT 1");
+		if (!$rs || !$rs->Next()) return;
+		$kid = (int)$rs->kingdom_id;
+		$pid = (int)$rs->park_id;
+		if ($kid > 0) {
+			$kKey = Ork3::$Lib->ghettocache->key(['KingdomId' => $kid]);
+			Ork3::$Lib->ghettocache->bust('Controller_Kingdom.players_json', $kKey);
+		}
+		if ($pid > 0) {
+			$pKey = Ork3::$Lib->ghettocache->key(['ParkId' => $pid]);
+			Ork3::$Lib->ghettocache->bust('Controller_Park.park_players', $pKey);
+		}
+	}
+
 	function delete_player_award($request) {
 		$r = $this->Player->RemoveAward($request);
 		if ($r['Status']['Status'] == 0) $this->bust_player_details_cache($request);
@@ -120,7 +144,10 @@ class Model_Player extends Model {
 	}
   
 	function update_player($request) {
-		return $this->Player->UpdatePlayer($request);
+		$r = $this->Player->UpdatePlayer($request);
+		$this->bust_player_details_cache($request);
+		$this->bust_player_roster_caches($request);
+		return $r;
 	}
 	
 	function set_ban($request) {
@@ -131,17 +158,26 @@ class Model_Player extends Model {
 		return $this->Player->CreatePlayer($request);
 	}
 	function move_player($request) {
+		// Bust source kingdom/park caches BEFORE the move (player still has old park_id),
+		// and again AFTER so the destination's caches refresh too.
+		$this->bust_player_roster_caches($request);
 		$r = $this->Player->MovePlayer($request);
+		$this->bust_player_roster_caches($request);
+		$this->bust_player_details_cache($request);
 		return $r;
 	}
-	
+
 	function suspend_player($request) {
 		$r = $this->Player->SetPlayerSuspension($request);
+		$this->bust_player_roster_caches($request);
+		$this->bust_player_details_cache($request);
 		return $r;
 	}
-	
+
 	function merge_player($request) {
 		$r = $this->Player->MergePlayer($request);
+		$this->bust_player_roster_caches($request);
+		$this->bust_player_details_cache($request);
 		return $r;
 	}
 

--- a/orkui/template/default/Search_index.tpl
+++ b/orkui/template/default/Search_index.tpl
@@ -285,7 +285,8 @@ html[data-theme="dark"] .sr-overflow-warning { background: #744210; color: #fbd3
 			Action:  'Search/Player',
 			search:  term.trim(),
 			type:    'all',
-			limit:   100
+			limit:   100,
+			token:   '<?= htmlspecialchars($Token ?? '', ENT_QUOTES) ?>'
 		};
 		if (_kid > 0) params.kingdom_id = _kid;
 		if (_pid > 0) params.park_id    = _pid;

--- a/orkui/template/revised-frontend/Kingdomnew_index.tpl
+++ b/orkui/template/revised-frontend/Kingdomnew_index.tpl
@@ -483,57 +483,65 @@
 				<!-- List view -->
 				<div id="kn-events-list-view">
 				<?php $hasParkDays = count($kingdom_park_days ?? []) > 0; ?>
-				<?php if (count($eventList) > 0 || $hasParkDays): ?>
-					<table class="kn-table kn-sortable" id="kn-events-table">
-						<thead>
-							<tr>
-								<th data-sorttype="text">Event</th>
-								<th data-sorttype="date">Next Date</th>
-								<th data-sorttype="text">Park</th>
-								<th data-sorttype="numeric">Going</th>
-							<th data-sorttype="numeric">Interested</th>
-							</tr>
-						</thead>
-						<tbody>
-							<?php foreach ($eventList as $event): ?>
-								<tr class="kn-row-link" data-type="<?= $event['_IsParkEvent'] ? 'park-event' : 'kingdom-event' ?>"<?= $event['NextDetailId'] ? ' onclick="window.location.href=\''.UIR.'Event/detail/' . $event['EventId'] . '/' . $event['NextDetailId'] . '\'"' : '' ?>>
-									<td class="kn-col-nowrap">
-										<img class="kn-thumb <?= $event['_IsParkEvent'] ? 'kn-evt-park' : 'kn-evt-kingdom' ?>"
-											loading="lazy"
-											src="<?= $event['HasHeraldry'] == 1 ? HTTP_EVENT_HERALDRY . Common::resolve_image_ext(DIR_EVENT_HERALDRY, sprintf("%05d", $event['EventId'])) : HTTP_EVENT_HERALDRY . '00000.jpg' ?>"
-											onerror="this.src='<?= HTTP_EVENT_HERALDRY ?>00000.jpg'"
-											alt="">
-										<?php if ($event['NextDetailId']): ?><a href="<?= UIR ?>Event/detail/<?= $event['EventId'] ?>/<?= $event['NextDetailId'] ?>"><?= htmlspecialchars($event['Name']) ?></a><?php else: ?><?= htmlspecialchars($event['Name']) ?><?php endif; ?>
-									</td>
-									<td class="kn-col-nowrap">
-										<?php if (0 != $event['NextDate'] && $event['NextDate'] != '0000-00-00'): ?>
-											<?= date("M j, Y", strtotime($event['NextDate'])) ?>
-											<?php if (strtotime($event['NextDate']) < time()): ?><span class='event-past-badge'>Past</span><?php endif; ?>
-										<?php else: ?>
-											<span style="color:#a0aec0">—</span>
-										<?php endif; ?>
-									</td>
-									<td><?= htmlspecialchars($event['ParkName']) ?></td>
-									<td style="text-align:center"><?= (int)($event['RsvpGoing'] ?? 0) ?: '—' ?></td>
-								<td style="text-align:center"><?= (int)($event['RsvpInterested'] ?? 0) ?: '—' ?></td>
-								</tr>
-							<?php endforeach; ?>
-						<?php foreach ($kingdom_park_days ?? [] as $day): ?>
-							<tr class="kn-row-link" data-type="park-day" style="display:none" onclick="window.location.href='<?= UIR ?>Park/profile/<?= $day['ParkId'] ?>'">
-								<td class="kn-col-nowrap" style="color:#718096;font-style:italic"><?= htmlspecialchars($day['Schedule']) ?></td>
+				<?php $eventCount = count($eventList); ?>
+				<?php $hasAnyRows = ($eventCount > 0) || $hasParkDays; ?>
+				<table class="kn-table kn-sortable" id="kn-events-table"<?= $hasAnyRows ? '' : ' style="display:none"' ?>>
+					<thead>
+						<tr>
+							<th data-sorttype="text">Event</th>
+							<th data-sorttype="date">Next Date</th>
+							<th data-sorttype="text">Park</th>
+							<th data-sorttype="numeric">Going</th>
+						<th data-sorttype="numeric">Interested</th>
+						</tr>
+					</thead>
+					<tbody>
+						<?php foreach ($eventList as $event): ?>
+							<tr class="kn-row-link" data-type="<?= $event['_IsParkEvent'] ? 'park-event' : 'kingdom-event' ?>"<?= $event['NextDetailId'] ? ' onclick="window.location.href=\''.UIR.'Event/detail/' . $event['EventId'] . '/' . $event['NextDetailId'] . '\'"' : '' ?>>
 								<td class="kn-col-nowrap">
-									<i class="fas fa-calendar" style="margin-right:6px;color:#a0aec0"></i>
-									<?php if (!empty($day['ParkAbbr'])): ?><strong style="color:#4a5568;margin-right:3px"><?= htmlspecialchars($day['ParkAbbr']) ?>:</strong><?php endif; ?>
-									<?= htmlspecialchars($day['Purpose']) ?> — <?= (!empty($day['Time'])) ? date('g:i A', strtotime($day['Time'])) : '' ?>
+									<img class="kn-thumb <?= $event['_IsParkEvent'] ? 'kn-evt-park' : 'kn-evt-kingdom' ?>"
+										loading="lazy"
+										src="<?= $event['HasHeraldry'] == 1 ? HTTP_EVENT_HERALDRY . Common::resolve_image_ext(DIR_EVENT_HERALDRY, sprintf("%05d", $event['EventId'])) : HTTP_EVENT_HERALDRY . '00000.jpg' ?>"
+										onerror="this.src='<?= HTTP_EVENT_HERALDRY ?>00000.jpg'"
+										alt="">
+									<?php if ($event['NextDetailId']): ?><a href="<?= UIR ?>Event/detail/<?= $event['EventId'] ?>/<?= $event['NextDetailId'] ?>"><?= htmlspecialchars($event['Name']) ?></a><?php else: ?><?= htmlspecialchars($event['Name']) ?><?php endif; ?>
 								</td>
-								<td><?= htmlspecialchars($day['ParkName']) ?></td>
+								<td class="kn-col-nowrap">
+									<?php if (0 != $event['NextDate'] && $event['NextDate'] != '0000-00-00'): ?>
+										<?= date("M j, Y", strtotime($event['NextDate'])) ?>
+										<?php if (strtotime($event['NextDate']) < time()): ?><span class='event-past-badge'>Past</span><?php endif; ?>
+									<?php else: ?>
+										<span style="color:#a0aec0">—</span>
+									<?php endif; ?>
+								</td>
+								<td><?= htmlspecialchars($event['ParkName']) ?></td>
+								<td style="text-align:center"><?= (int)($event['RsvpGoing'] ?? 0) ?: '—' ?></td>
+							<td style="text-align:center"><?= (int)($event['RsvpInterested'] ?? 0) ?: '—' ?></td>
 							</tr>
 						<?php endforeach; ?>
-						</tbody>
-					</table>
-				<?php else: ?>
-					<div class="kn-empty">No upcoming events</div>
-				<?php endif; ?>
+					<?php foreach ($kingdom_park_days ?? [] as $day): ?>
+						<tr class="kn-row-link" data-type="park-day" style="display:none" onclick="window.location.href='<?= UIR ?>Park/profile/<?= $day['ParkId'] ?>'">
+							<td class="kn-col-nowrap" style="color:#718096;font-style:italic"><?= htmlspecialchars($day['Schedule']) ?></td>
+							<td class="kn-col-nowrap">
+								<i class="fas fa-calendar" style="margin-right:6px;color:#a0aec0"></i>
+								<?php if (!empty($day['ParkAbbr'])): ?><strong style="color:#4a5568;margin-right:3px"><?= htmlspecialchars($day['ParkAbbr']) ?>:</strong><?php endif; ?>
+								<?= htmlspecialchars($day['Purpose']) ?> — <?= (!empty($day['Time'])) ? date('g:i A', strtotime($day['Time'])) : '' ?>
+							</td>
+							<td><?= htmlspecialchars($day['ParkName']) ?></td>
+						</tr>
+					<?php endforeach; ?>
+					</tbody>
+				</table>
+				<div class="kn-empty" id="kn-events-empty"<?= $hasAnyRows ? ' style="display:none"' : '' ?>>No upcoming events</div>
+
+				<div class="kn-events-loadmore" id="kn-events-loadmore" data-next-window="1" data-loaded-event-count="<?= $eventCount ?>">
+					<span class="kn-events-loadmore-msg">
+						Showing <strong id="kn-events-loadmore-count"><?= $eventCount ?></strong>
+						event<span id="kn-events-loadmore-plural"><?= $eventCount === 1 ? '' : 's' ?></span>
+						in the next <strong id="kn-events-loadmore-months">12</strong> months.
+					</span>
+					<a href="#" class="kn-events-loadmore-link" id="kn-events-loadmore-link" onclick="knLoadMoreEvents(event); return false;">Load more <i class="fas fa-chevron-down" style="font-size:10px;margin-left:3px"></i></a>
+				</div>
 				</div><!-- /kn-events-list-view -->
 
 				<?php /* [TOURNAMENTS HIDDEN] */ ?>
@@ -744,7 +752,7 @@
 							<dt>Below Recommended</dt>
 							<dd>Players who haven&rsquo;t yet reached the recommended rank. The core action list &mdash; Grant these.</dd>
 							<dt>Non-Ladder</dt>
-							<dd>Flat awards with no rank progression (e.g. service awards). Grant or Delete as appropriate.</dd>
+							<dd>Includes titles such as Master, Noble, or Knight, custom awards, and other non-ranked options. Grant or Delete as appropriate.</dd>
 							<dt>At or Above Recommended</dt>
 							<dd>Players who already hold this award at or above the recommended rank. The rec has been fulfilled &mdash; Delete these to keep the list tidy.</dd>
 							<dt>All</dt>
@@ -2178,6 +2186,131 @@ html[data-theme="dark"] .kn-btn-danger { background: #fc8181; color: #1a202c; bo
 	});
 
 })();
+</script>
+<script>
+// ---- Events: Load-more (next 12-month window) ----
+function knLoadMoreEvents(ev) {
+	if (ev) ev.preventDefault();
+	var wrap = document.getElementById('kn-events-loadmore');
+	var link = document.getElementById('kn-events-loadmore-link');
+	if (!wrap || !link) return;
+	var nextWindow = parseInt(wrap.dataset.nextWindow || '1', 10);
+	var kingdomId = (window.KnConfig && KnConfig.kingdomId) || 0;
+	var uir       = (window.KnConfig && KnConfig.uir)       || '<?= UIR ?>';
+	if (!kingdomId) return;
+
+	var origHtml = link.innerHTML;
+	link.innerHTML = '<i class="fas fa-spinner fa-spin"></i> Loading...';
+	link.style.pointerEvents = 'none';
+	link.setAttribute('aria-busy', 'true');
+
+	fetch(uir + 'Kingdom/events_more/' + kingdomId + '&window=' + nextWindow, { credentials: 'same-origin' })
+		.then(function(r) {
+			if (!r.ok) throw new Error('HTTP ' + r.status);
+			return r.json();
+		})
+		.then(function(data) {
+			var table = document.getElementById('kn-events-table');
+			var tbody = table ? table.querySelector('tbody') : null;
+			if (!tbody) return;
+
+			// Reveal the table if it was hidden (empty-state page)
+			if (table.style.display === 'none') table.style.display = '';
+			var emptyEl = document.getElementById('kn-events-empty');
+			if (emptyEl) emptyEl.style.display = 'none';
+
+			// Append the new rows
+			var appended = 0;
+			(data.Events || []).forEach(function(e) {
+				// Skip duplicates (shouldn't happen with non-overlapping windows, but defensive)
+				if (document.querySelector('#kn-events-table tr[data-event-id="' + e.EventId + '"]')) return;
+				tbody.appendChild(knBuildEventRow(e, data.FallbackHeraldry, data.Uir || uir));
+				appended++;
+			});
+
+			// Update count + months in footer
+			var countEl  = document.getElementById('kn-events-loadmore-count');
+			var pluralEl = document.getElementById('kn-events-loadmore-plural');
+			var monthsEl = document.getElementById('kn-events-loadmore-months');
+			var prevLoaded = parseInt(wrap.dataset.loadedEventCount || '0', 10);
+			var total = prevLoaded + appended;
+			wrap.dataset.loadedEventCount = String(total);
+			if (countEl)  countEl.textContent  = String(total);
+			if (pluralEl) pluralEl.textContent = (total === 1 ? '' : 's');
+			if (monthsEl) monthsEl.textContent = String(data.EndMonths);
+
+			wrap.dataset.nextWindow = String(nextWindow + 1);
+
+			// Respect current filter toggles for newly-appended rows
+			try {
+				if (typeof knFilters === 'object' && knFilters) {
+					Object.keys(knFilters).forEach(function(type) {
+						if (!knFilters[type]) {
+							var rows = tbody.querySelectorAll('tr[data-type="' + type + '"]');
+							rows.forEach(function(tr) { tr.style.display = 'none'; });
+						}
+					});
+				}
+			} catch (e) { console.warn('[knLoadMoreEvents] filter reapply failed', e); }
+
+			// Re-run pagination if present
+			try { if (typeof knPaginate === 'function' && window.jQuery) knPaginate(window.jQuery('#kn-events-table'), 1); } catch(e) {}
+
+			// Calendar view: invalidate so next open re-fetches
+			try { if (window.knCalendar) knCalendar.refetchEvents(); } catch(e) {}
+
+			if (!data.HasMore) {
+				link.remove();
+			} else {
+				link.innerHTML = 'Load more <i class="fas fa-chevron-down" style="font-size:10px;margin-left:3px"></i>';
+				link.style.pointerEvents = '';
+				link.removeAttribute('aria-busy');
+			}
+		})
+		.catch(function(err) {
+			console.error('[knLoadMoreEvents]', err);
+			link.innerHTML = origHtml;
+			link.style.pointerEvents = '';
+			link.removeAttribute('aria-busy');
+		});
+}
+
+function knBuildEventRow(e, fallbackHeraldry, uir) {
+	var tr = document.createElement('tr');
+	tr.className = 'kn-row-link';
+	tr.dataset.type    = e.IsParkEvent ? 'park-event' : 'kingdom-event';
+	tr.dataset.eventId = String(e.EventId);
+	var detailHref = e.NextDetailId ? (uir + 'Event/detail/' + e.EventId + '/' + e.NextDetailId) : '';
+	if (detailHref) tr.setAttribute('onclick', "window.location.href='" + detailHref + "'");
+
+	var nameHtml = detailHref
+		? '<a href="' + detailHref + '">' + knEscape(e.Name) + '</a>'
+		: knEscape(e.Name);
+	var dateHtml = e.NextDateText ? knEscape(e.NextDateText) : '<span style="color:#a0aec0">&mdash;</span>';
+	var heraldry = e.HeraldryUrl || fallbackHeraldry;
+
+	tr.innerHTML =
+		'<td class="kn-col-nowrap">' + dateHtml + '</td>' +
+		'<td class="kn-col-nowrap">' +
+			'<img class="kn-thumb ' + (e.IsParkEvent ? 'kn-evt-park' : 'kn-evt-kingdom') +
+				'" loading="lazy" src="' + knEscapeAttr(heraldry) +
+				'" onerror="this.src=\'' + knEscapeAttr(fallbackHeraldry) + '\'" alt="">' +
+			nameHtml +
+		'</td>' +
+		'<td>' + knEscape(e.ParkName || '') + '</td>' +
+		'<td style="text-align:center">' + (e.RsvpGoing > 0 ? e.RsvpGoing : '&mdash;') + '</td>' +
+		'<td style="text-align:center">' + (e.RsvpInterested > 0 ? e.RsvpInterested : '&mdash;') + '</td>';
+	return tr;
+}
+
+function knEscape(s) {
+	var d = document.createElement('div');
+	d.textContent = (s == null ? '' : String(s));
+	return d.innerHTML;
+}
+function knEscapeAttr(s) {
+	return String(s == null ? '' : s).replace(/&/g,'&amp;').replace(/"/g,'&quot;').replace(/'/g,'&#39;');
+}
 </script>
 <script src="<?= HTTP_TEMPLATE ?>revised-frontend/script/email-spell-checker.min.js"></script>
 <script src="<?= HTTP_TEMPLATE ?>revised-frontend/script/revised.js?v=<?= filemtime(__DIR__ . '/script/revised.js') ?>"></script>

--- a/orkui/template/revised-frontend/Kingdomnew_index.tpl
+++ b/orkui/template/revised-frontend/Kingdomnew_index.tpl
@@ -540,7 +540,9 @@
 						event<span id="kn-events-loadmore-plural"><?= $eventCount === 1 ? '' : 's' ?></span>
 						in the next <strong id="kn-events-loadmore-months">12</strong> months.
 					</span>
+					<?php if (!empty($HasMoreEvents)): ?>
 					<a href="#" class="kn-events-loadmore-link" id="kn-events-loadmore-link" onclick="knLoadMoreEvents(event); return false;">Load more <i class="fas fa-chevron-down" style="font-size:10px;margin-left:3px"></i></a>
+					<?php endif; ?>
 				</div>
 				</div><!-- /kn-events-list-view -->
 
@@ -828,6 +830,7 @@
 						<i class="fas fa-search kn-player-search-icon"></i>
 						<input type="text" id="kn-player-search" class="kn-player-search-input" placeholder="Search all players&hellip;" autocomplete="off">
 					</div>
+					<button class="kn-view-btn" id="kn-active-only-btn" type="button" title="Show only members with sign-ins in the past 6 months"><i class="fas fa-filter"></i> Active only</button>
 					<div class="kn-view-toggle">
 						<button class="kn-view-btn kn-view-active" data-knview="cards"><i class="fas fa-th-large"></i> Cards</button>
 						<button class="kn-view-btn" data-knview="list"><i class="fas fa-list"></i> List</button>
@@ -2007,12 +2010,12 @@ html[data-theme="dark"] .kn-btn-danger { background: #fc8181; color: #1a202c; bo
 		}).join('');
 		var classSpan = p.lastClass ? '<span><i class="fas fa-shield-alt" style="color:#b794f4;width:14px"></i> ' + knHtmlEsc(p.lastClass) + '</span>' : '';
 		var mnAttr = p.mundaneName ? ' data-mundane-name="' + knHtmlEsc(p.mundaneName.toLowerCase()) + '"' : '';
-		return '<a class="kn-player-card' + hbgClass + '"' + hbgAttr + mnAttr + ' href="' + uir + 'Player/profile/' + p.id + '">'
+		return '<a class="kn-player-card' + hbgClass + '"' + hbgAttr + mnAttr + ' data-signin-count="' + p.signinCount + '" href="' + uir + 'Player/profile/' + p.id + '">'
 			+ '<div class="kn-player-card-top"><div class="kn-player-avatar">' + avatarHtml + '</div>'
 			+ '<div><div class="kn-player-name">' + knHtmlEsc(p.persona) + '</div>' + pills + '</div></div>'
 			+ '<div class="kn-player-stats">'
 			+ '<span><i class="fas fa-map-marker-alt" style="color:#68d391;width:14px"></i> ' + knHtmlEsc(p.parkName) + '</span>'
-			+ '<span><i class="fas fa-check-circle" style="color:#68d391;width:14px"></i> ' + p.signinCount + ' sign-in' + (p.signinCount !== 1 ? 's' : '') + '</span>'
+			+ '<span><i class="fas fa-check-circle" style="color:#68d391;width:14px"></i> ' + p.signinCount + ' six month sign-in' + (p.signinCount !== 1 ? 's' : '') + '</span>'
 			+ '<span><i class="fas fa-calendar-check" style="color:#63b3ed;width:14px"></i> ' + knFmtDate(p.lastSignin) + '</span>'
 			+ classSpan + '</div></a>';
 	}
@@ -2021,7 +2024,7 @@ html[data-theme="dark"] .kn-btn-danger { background: #fc8181; color: #1a202c; bo
 			return '<span class="kn-officer-pill">' + knHtmlEsc(r.trim()) + '</span>';
 		}).join('');
 		var mnAttr = p.mundaneName ? ' data-mundane-name="' + knHtmlEsc(p.mundaneName.toLowerCase()) + '"' : '';
-		return '<tr' + mnAttr + ' onclick=\'window.location.href="' + uir + 'Player/profile/' + p.id + '"\'>'
+		return '<tr' + mnAttr + ' data-signin-count="' + p.signinCount + '" onclick=\'window.location.href="' + uir + 'Player/profile/' + p.id + '"\'>'
 			+ '<td>' + knHtmlEsc(p.persona) + pills + '</td>'
 			+ '<td>' + knHtmlEsc(p.parkName || '') + '</td>'
 			+ '<td data-sortval="' + p.signinCount + '">' + p.signinCount + '</td>'
@@ -2105,7 +2108,7 @@ html[data-theme="dark"] .kn-btn-danger { background: #fc8181; color: #1a202c; bo
 						+ '<table class="kn-table kn-year-table"><thead><tr>'
 						+ '<th data-sorttype="text">Persona</th>'
 						+ '<th data-sorttype="text">Park</th>'
-						+ '<th data-sorttype="numeric">Sign-ins</th>'
+						+ '<th data-sorttype="numeric">6mo Sign-ins</th>'
 						+ '<th data-sorttype="date">Last Visit</th>'
 						+ '<th data-sorttype="text">Last Class</th>'
 						+ '<th data-sorttype="text">Role</th>'
@@ -2134,42 +2137,49 @@ html[data-theme="dark"] .kn-btn-danger { background: #fc8181; color: #1a202c; bo
 		var btn = document.querySelector('[data-kntab="players"]');
 		if (btn) btn.addEventListener('click', knLoadPlayers, {once: true});
 
-		var searchInput = document.getElementById('kn-player-search');
-		if (searchInput) {
-			searchInput.addEventListener('input', function() {
-				var q = this.value.trim().toLowerCase();
-				var roots = [
-					document.getElementById('kn-players-cards'),
-					document.getElementById('kn-players-list')
-				];
-				roots.forEach(function(root) {
-					if (!root) return;
-					// Cards
-					root.querySelectorAll('.kn-player-card').forEach(function(card) {
-						var nameEl = card.querySelector('.kn-player-name');
-						var pName  = nameEl ? nameEl.textContent.toLowerCase() : '';
-						var mn     = (card.dataset.mundaneName || '').toLowerCase();
-						card.style.display = (!q || pName.indexOf(q) !== -1 || mn.indexOf(q) !== -1) ? '' : 'none';
-					});
-					// List rows
-					root.querySelectorAll('.kn-year-table tbody tr').forEach(function(row) {
-						var persona = row.cells[0] ? row.cells[0].textContent.toLowerCase() : '';
-						var mn      = (row.dataset.mundaneName || '').toLowerCase();
-						row.style.display = (!q || persona.indexOf(q) !== -1 || mn.indexOf(q) !== -1) ? '' : 'none';
-					});
-					// Auto-open + collapse year sections based on visible content during search
-					root.querySelectorAll('.kn-year-section').forEach(function(sec) {
-						if (!q) return; // leave default open/closed state alone when search is cleared
-						var hasMatch = sec.querySelector('.kn-player-card:not([style*="display: none"]), .kn-year-table tbody tr:not([style*="display: none"])');
-						sec.style.display = hasMatch ? '' : 'none';
-						if (hasMatch) sec.open = true;
-					});
-					if (!q) {
-						root.querySelectorAll('.kn-year-section').forEach(function(sec) { sec.style.display = ''; });
-					}
+		function knApplyPlayerFilters() {
+			var qInput = document.getElementById('kn-player-search');
+			var q = (qInput ? qInput.value : '').trim().toLowerCase();
+			var aoBtn = document.getElementById('kn-active-only-btn');
+			var activeOnly = aoBtn && aoBtn.classList.contains('kn-view-active');
+			var roots = [
+				document.getElementById('kn-players-cards'),
+				document.getElementById('kn-players-list')
+			];
+			roots.forEach(function(root) {
+				if (!root) return;
+				root.querySelectorAll('.kn-player-card').forEach(function(card) {
+					var nameEl = card.querySelector('.kn-player-name');
+					var pName  = nameEl ? nameEl.textContent.toLowerCase() : '';
+					var mn     = (card.dataset.mundaneName || '').toLowerCase();
+					var sc     = parseInt(card.dataset.signinCount || '0', 10);
+					var match  = (!q || pName.indexOf(q) !== -1 || mn.indexOf(q) !== -1) && (!activeOnly || sc > 0);
+					card.style.display = match ? '' : 'none';
+				});
+				root.querySelectorAll('.kn-year-table tbody tr').forEach(function(row) {
+					var persona = row.cells[0] ? row.cells[0].textContent.toLowerCase() : '';
+					var mn      = (row.dataset.mundaneName || '').toLowerCase();
+					var sc      = parseInt(row.dataset.signinCount || '0', 10);
+					var match   = (!q || persona.indexOf(q) !== -1 || mn.indexOf(q) !== -1) && (!activeOnly || sc > 0);
+					row.style.display = match ? '' : 'none';
+				});
+				var filtering = q || activeOnly;
+				root.querySelectorAll('.kn-year-section').forEach(function(sec) {
+					if (!filtering) { sec.style.display = ''; return; }
+					var hasMatch = sec.querySelector('.kn-player-card:not([style*="display: none"]), .kn-year-table tbody tr:not([style*="display: none"])');
+					sec.style.display = hasMatch ? '' : 'none';
+					if (hasMatch) sec.open = true;
 				});
 			});
 		}
+
+		var searchInput = document.getElementById('kn-player-search');
+		if (searchInput) searchInput.addEventListener('input', knApplyPlayerFilters);
+		var aoBtn = document.getElementById('kn-active-only-btn');
+		if (aoBtn) aoBtn.addEventListener('click', function() {
+			this.classList.toggle('kn-view-active');
+			knApplyPlayerFilters();
+		});
 	});
 
 	window.knCopyIcsUrl = function() {

--- a/orkui/template/revised-frontend/Kingdomnew_index.tpl
+++ b/orkui/template/revised-frontend/Kingdomnew_index.tpl
@@ -2204,7 +2204,7 @@ function knLoadMoreEvents(ev) {
 	link.style.pointerEvents = 'none';
 	link.setAttribute('aria-busy', 'true');
 
-	fetch(uir + 'Kingdom/events_more/' + kingdomId + '&window=' + nextWindow, { credentials: 'same-origin' })
+	fetch(uir + 'Kingdom/events_more/' + kingdomId + '?window=' + nextWindow, { credentials: 'same-origin' })
 		.then(function(r) {
 			if (!r.ok) throw new Error('HTTP ' + r.status);
 			return r.json();

--- a/orkui/template/revised-frontend/Kingdomnew_index.tpl
+++ b/orkui/template/revised-frontend/Kingdomnew_index.tpl
@@ -848,28 +848,7 @@
 			</div>
 			<div id="kn-players-loading" style="text-align:center;padding:32px;color:#a0aec0"><i class="fas fa-spinner fa-spin"></i> Loading players&hellip;</div>
 			<div id="kn-players-cards" style="display:none"></div>
-			<div id="kn-players-list" style="display:none">
-				<table class="kn-table" id="kn-players-table">
-					<thead>
-						<tr>
-							<th data-sorttype="text">Persona</th>
-							<th data-sorttype="text">Park</th>
-							<th data-sorttype="numeric">Sign-ins</th>
-							<th data-sorttype="date">Last Visit</th>
-							<th data-sorttype="text">Last Class</th>
-							<th data-sorttype="text">Role</th>
-						</tr>
-					</thead>
-					<tbody id="kn-players-tbody"></tbody>
-				</table>
-				<div id="kn-players-list-more" style="display:none">
-					<div class="kn-load-more-wrap kn-load-more-list" data-next="1">
-						<button class="kn-load-more-btn" onclick="knLoadMoreList('kn-players-table', 'kn-players-tmpl', this)"><i class="fas fa-chevron-down"></i> Load More...</button>
-						<span class="kn-load-more-hint" id="kn-players-list-hint"></span>
-					</div>
-				</div>
-				<div class="kn-pagination" id="kn-players-table-pages"></div>
-			</div>
+			<div id="kn-players-list" style="display:none"></div>
 		</div><!-- /kn-tab-players -->
 
 		</div><!-- /kn-tabs -->
@@ -2060,67 +2039,84 @@ html[data-theme="dark"] .kn-btn-danger { background: #fc8181; color: #1a202c; bo
 			.then(function(r) { return r.json(); })
 			.then(function(data) {
 				knPlayersLoaded = true;
-				var players  = data.players || [];
-				var nowTs    = Math.floor(Date.now() / 1000);
-				var periods  = {};
-				players.forEach(function(p) {
-					var ts     = new Date((p.lastSignin || '1970-01-01') + 'T00:00:00').getTime() / 1000;
-					var period = Math.max(0, Math.floor((nowTs - ts) / (30.44 * 24 * 3600 * 6)));
-					if (!periods[period]) periods[period] = [];
-					periods[period].push(p);
-				});
-				var periodKeys = Object.keys(periods).map(Number).sort(function(a,b){return a-b;});
-				var active = (periods[0] || []).length, total = players.length;
+				var players = data.players || [];
+				var total   = players.length;
 
-				// Update tab count
+				// Bucket by year of last sign-in. Use a sentinel "Inactive" bucket for
+				// players whose last_signin is the 1970 default (never attended).
+				var byYear = {};
+				var nowYear = new Date().getFullYear();
+				var sixMoCutoff = Date.now() - 6 * 30.44 * 24 * 3600 * 1000;
+				var activeRecent = 0;
+				players.forEach(function(p) {
+					var raw = p.lastSignin || '1970-01-01';
+					var key;
+					if (raw === '1970-01-01' || raw.indexOf('1970') === 0) {
+						key = 'never';
+					} else {
+						key = raw.slice(0, 4); // YYYY
+					}
+					(byYear[key] = byYear[key] || []).push(p);
+					var ts = new Date(raw + 'T00:00:00').getTime();
+					if (ts >= sixMoCutoff) activeRecent++;
+				});
+
+				// Sort keys: real years descending (newest first), 'never' last.
+				var yearKeys = Object.keys(byYear).filter(function(k){ return k !== 'never'; })
+					.sort(function(a,b){ return b.localeCompare(a); });
+				if (byYear.never) yearKeys.push('never');
+
+				// Update tab count + summary line
 				var tabCount = document.getElementById('kn-players-tab-count');
 				if (tabCount) tabCount.textContent = '(' + total + ')';
-				// Update summary line
 				var summEl = document.getElementById('kn-players-summary');
-				if (summEl) summEl.textContent = active + ' active member' + (active!==1?'s':'') + ' (past 6 months)' + (total > active ? ' · ' + total + ' total' : '');
+				if (summEl) {
+					summEl.textContent = activeRecent + ' active member' + (activeRecent!==1?'s':'')
+						+ ' (past 6 months)' + (total > activeRecent ? ' · ' + total + ' total' : '');
+				}
 
-				// Build cards HTML
+				// Build year-bucketed cards + list sections in one pass.
 				var cardsEl = document.getElementById('kn-players-cards');
-				if (cardsEl) {
-					var html = '<div class="kn-players-grid">' + (periods[0]||[]).map(function(p){return knPlayerCardHtml(p,uir);}).join('') + '</div>';
-					periodKeys.slice(1).forEach(function(period) {
-						html += '<div class="kn-period-block" id="kn-players-block-' + period + '" style="display:none">'
-							+ '<div class="kn-period-label">' + (period*6) + '–' + ((period+1)*6) + ' months ago</div>'
-							+ '<div class="kn-players-grid">' + periods[period].map(function(p){return knPlayerCardHtml(p,uir);}).join('') + '</div>'
-							+ '</div>';
-					});
-					if (periodKeys.length > 1) {
-						html += '<div class="kn-load-more-wrap" data-next="1" data-group="kn-players">'
-							+ '<button class="kn-load-more-btn" onclick="knLoadMoreCards(\'kn-players\',this)"><i class="fas fa-chevron-down"></i> Load More...</button>'
-							+ '<span class="kn-load-more-hint">Showing ' + active + ' of ' + total + ' members</span>'
-							+ '</div>';
-					}
-					cardsEl.innerHTML = html;
-					cardsEl.style.display = '';
-				}
+				var listEl  = document.getElementById('kn-players-list');
+				var cardsHtml = [];
+				var listHtml  = [];
+				yearKeys.forEach(function(yk, idx) {
+					var bucket = byYear[yk];
+					var label  = (yk === 'never') ? 'No recorded sign-ins' : yk;
+					if (yk !== 'never' && yk == nowYear) label = yk + ' (current)';
+					var openAttr = idx === 0 ? ' open' : '';
+					var count    = bucket.length;
+					var summary  =
+						'<summary class="kn-year-summary">'
+						+ '<span class="kn-year-label">' + label + '</span>'
+						+ '<span class="kn-year-count">' + count + ' member' + (count!==1?'s':'') + '</span>'
+						+ '</summary>';
 
-				// Build list tbody + templates
-				var tbody = document.getElementById('kn-players-tbody');
-				if (tbody) {
-					tbody.innerHTML = (periods[0]||[]).map(function(p){return knPlayerRowHtml(p,uir);}).join('');
-					var table = document.getElementById('kn-players-table');
-					if (table) {
-						periodKeys.slice(1).forEach(function(period) {
-							var tmpl = document.createElement('template');
-							tmpl.id = 'kn-players-tmpl-' + period;
-							tmpl.innerHTML = periods[period].map(function(p){return knPlayerRowHtml(p,uir);}).join('');
-							table.parentNode.insertBefore(tmpl, table.nextSibling);
-						});
-					}
-					if (periodKeys.length > 1) {
-						var moreWrap = document.getElementById('kn-players-list-more');
-						if (moreWrap) {
-							moreWrap.style.display = '';
-							var hint = document.getElementById('kn-players-list-hint');
-							if (hint) hint.textContent = 'Showing ' + active + ' of ' + total + ' members';
-						}
-					}
-				}
+					cardsHtml.push(
+						'<details class="kn-year-section"' + openAttr + ' data-year="' + yk + '">'
+						+ summary
+						+ '<div class="kn-players-grid">'
+						+ bucket.map(function(p){ return knPlayerCardHtml(p, uir); }).join('')
+						+ '</div></details>'
+					);
+					listHtml.push(
+						'<details class="kn-year-section"' + openAttr + ' data-year="' + yk + '">'
+						+ summary
+						+ '<table class="kn-table kn-year-table"><thead><tr>'
+						+ '<th data-sorttype="text">Persona</th>'
+						+ '<th data-sorttype="text">Park</th>'
+						+ '<th data-sorttype="numeric">Sign-ins</th>'
+						+ '<th data-sorttype="date">Last Visit</th>'
+						+ '<th data-sorttype="text">Last Class</th>'
+						+ '<th data-sorttype="text">Role</th>'
+						+ '</tr></thead><tbody>'
+						+ bucket.map(function(p){ return knPlayerRowHtml(p, uir); }).join('')
+						+ '</tbody></table></details>'
+					);
+				});
+
+				if (cardsEl) { cardsEl.innerHTML = cardsHtml.join(''); cardsEl.style.display = ''; }
+				if (listEl)  { listEl.innerHTML  = listHtml.join('');  /* keeps display:none until view toggle */ }
 
 				// Hide spinner
 				var loadEl = document.getElementById('kn-players-loading');
@@ -2142,23 +2138,36 @@ html[data-theme="dark"] .kn-btn-danger { background: #fc8181; color: #1a202c; bo
 		if (searchInput) {
 			searchInput.addEventListener('input', function() {
 				var q = this.value.trim().toLowerCase();
-				var tbody = document.getElementById('kn-players-tbody');
-				if (tbody) {
-					tbody.querySelectorAll('tr').forEach(function(row) {
+				var roots = [
+					document.getElementById('kn-players-cards'),
+					document.getElementById('kn-players-list')
+				];
+				roots.forEach(function(root) {
+					if (!root) return;
+					// Cards
+					root.querySelectorAll('.kn-player-card').forEach(function(card) {
+						var nameEl = card.querySelector('.kn-player-name');
+						var pName  = nameEl ? nameEl.textContent.toLowerCase() : '';
+						var mn     = (card.dataset.mundaneName || '').toLowerCase();
+						card.style.display = (!q || pName.indexOf(q) !== -1 || mn.indexOf(q) !== -1) ? '' : 'none';
+					});
+					// List rows
+					root.querySelectorAll('.kn-year-table tbody tr').forEach(function(row) {
 						var persona = row.cells[0] ? row.cells[0].textContent.toLowerCase() : '';
-						var mundane = (row.dataset.mundaneName || '').toLowerCase();
-						row.style.display = (!q || persona.indexOf(q) !== -1 || mundane.indexOf(q) !== -1) ? '' : 'none';
+						var mn      = (row.dataset.mundaneName || '').toLowerCase();
+						row.style.display = (!q || persona.indexOf(q) !== -1 || mn.indexOf(q) !== -1) ? '' : 'none';
 					});
-				}
-				var cards = document.getElementById('kn-players-cards');
-				if (cards) {
-					cards.querySelectorAll('.kn-player-card').forEach(function(card) {
-						var persona = card.querySelector('.kn-player-name');
-						var pName = persona ? persona.textContent.toLowerCase() : '';
-						var mundane = (card.dataset.mundaneName || '').toLowerCase();
-						card.style.display = (!q || pName.indexOf(q) !== -1 || mundane.indexOf(q) !== -1) ? '' : 'none';
+					// Auto-open + collapse year sections based on visible content during search
+					root.querySelectorAll('.kn-year-section').forEach(function(sec) {
+						if (!q) return; // leave default open/closed state alone when search is cleared
+						var hasMatch = sec.querySelector('.kn-player-card:not([style*="display: none"]), .kn-year-table tbody tr:not([style*="display: none"])');
+						sec.style.display = hasMatch ? '' : 'none';
+						if (hasMatch) sec.open = true;
 					});
-				}
+					if (!q) {
+						root.querySelectorAll('.kn-year-section').forEach(function(sec) { sec.style.display = ''; });
+					}
+				});
 			});
 		}
 	});

--- a/orkui/template/revised-frontend/Parknew_index.tpl
+++ b/orkui/template/revised-frontend/Parknew_index.tpl
@@ -38,23 +38,34 @@
 		? 'https://maps.google.com/maps?q=@' . $parkLat . ',' . $parkLng
 		: null;
 
-	// Group all players by 6-month period (0 = 0–6 months ago, 1 = 6–12, etc.)
-	$allPlayers = $park_players ?? [];
-	$nowTs      = time();
-	$playerPeriods  = [];
-	$heraldryPeriods = [];
+	// Group all players by year of last sign-in (newest year first; 'never' last).
+	// Also separately track players whose last signin is within the past 6 months
+	// (for the "active member" stat) and 12 months (for the Heraldry hall of arms).
+	$allPlayers      = $park_players ?? [];
+	$nowTs           = time();
+	$nowYear         = (int)date('Y');
+	$sixMoCutoff     = strtotime('-6 months');
+	$twelveMoCutoff  = strtotime('-12 months');
+	$playersByYear   = [];   // key: 'YYYY' or 'never', value: array of players
+	$playerList      = [];   // active in past 6 months
+	$hoaPlayers12    = [];   // heraldry holders active in past 12 months
+	$totalHeraldry   = 0;
 	foreach ($allPlayers as $p) {
-		$ts = strtotime($p['LastSignin']);
-		$period = max(0, (int)floor(($nowTs - $ts) / (30.44 * 24 * 3600) / 6));
-		$playerPeriods[$period][] = $p;
-		if ($p['HasHeraldry']) $heraldryPeriods[$period][] = $p;
+		$ts  = strtotime($p['LastSignin']);
+		$key = ($ts && $ts > 0 && date('Y', $ts) !== '1970') ? date('Y', $ts) : 'never';
+		$playersByYear[$key][] = $p;
+		if (!empty($p['HasHeraldry'])) {
+			$totalHeraldry++;
+			if ($ts >= $twelveMoCutoff) $hoaPlayers12[] = $p;
+		}
+		if ($ts >= $sixMoCutoff) $playerList[] = $p;
 	}
-	ksort($playerPeriods);
-	ksort($heraldryPeriods);
-
-	$playerList    = $playerPeriods[0] ?? [];  // 0–6 months (used for stats row count)
-	$totalHeraldry = array_sum(array_map('count', $heraldryPeriods));
-	$hoaPlayers12  = array_merge($heraldryPeriods[0] ?? [], $heraldryPeriods[1] ?? []);
+	// Sort: real years descending (newest first); 'never' bucket goes last.
+	uksort($playersByYear, function ($a, $b) {
+		if ($a === 'never') return 1;
+		if ($b === 'never') return -1;
+		return strcmp($b, $a);
+	});
 
 	$firstTab = 'about';
 
@@ -159,7 +170,7 @@
 	}
 
 	// Active Players: last sign-in within the past 6 months — matches the Players tab subtitle
-	$activePlayersYear = count($playerPeriods[0] ?? []);
+	$activePlayersYear = count($playerList);
 ?>
 
 <link rel="stylesheet" href="<?= HTTP_TEMPLATE ?>revised-frontend/style/revised.css?v=<?= filemtime(DIR_TEMPLATE . 'revised-frontend/style/revised.css') ?>">
@@ -680,7 +691,7 @@
 				<?php if (count($allPlayers) > 0): ?>
 					<div class="pk-players-toolbar">
 						<span class="pk-players-toolbar-left">
-							<?= count($playerPeriods[0] ?? []) ?> active member<?= count($playerPeriods[0] ?? []) != 1 ? 's' : '' ?> (past 6 months)<?php if (count($allPlayers) > count($playerPeriods[0] ?? [])): ?> &middot; <?= count($allPlayers) ?> total<?php endif; ?>
+							<?= count($playerList) ?> active member<?= count($playerList) != 1 ? 's' : '' ?> (past 6 months)<?php if (count($allPlayers) > count($playerList)): ?> &middot; <?= count($allPlayers) ?> total<?php endif; ?>
 						</span>
 						<div class="pk-players-toolbar-right">
 							<div class="pk-player-search-wrap">
@@ -710,23 +721,20 @@
 						</div>
 					</div>
 
-					<!-- Card view (default) -->
-					<div id="pk-players-cards">
-						<!-- Period 0 (0–6 months) always visible -->
-						<div class="pk-players-grid">
-							<?php foreach ($playerPeriods[0] ?? [] as $p): ?>
-							<?php
-								$initial = htmlspecialchars(strtoupper(mb_substr($p['Persona'], 0, 1)));
-								$heraldryBgSrc = $p['HasHeraldry']
-									? HTTP_PLAYER_HERALDRY . Common::resolve_image_ext(DIR_PLAYER_HERALDRY, sprintf('%06d', $p['MundaneId']))
-									: null;
-								if ($p['HasImage']) {
-									$avatarSrc = HTTP_PLAYER_IMAGE . Common::resolve_image_ext(DIR_PLAYER_IMAGE, sprintf('%06d', $p['MundaneId']));
-								} elseif ($p['HasHeraldry']) {
-									$avatarSrc = $heraldryBgSrc;
-								} else {
-									$avatarSrc = null;
-								}
+					<?php
+						// Renderers reused for each year section.
+						$pkRenderCard = function (array $p) {
+							$initial = htmlspecialchars(strtoupper(mb_substr($p['Persona'], 0, 1)));
+							$heraldryBgSrc = $p['HasHeraldry']
+								? HTTP_PLAYER_HERALDRY . Common::resolve_image_ext(DIR_PLAYER_HERALDRY, sprintf('%06d', $p['MundaneId']))
+								: null;
+							if ($p['HasImage']) {
+								$avatarSrc = HTTP_PLAYER_IMAGE . Common::resolve_image_ext(DIR_PLAYER_IMAGE, sprintf('%06d', $p['MundaneId']));
+							} elseif ($p['HasHeraldry']) {
+								$avatarSrc = $heraldryBgSrc;
+							} else {
+								$avatarSrc = null;
+							}
 							?>
 							<a class="pk-player-card<?= $heraldryBgSrc ? ' pk-player-card-hbg' : '' ?>"
 							   <?= $heraldryBgSrc ? 'style="--hbg: url(\'' . htmlspecialchars($heraldryBgSrc) . '\')"'  : '' ?>
@@ -735,10 +743,7 @@
 								<div class="pk-player-card-top">
 									<div class="pk-player-avatar">
 										<?php if ($avatarSrc): ?>
-											<img src="<?= htmlspecialchars($avatarSrc) ?>"
-											     alt=""
-											     loading="lazy"
-											     onerror="pkAvatarFallback(this,'<?= $initial ?>')">
+											<img src="<?= htmlspecialchars($avatarSrc) ?>" alt="" loading="lazy" onerror="pkAvatarFallback(this,'<?= $initial ?>')">
 										<?php else: ?>
 											<?= $initial ?>
 										<?php endif; ?>
@@ -754,119 +759,18 @@
 								</div>
 								<div class="pk-player-stats">
 									<span><i class="fas fa-check-circle" style="color:#68d391;width:14px"></i> <?= $p['SigninCount'] ?> sign-in<?= $p['SigninCount'] != 1 ? 's' : '' ?></span>
-									<span><i class="fas fa-calendar-check" style="color:#63b3ed;width:14px"></i> <?= date('M j', strtotime($p['LastSignin'])) ?></span>
+									<span><i class="fas fa-calendar-check" style="color:#63b3ed;width:14px"></i> <?= date('M j, Y', strtotime($p['LastSignin'])) ?></span>
 									<?php if (!empty($p['LastClass'])): ?>
 										<span><i class="fas fa-shield-alt" style="color:#b794f4;width:14px"></i> <?= htmlspecialchars($p['LastClass']) ?></span>
 									<?php endif; ?>
 								</div>
 							</a>
-							<?php endforeach; ?>
-						</div>
+							<?php
+						};
 
-						<!-- Period 1+ (hidden; revealed by Load More) -->
-						<?php $_pkCardIdx = 1; foreach (array_slice($playerPeriods, 1, null, true) as $pkPeriod => $pkPeriodPlayers): ?>
-						<div class="pk-period-block" id="pk-players-block-<?= $_pkCardIdx ?>" style="display:none">
-							<div class="pk-period-label"><?= $pkPeriod * 6 ?>–<?= ($pkPeriod + 1) * 6 ?> months ago</div>
-							<div class="pk-players-grid">
-								<?php foreach ($pkPeriodPlayers as $p): ?>
-								<?php
-									$initial = htmlspecialchars(strtoupper(mb_substr($p['Persona'], 0, 1)));
-									$heraldryBgSrc = $p['HasHeraldry']
-										? HTTP_PLAYER_HERALDRY . Common::resolve_image_ext(DIR_PLAYER_HERALDRY, sprintf('%06d', $p['MundaneId']))
-										: null;
-									if ($p['HasImage']) {
-										$avatarSrc = HTTP_PLAYER_IMAGE . Common::resolve_image_ext(DIR_PLAYER_IMAGE, sprintf('%06d', $p['MundaneId']));
-									} elseif ($p['HasHeraldry']) {
-										$avatarSrc = $heraldryBgSrc;
-									} else {
-										$avatarSrc = null;
-									}
-								?>
-								<a class="pk-player-card<?= $heraldryBgSrc ? ' pk-player-card-hbg' : '' ?>"
-								   <?= $heraldryBgSrc ? 'style="--hbg: url(\'' . htmlspecialchars($heraldryBgSrc) . '\')"'  : '' ?>
-								   <?= !empty($p['MundaneName']) ? 'data-mundane-name="' . htmlspecialchars(strtolower($p['MundaneName'])) . '"' : '' ?>
-								   href="<?= UIR ?>Player/profile/<?= $p['MundaneId'] ?>">
-									<div class="pk-player-card-top">
-										<div class="pk-player-avatar">
-											<?php if ($avatarSrc): ?>
-												<img src="<?= htmlspecialchars($avatarSrc) ?>"
-												     loading="lazy"
-												     alt=""
-												     onerror="pkAvatarFallback(this,'<?= $initial ?>')">
-											<?php else: ?>
-												<?= $initial ?>
-											<?php endif; ?>
-										</div>
-										<div>
-											<div class="pk-player-name"><?= htmlspecialchars($p['Persona']) ?></div>
-											<?php if (!empty($p['OfficerRoles'])): ?>
-												<?php foreach (explode(', ', $p['OfficerRoles']) as $role): ?>
-													<span class="pk-officer-pill"><?= htmlspecialchars(trim($role)) ?></span>
-												<?php endforeach; ?>
-											<?php endif; ?>
-										</div>
-									</div>
-									<div class="pk-player-stats">
-										<span><i class="fas fa-check-circle" style="color:#68d391;width:14px"></i> <?= $p['SigninCount'] ?> sign-in<?= $p['SigninCount'] != 1 ? 's' : '' ?></span>
-										<span><i class="fas fa-calendar-check" style="color:#63b3ed;width:14px"></i> <?= date('M j', strtotime($p['LastSignin'])) ?></span>
-										<?php if (!empty($p['LastClass'])): ?>
-											<span><i class="fas fa-shield-alt" style="color:#b794f4;width:14px"></i> <?= htmlspecialchars($p['LastClass']) ?></span>
-										<?php endif; ?>
-									</div>
-								</a>
-								<?php endforeach; ?>
-							</div>
-						</div>
-						<?php $_pkCardIdx++; endforeach; ?>
-
-						<?php if (count($playerPeriods) > 1): ?>
-						<div class="pk-load-more-wrap" data-next="1" data-group="pk-players">
-							<button class="pk-load-more-btn" onclick="pkLoadMoreCards('pk-players', this)">
-								<i class="fas fa-chevron-down"></i> Load More...
-							</button>
-							<span class="pk-load-more-hint">Showing <?= count($playerPeriods[0] ?? []) ?> of <?= count($allPlayers) ?> members</span>
-						</div>
-						<?php endif; ?>
-					</div><!-- /pk-players-cards -->
-
-					<!-- List view (hidden by default) -->
-					<div id="pk-players-list" style="display:none">
-						<table class="pk-table" id="pk-players-table">
-							<thead>
-								<tr>
-									<th data-sorttype="text">Persona</th>
-									<th data-sorttype="numeric">Sign-ins</th>
-									<th data-sorttype="date">Last Visit</th>
-									<th data-sorttype="text">Last Class</th>
-									<th data-sorttype="text">Role</th>
-								</tr>
-							</thead>
-							<tbody>
-								<?php foreach ($playerPeriods[0] ?? [] as $p): ?>
-								<tr <?= !empty($p['MundaneName']) ? 'data-mundane-name="' . htmlspecialchars(strtolower($p['MundaneName'])) . '"' : '' ?> onclick='window.location.href="<?= UIR ?>Player/profile/<?= $p['MundaneId'] ?>"'>
-									<td>
-										<?= htmlspecialchars($p['Persona']) ?>
-										<?php if (!empty($p['OfficerRoles'])): ?>
-											<?php foreach (explode(', ', $p['OfficerRoles']) as $role): ?>
-												<span class="pk-officer-pill"><?= htmlspecialchars(trim($role)) ?></span>
-											<?php endforeach; ?>
-										<?php endif; ?>
-									</td>
-									<td data-sortval="<?= $p['SigninCount'] ?>"><?= $p['SigninCount'] ?></td>
-									<td class="pk-date-col" data-sortval="<?= $p['LastSignin'] ?>">
-										<?= date('M j, Y', strtotime($p['LastSignin'])) ?>
-									</td>
-									<td><?= htmlspecialchars($p['LastClass'] ?? '') ?></td>
-									<td><?= htmlspecialchars($p['OfficerRoles'] ?? '') ?></td>
-								</tr>
-								<?php endforeach; ?>
-							</tbody>
-						</table>
-						<!-- Hidden row templates for older periods -->
-						<?php $_pkListIdx = 1; foreach (array_slice($playerPeriods, 1, null, true) as $pkPeriod => $pkPeriodPlayers): ?>
-						<template id="pk-players-tmpl-<?= $_pkListIdx ?>">
-							<?php foreach ($pkPeriodPlayers as $p): ?>
-							<tr onclick='window.location.href="<?= UIR ?>Player/profile/<?= $p['MundaneId'] ?>"'>
+						$pkRenderRow = function (array $p) {
+							?>
+							<tr <?= !empty($p['MundaneName']) ? 'data-mundane-name="' . htmlspecialchars(strtolower($p['MundaneName'])) . '"' : '' ?> onclick='window.location.href="<?= UIR ?>Player/profile/<?= $p['MundaneId'] ?>"'>
 								<td>
 									<?= htmlspecialchars($p['Persona']) ?>
 									<?php if (!empty($p['OfficerRoles'])): ?>
@@ -876,24 +780,58 @@
 									<?php endif; ?>
 								</td>
 								<td data-sortval="<?= $p['SigninCount'] ?>"><?= $p['SigninCount'] ?></td>
-								<td class="pk-date-col" data-sortval="<?= $p['LastSignin'] ?>">
-									<?= date('M j, Y', strtotime($p['LastSignin'])) ?>
-								</td>
+								<td class="pk-date-col" data-sortval="<?= $p['LastSignin'] ?>"><?= date('M j, Y', strtotime($p['LastSignin'])) ?></td>
 								<td><?= htmlspecialchars($p['LastClass'] ?? '') ?></td>
 								<td><?= htmlspecialchars($p['OfficerRoles'] ?? '') ?></td>
 							</tr>
-							<?php endforeach; ?>
-						</template>
-						<?php $_pkListIdx++; endforeach; ?>
-						<?php if (count($playerPeriods) > 1): ?>
-						<div class="pk-load-more-wrap pk-load-more-list" data-next="1">
-							<button class="pk-load-more-btn" onclick="pkLoadMoreList('pk-players-table', 'pk-players-tmpl', this)">
-								<i class="fas fa-chevron-down"></i> Load More...
-							</button>
-							<span class="pk-load-more-hint">Showing <?= count($playerPeriods[0] ?? []) ?> of <?= count($allPlayers) ?> members</span>
-						</div>
-						<?php endif; ?>
-						<div class="pk-pagination" id="pk-players-table-pages"></div>
+							<?php
+						};
+
+						$pkYearLabel = function ($year) use ($nowYear) {
+							if ($year === 'never') return 'No recorded sign-ins';
+							return ((int)$year === $nowYear) ? ($year . ' (current)') : (string)$year;
+						};
+					?>
+
+					<!-- Card view (default) — one details/year section -->
+					<div id="pk-players-cards">
+						<?php $_pkIdx = 0; foreach ($playersByYear as $_pkYear => $_pkYearPlayers): ?>
+						<details class="pk-year-section"<?= $_pkIdx === 0 ? ' open' : '' ?> data-year="<?= htmlspecialchars((string)$_pkYear) ?>">
+							<summary class="pk-year-summary">
+								<span class="pk-year-label"><?= htmlspecialchars($pkYearLabel($_pkYear)) ?></span>
+								<span class="pk-year-count"><?= count($_pkYearPlayers) ?> member<?= count($_pkYearPlayers) != 1 ? 's' : '' ?></span>
+							</summary>
+							<div class="pk-players-grid">
+								<?php foreach ($_pkYearPlayers as $p) { $pkRenderCard($p); } ?>
+							</div>
+						</details>
+						<?php $_pkIdx++; endforeach; ?>
+					</div><!-- /pk-players-cards -->
+
+					<!-- List view (hidden by default) — one details/year section, each with its own table -->
+					<div id="pk-players-list" style="display:none">
+						<?php $_pkIdx = 0; foreach ($playersByYear as $_pkYear => $_pkYearPlayers): ?>
+						<details class="pk-year-section"<?= $_pkIdx === 0 ? ' open' : '' ?> data-year="<?= htmlspecialchars((string)$_pkYear) ?>">
+							<summary class="pk-year-summary">
+								<span class="pk-year-label"><?= htmlspecialchars($pkYearLabel($_pkYear)) ?></span>
+								<span class="pk-year-count"><?= count($_pkYearPlayers) ?> member<?= count($_pkYearPlayers) != 1 ? 's' : '' ?></span>
+							</summary>
+							<table class="pk-table pk-year-table">
+								<thead>
+									<tr>
+										<th data-sorttype="text">Persona</th>
+										<th data-sorttype="numeric">Sign-ins</th>
+										<th data-sorttype="date">Last Visit</th>
+										<th data-sorttype="text">Last Class</th>
+										<th data-sorttype="text">Role</th>
+									</tr>
+								</thead>
+								<tbody>
+									<?php foreach ($_pkYearPlayers as $p) { $pkRenderRow($p); } ?>
+								</tbody>
+							</table>
+						</details>
+						<?php $_pkIdx++; endforeach; ?>
 					</div><!-- /pk-players-list -->
 				<?php else: ?>
 					<div class="pk-empty">No players found</div>

--- a/orkui/template/revised-frontend/Parknew_index.tpl
+++ b/orkui/template/revised-frontend/Parknew_index.tpl
@@ -698,6 +698,7 @@
 								<i class="fas fa-search pk-player-search-icon"></i>
 								<input type="text" id="pk-player-search" class="pk-player-search-input" placeholder="Search all players…" autocomplete="off">
 							</div>
+							<button class="pk-view-btn" id="pk-active-only-btn" type="button" title="Show only members with sign-ins in the past 6 months"><i class="fas fa-filter"></i> Active only</button>
 							<div class="pk-view-toggle">
 								<button class="pk-view-btn pk-view-active" data-pkview="cards">
 									<i class="fas fa-th-large"></i> Cards
@@ -739,6 +740,7 @@
 							<a class="pk-player-card<?= $heraldryBgSrc ? ' pk-player-card-hbg' : '' ?>"
 							   <?= $heraldryBgSrc ? 'style="--hbg: url(\'' . htmlspecialchars($heraldryBgSrc) . '\')"'  : '' ?>
 							   <?= !empty($p['MundaneName']) ? 'data-mundane-name="' . htmlspecialchars(strtolower($p['MundaneName'])) . '"' : '' ?>
+							   data-signin-count="<?= (int)$p['SigninCount'] ?>"
 							   href="<?= UIR ?>Player/profile/<?= $p['MundaneId'] ?>">
 								<div class="pk-player-card-top">
 									<div class="pk-player-avatar">
@@ -758,8 +760,17 @@
 									</div>
 								</div>
 								<div class="pk-player-stats">
-									<span><i class="fas fa-check-circle" style="color:#68d391;width:14px"></i> <?= $p['SigninCount'] ?> sign-in<?= $p['SigninCount'] != 1 ? 's' : '' ?></span>
-									<span><i class="fas fa-calendar-check" style="color:#63b3ed;width:14px"></i> <?= date('M j, Y', strtotime($p['LastSignin'])) ?></span>
+									<span><i class="fas fa-check-circle" style="color:#68d391;width:14px"></i> <?= $p['SigninCount'] ?> six month sign-in<?= $p['SigninCount'] != 1 ? 's' : '' ?></span>
+									<?php $_lsTs = strtotime($p['LastSignin']); ?>
+									<span><i class="fas fa-calendar-check" style="color:#63b3ed;width:14px"></i> <?= ($_lsTs > 0 && date('Y', $_lsTs) !== '1970') ? date('M j, Y', $_lsTs) : '—' ?></span>
+									<?php
+										// "Last here" indicator when the player's most recent sign-in wasn't at this park.
+										$_lpTs = !empty($p['LastSigninAtPark']) ? strtotime($p['LastSigninAtPark']) : 0;
+										if (!empty($p['LastSigninAtPark']) && $p['LastSigninAtPark'] !== $p['LastSignin']):
+											$_hereTxt = ($_lpTs > 0 && date('Y', $_lpTs) !== '1970') ? 'here ' . date('M j, Y', $_lpTs) : 'never here';
+									?>
+										<span style="color:#a0aec0"><i class="fas fa-flag" style="color:#a0aec0;width:14px"></i> <?= htmlspecialchars($_hereTxt) ?></span>
+									<?php endif; ?>
 									<?php if (!empty($p['LastClass'])): ?>
 										<span><i class="fas fa-shield-alt" style="color:#b794f4;width:14px"></i> <?= htmlspecialchars($p['LastClass']) ?></span>
 									<?php endif; ?>
@@ -770,7 +781,7 @@
 
 						$pkRenderRow = function (array $p) {
 							?>
-							<tr <?= !empty($p['MundaneName']) ? 'data-mundane-name="' . htmlspecialchars(strtolower($p['MundaneName'])) . '"' : '' ?> onclick='window.location.href="<?= UIR ?>Player/profile/<?= $p['MundaneId'] ?>"'>
+							<tr <?= !empty($p['MundaneName']) ? 'data-mundane-name="' . htmlspecialchars(strtolower($p['MundaneName'])) . '"' : '' ?> data-signin-count="<?= (int)$p['SigninCount'] ?>" onclick='window.location.href="<?= UIR ?>Player/profile/<?= $p['MundaneId'] ?>"'>
 								<td>
 									<?= htmlspecialchars($p['Persona']) ?>
 									<?php if (!empty($p['OfficerRoles'])): ?>
@@ -780,7 +791,16 @@
 									<?php endif; ?>
 								</td>
 								<td data-sortval="<?= $p['SigninCount'] ?>"><?= $p['SigninCount'] ?></td>
-								<td class="pk-date-col" data-sortval="<?= $p['LastSignin'] ?>"><?= date('M j, Y', strtotime($p['LastSignin'])) ?></td>
+								<?php
+									$_lsTsRow = strtotime($p['LastSignin']);
+									$_lpTsRow = !empty($p['LastSigninAtPark']) ? strtotime($p['LastSigninAtPark']) : 0;
+									$_dateCell = ($_lsTsRow > 0 && date('Y', $_lsTsRow) !== '1970') ? date('M j, Y', $_lsTsRow) : '—';
+									if (!empty($p['LastSigninAtPark']) && $p['LastSigninAtPark'] !== $p['LastSignin']) {
+										$_hereTxtRow = ($_lpTsRow > 0 && date('Y', $_lpTsRow) !== '1970') ? 'here ' . date('M j, Y', $_lpTsRow) : 'never here';
+										$_dateCell .= ' <span style="color:#a0aec0;font-size:.85em">(' . htmlspecialchars($_hereTxtRow) . ')</span>';
+									}
+								?>
+								<td class="pk-date-col" data-sortval="<?= $p['LastSignin'] ?>"><?= $_dateCell ?></td>
 								<td><?= htmlspecialchars($p['LastClass'] ?? '') ?></td>
 								<td><?= htmlspecialchars($p['OfficerRoles'] ?? '') ?></td>
 							</tr>
@@ -820,7 +840,7 @@
 								<thead>
 									<tr>
 										<th data-sorttype="text">Persona</th>
-										<th data-sorttype="numeric">Sign-ins</th>
+										<th data-sorttype="numeric">6mo Sign-ins</th>
 										<th data-sorttype="date">Last Visit</th>
 										<th data-sorttype="text">Last Class</th>
 										<th data-sorttype="text">Role</th>

--- a/orkui/template/revised-frontend/Parknew_index.tpl
+++ b/orkui/template/revised-frontend/Parknew_index.tpl
@@ -1081,7 +1081,7 @@
 								<dt>Below Recommended</dt>
 								<dd>Players who haven&rsquo;t yet reached the recommended rank. The core action list &mdash; Grant these.</dd>
 								<dt>Non-Ladder</dt>
-								<dd>Flat awards with no rank progression (e.g. service awards). Grant or Delete as appropriate.</dd>
+								<dd>Includes titles such as Master, Noble, or Knight, custom awards, and other non-ranked options. Grant or Delete as appropriate.</dd>
 								<dt>At or Above Recommended</dt>
 								<dd>Players who already hold this award at or above the recommended rank. The rec has been fulfilled &mdash; Delete these to keep the list tidy.</dd>
 								<dt>All</dt>

--- a/orkui/template/revised-frontend/Playernew_index.tpl
+++ b/orkui/template/revised-frontend/Playernew_index.tpl
@@ -2078,16 +2078,18 @@ html[data-theme="dark"] .pn-persona { color: #fff !important; background: transp
 <?php endif; ?>
 
 <?php
-// Build KingdomAwardId => max rank held by this player (for ladder award pre-fill)
-// and the set of KingdomAwardIds the player already holds (for title duplicate detection)
-$playerAwardRanks        = array();
+// Build AwardId => max rank held by this player (for ladder award pre-fill),
+// and the set of held base AwardIds and KingdomAwardIds (for duplicate / Master-peerage detection)
+$playerAwardRanks          = array();
+$playerHeldAwardIds        = array();
 $playerHeldKingdomAwardIds = array();
 if (is_array($Details['Awards'])) {
 	foreach ($Details['Awards'] as $a) {
 		$aid  = (int)$a['AwardId'];
 		$rank = (int)$a['Rank'];
-		if ($aid > 0 && $rank > 0) {
-			if (!isset($playerAwardRanks[$aid]) || $rank > $playerAwardRanks[$aid]) {
+		if ($aid > 0) {
+			$playerHeldAwardIds[$aid] = true;
+			if ($rank > 0 && (!isset($playerAwardRanks[$aid]) || $rank > $playerAwardRanks[$aid])) {
 				$playerAwardRanks[$aid] = $rank;
 			}
 		}
@@ -2097,7 +2099,9 @@ if (is_array($Details['Awards'])) {
 		}
 	}
 }
+$playerHeldAwardIds        = array_keys($playerHeldAwardIds);
 $playerHeldKingdomAwardIds = array_keys($playerHeldKingdomAwardIds);
+$ladderMasterMap           = Award::GetLadderMasterMap();
 ?>
 
 <!-- =============================================
@@ -2141,7 +2145,10 @@ var PnConfig = {
 	canManageAwards:<?= !empty($canManageAwards) ? 'true' : 'false' ?>,
 	classList:      <?= json_encode(array_values(array_map(function($c) { return ['ClassId' => (int)$c['ClassId'], 'ClassName' => $c['ClassName'], 'Credits' => (float)($c['Credits'] ?? 0), 'Reconciled' => (int)($c['Reconciled'] ?? 0)]; }, $classList ?? []))) ?>,
 	awardRanks:     <?= json_encode($playerAwardRanks) ?>,
+	heldAwardIds:        <?= json_encode(array_values($playerHeldAwardIds)) ?>,
 	heldKingdomAwardIds: <?= json_encode($playerHeldKingdomAwardIds) ?>,
+	ladderMasterMap:     <?= json_encode($ladderMasterMap) ?>,
+	playerName:          <?= json_encode($Player['Persona'] ?? 'This player') ?>,
 	awardOptHTML:   <?= json_encode('<option value="">Select award...</option>' . ($AwardOptions ?? '')) ?>,
 	officerOptHTML: <?= json_encode('<option value="">Select title...</option>' . ($OfficerOptions ?? '')) ?>,
 	preloadOfficers:<?= json_encode($PreloadOfficers ?? []) ?>,

--- a/orkui/template/revised-frontend/script/revised.js
+++ b/orkui/template/revised-frontend/script/revised.js
@@ -851,8 +851,117 @@ if (PnConfig.recError) {
         var desc = AWARD_DESCRIPTIONS[aid] || '';
         var el = document.getElementById('pn-rec-award-desc');
         if (el) { el.textContent = desc; el.style.display = desc ? '' : 'none'; }
-        pnRecRefreshWarn();
+        pnApplyLadderSuggestion($(this).val());
     });
+
+    // Called whenever the award picker changes. If the player has already achieved the
+    // Master peerage for a ladder, hard-block submit. If they've reached the top rank but
+    // not the Master yet, offer a clickable suggestion that swaps the select to the Master.
+    function pnApplyLadderSuggestion(kingdomAwardId) {
+        var $err    = $('#pn-rec-error');
+        var $submit = $('#pn-rec-submit');
+        // Reset any previous suggestion state
+        $err.removeClass('pn-rec-suggest pn-rec-block').hide().empty();
+        $submit.prop('disabled', false);
+
+        if (!kingdomAwardId) return;
+        var opt = document.querySelector('#pn-rec-award option[value="' + kingdomAwardId + '"]');
+        if (!opt) return;
+
+        var baseAwardId = parseInt(opt.getAttribute('data-award-id')) || 0;
+        var map  = (PnConfig && PnConfig.ladderMasterMap) || {};
+        var held = (PnConfig.heldAwardIds || []).reduce(function(s, x) { s[x] = true; return s; }, {});
+        var name = PnConfig.playerName || 'This player';
+
+        // Case A — recommending a Master peerage the player already holds
+        if (baseAwardId > 0 && opt.getAttribute('data-peerage') === 'Master' && held[baseAwardId]) {
+            $err.addClass('pn-rec-block')
+                .text(name + ' has already achieved the rank of ' + (opt.textContent || '').trim() + '. Maybe consider recommending for a different award?')
+                .show();
+            $submit.prop('disabled', true);
+            return;
+        }
+
+        if (opt.getAttribute('data-is-ladder') !== '1') return;
+
+        var info = map[baseAwardId];
+        if (!info) return;
+
+        var maxRank  = parseInt(info.MaxRank) || (/zodiac/i.test(opt.textContent) ? 12 : 10);
+        var rankHeld = (PnConfig.awardRanks || {})[baseAwardId] || 0;
+
+        // Branch 1 — player already holds the Master peerage
+        var masterHeld = (info.MasterAwardIds || []).some(function(mid) { return !!held[mid]; });
+        if (masterHeld) {
+            $err.addClass('pn-rec-block')
+                .text(name + ' has already achieved the rank of ' + info.MasterName + '. Maybe consider recommending for a different award?')
+                .show();
+            $submit.prop('disabled', true);
+            return;
+        }
+
+        // Branch 2 — player at top rank of the ladder, no Master peerage yet
+        if (rankHeld >= maxRank) {
+            var masterOpt = null;
+            (info.MasterAwardIds || []).some(function(mid) {
+                masterOpt = document.querySelector('#pn-rec-award option[data-peerage="Master"][data-award-id="' + mid + '"]');
+                return !!masterOpt;
+            });
+            var msgParts = [
+                pnEscapeHtml(name),
+                ' has already received the ',
+                pnOrdinal(maxRank),
+                ' ',
+                pnEscapeHtml(info.LadderName),
+                '.'
+            ];
+            if (masterOpt) {
+                msgParts.push(
+                    ' Would you like to recommend them for ',
+                    '<a href="#" class="pn-rec-suggest-link" data-master-value="',
+                    pnEscapeAttr(masterOpt.value),
+                    '">',
+                    pnEscapeHtml(info.MasterName),
+                    '</a> instead?'
+                );
+            } else {
+                msgParts.push(' No higher rank is available.');
+            }
+            $err.addClass('pn-rec-suggest').html(msgParts.join('')).show();
+            $submit.prop('disabled', true);
+            return;
+        }
+    }
+
+    // Click handler: swap the select to the suggested Master option
+    $(document).on('click', '.pn-rec-suggest-link', function(e) {
+        e.preventDefault();
+        var val = $(this).data('master-value');
+        if (!val) return;
+        var $sel = $('#pn-rec-award');
+        $sel.val(String(val));
+        // Rebuild the Select2-style picker if present; otherwise fire change
+        if (typeof awInitPicker === 'function') {
+            try { awInitPicker($sel.get(0)); } catch(e) {}
+        }
+        $sel.trigger('change');
+        $('#pn-rec-reason').focus();
+    });
+
+    function pnOrdinal(n) {
+        n = parseInt(n) || 0;
+        var s = ['th','st','nd','rd'];
+        var v = n % 100;
+        return n + (s[(v - 20) % 10] || s[v] || s[0]);
+    }
+    function pnEscapeHtml(s) {
+        return String(s == null ? '' : s)
+            .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;').replace(/'/g, '&#39;');
+    }
+    function pnEscapeAttr(s) {
+        return pnEscapeHtml(s);
+    }
 
     // ---- Rec dismiss button (player page) ----
     document.addEventListener('click', function(e) {

--- a/orkui/template/revised-frontend/script/revised.js
+++ b/orkui/template/revised-frontend/script/revised.js
@@ -2409,43 +2409,6 @@ function knAvatarFallback(img, initial) {
     img.parentElement.innerText = initial;
 }
 
-// ---- Load More: card view (reveals next hidden period block) ----
-function knLoadMoreCards(group, btn) {
-    var $wrap = $(btn).closest('.kn-load-more-wrap');
-    var next  = parseInt($wrap.attr('data-next') || '1');
-    var $block = $('#' + group + '-block-' + next);
-    if ($block.length) {
-        $block.show();
-        var newNext = next + 1;
-        $wrap.attr('data-next', newNext);
-        if (!$('#' + group + '-block-' + newNext).length) {
-            $wrap.hide();
-        }
-    } else {
-        $wrap.hide();
-    }
-}
-
-// ---- Load More: list view (appends template rows to table, re-paginates) ----
-function knLoadMoreList(tableId, tmplBase, btn) {
-    var $wrap  = $(btn).closest('.kn-load-more-wrap');
-    var next   = parseInt($wrap.attr('data-next') || '1');
-    var tmpl   = document.getElementById(tmplBase + '-' + next);
-    if (tmpl) {
-        var $tbody = $('#' + tableId + ' tbody');
-        var frag = document.importNode(tmpl.content, true);
-        $(frag.querySelectorAll('tr')).appendTo($tbody);
-        var newNext = next + 1;
-        $wrap.attr('data-next', newNext);
-        knPaginate($('#' + tableId), 1);
-        if (!document.getElementById(tmplBase + '-' + newNext)) {
-            $wrap.hide();
-        }
-    } else {
-        $wrap.hide();
-    }
-}
-
 // ---- Activate a tab by name (used by buttons + links) ----
 function knActivateTab(tab) {
     $('.kn-tab-nav li').removeClass('kn-tab-active');
@@ -2740,25 +2703,37 @@ $(document).ready(function() {
         }
     });
 
-    // ---- Players: search (filters all .kn-player-card across all periods) ----
+    // ---- Players: search across every year section (cards + list rows) ----
+    // The DOM is fully populated up-front; content-visibility:auto on each year
+    // section keeps off-screen ones cheap. Search filters in place and force-opens
+    // any year section that has matches.
     $('#kn-player-search').on('input', function() {
         var q = $(this).val().trim().toLowerCase();
+        var $roots = $('#kn-players-cards, #kn-players-list');
         if (q === '') {
-            $('.kn-period-block').show();
-            $('.kn-player-card').show();
-        } else {
-            // Show all period blocks first so cards inside are visible/searchable
-            $('.kn-period-block').show();
-            $('.kn-player-card').each(function() {
-                var name = $(this).find('.kn-player-name').text().toLowerCase();
-                $(this).toggle(name.indexOf(q) !== -1);
-            });
-            // Hide period blocks with no visible cards
-            $('.kn-period-block').each(function() {
-                var hasVisible = $(this).find('.kn-player-card:visible').length > 0;
-                $(this).toggle(hasVisible);
-            });
+            $roots.find('.kn-player-card, .kn-year-table tbody tr').show();
+            $roots.find('.kn-year-section').show();
+            return;
         }
+        $roots.each(function() {
+            var $root = $(this);
+            $root.find('.kn-player-card').each(function() {
+                var name = $(this).find('.kn-player-name').text().toLowerCase();
+                var mn   = ($(this).attr('data-mundane-name') || '').toLowerCase();
+                $(this).toggle(name.indexOf(q) !== -1 || mn.indexOf(q) !== -1);
+            });
+            $root.find('.kn-year-table tbody tr').each(function() {
+                var persona = (this.cells[0] ? this.cells[0].textContent : '').toLowerCase();
+                var mn      = ($(this).attr('data-mundane-name') || '').toLowerCase();
+                $(this).toggle(persona.indexOf(q) !== -1 || mn.indexOf(q) !== -1);
+            });
+            $root.find('.kn-year-section').each(function() {
+                var hasVisible =
+                    $(this).find('.kn-player-card:visible, .kn-year-table tbody tr:visible').length > 0;
+                $(this).toggle(hasVisible);
+                if (hasVisible) this.open = true;
+            });
+        });
     });
 
     // ---- Default sort + initial pagination ----
@@ -2771,8 +2746,6 @@ $(document).ready(function() {
 
     // [TOURNAMENTS HIDDEN] knSortDesc($('#kn-tournaments-table'), 0, 'date');
     // [TOURNAMENTS HIDDEN] knPaginate($('#kn-tournaments-table'), 1);
-
-    knPaginate($('#kn-players-table'), 1);
 
 });
 (function() {
@@ -5463,50 +5436,6 @@ function pkAvatarFallback(img, initial) {
     img.parentElement.innerText = initial;
 }
 
-// ---- Load More: card view (reveals next hidden period block) ----
-// group: prefix string like 'pk-players' or 'pk-hoa'
-// btn:   the button element inside .pk-load-more-wrap[data-next][data-group]
-function pkLoadMoreCards(group, btn) {
-    var $wrap = $(btn).closest('.pk-load-more-wrap');
-    var next  = parseInt($wrap.attr('data-next') || '1');
-    var $block = $('#' + group + '-block-' + next);
-    if ($block.length) {
-        $block.show();
-        var newNext = next + 1;
-        $wrap.attr('data-next', newNext);
-        if (!$('#' + group + '-block-' + newNext).length) {
-            $wrap.hide(); // no more periods to load
-        }
-    } else {
-        $wrap.hide();
-    }
-}
-
-// ---- Load More: list view (appends template rows to table, re-paginates) ----
-// tableId:  id of the <table> element
-// tmplBase: id prefix of <template> elements (e.g. 'pk-players-tmpl')
-// btn:      the button element inside .pk-load-more-wrap[data-next]
-function pkLoadMoreList(tableId, tmplBase, btn) {
-    var $wrap  = $(btn).closest('.pk-load-more-wrap');
-    var next   = parseInt($wrap.attr('data-next') || '1');
-    var tmpl   = document.getElementById(tmplBase + '-' + next);
-    if (tmpl) {
-        var $tbody = $('#' + tableId + ' tbody');
-        // Clone template content and append to tbody
-        var frag = document.importNode(tmpl.content, true);
-        $(frag.querySelectorAll('tr')).appendTo($tbody);
-        var newNext = next + 1;
-        $wrap.attr('data-next', newNext);
-        // Re-paginate from page 1 with the expanded row set
-        pkPaginate($('#' + tableId), 1);
-        if (!document.getElementById(tmplBase + '-' + newNext)) {
-            $wrap.hide();
-        }
-    } else {
-        $wrap.hide();
-    }
-}
-
 // ---- Hero color from heraldry ----
 // Samples the heraldry image via Canvas to find its dominant non-white, non-black
 // color and applies a darkened version as the hero background.
@@ -5749,30 +5678,36 @@ $(document).ready(function() {
         pkPaginate($table, page);
     });
 
-    // ---- Player search (filters cards + list rows across all periods) ----
+    // ---- Player search across every year section (cards + list rows) ----
+    // The DOM holds every player up-front; content-visibility:auto on each year
+    // section keeps off-screen ones cheap. Search filters in place and force-opens
+    // any year section that has matches.
     $('#pk-player-search').on('input', function() {
         var q = $(this).val().trim().toLowerCase();
+        var $roots = $('#pk-players-cards, #pk-players-list');
         if (q === '') {
-            $('.pk-period-block').show();
-            $('.pk-player-card').show();
-        } else {
-            $('.pk-period-block').show();
-            $('.pk-player-card').each(function() {
-                var name = $(this).find('.pk-player-name').text().toLowerCase();
-                var mundane = ($(this).data('mundane-name') || '').toLowerCase();
-                $(this).toggle(name.indexOf(q) !== -1 || mundane.indexOf(q) !== -1);
-            });
-            // Hide period blocks with no visible cards
-            $('.pk-period-block').each(function() {
-                var hasVisible = $(this).find('.pk-player-card:visible').length > 0;
-                $(this).toggle(hasVisible);
-            });
+            $roots.find('.pk-player-card, .pk-year-table tbody tr').show();
+            $roots.find('.pk-year-section').show();
+            return;
         }
-        // Also filter list view rows
-        $('#pk-players-table tbody tr').each(function() {
-            var name = $(this).find('td:first').text().toLowerCase();
-            var mundane = ($(this).data('mundane-name') || '').toLowerCase();
-            $(this).toggle(!q || name.indexOf(q) !== -1 || mundane.indexOf(q) !== -1);
+        $roots.each(function() {
+            var $root = $(this);
+            $root.find('.pk-player-card').each(function() {
+                var name = $(this).find('.pk-player-name').text().toLowerCase();
+                var mn   = ($(this).attr('data-mundane-name') || '').toLowerCase();
+                $(this).toggle(name.indexOf(q) !== -1 || mn.indexOf(q) !== -1);
+            });
+            $root.find('.pk-year-table tbody tr').each(function() {
+                var persona = (this.cells[0] ? this.cells[0].textContent : '').toLowerCase();
+                var mn      = ($(this).attr('data-mundane-name') || '').toLowerCase();
+                $(this).toggle(persona.indexOf(q) !== -1 || mn.indexOf(q) !== -1);
+            });
+            $root.find('.pk-year-section').each(function() {
+                var hasVisible =
+                    $(this).find('.pk-player-card:visible, .pk-year-table tbody tr:visible').length > 0;
+                $(this).toggle(hasVisible);
+                if (hasVisible) this.open = true;
+            });
         });
     });
 
@@ -5797,8 +5732,6 @@ $(document).ready(function() {
 
     pkSortDesc($('#pk-tournaments-table'), 2, 'date');
     pkPaginate($('#pk-tournaments-table'), 1);
-
-    pkPaginate($('#pk-players-table'), 1);
 
 });
 (function() {

--- a/orkui/template/revised-frontend/script/revised.js
+++ b/orkui/template/revised-frontend/script/revised.js
@@ -5678,37 +5678,44 @@ $(document).ready(function() {
         pkPaginate($table, page);
     });
 
-    // ---- Player search across every year section (cards + list rows) ----
+    // ---- Player search + active-only filter (cards + list rows) ----
     // The DOM holds every player up-front; content-visibility:auto on each year
-    // section keeps off-screen ones cheap. Search filters in place and force-opens
+    // section keeps off-screen ones cheap. Filters apply in place and force-open
     // any year section that has matches.
-    $('#pk-player-search').on('input', function() {
-        var q = $(this).val().trim().toLowerCase();
+    function pkApplyPlayerFilters() {
+        var q = ($('#pk-player-search').val() || '').trim().toLowerCase();
+        var activeOnly = $('#pk-active-only-btn').hasClass('pk-view-active');
+        var filtering  = q || activeOnly;
         var $roots = $('#pk-players-cards, #pk-players-list');
-        if (q === '') {
-            $roots.find('.pk-player-card, .pk-year-table tbody tr').show();
-            $roots.find('.pk-year-section').show();
-            return;
-        }
         $roots.each(function() {
             var $root = $(this);
             $root.find('.pk-player-card').each(function() {
                 var name = $(this).find('.pk-player-name').text().toLowerCase();
                 var mn   = ($(this).attr('data-mundane-name') || '').toLowerCase();
-                $(this).toggle(name.indexOf(q) !== -1 || mn.indexOf(q) !== -1);
+                var sc   = parseInt($(this).attr('data-signin-count') || '0', 10);
+                var match = (!q || name.indexOf(q) !== -1 || mn.indexOf(q) !== -1) && (!activeOnly || sc > 0);
+                $(this).toggle(match);
             });
             $root.find('.pk-year-table tbody tr').each(function() {
                 var persona = (this.cells[0] ? this.cells[0].textContent : '').toLowerCase();
                 var mn      = ($(this).attr('data-mundane-name') || '').toLowerCase();
-                $(this).toggle(persona.indexOf(q) !== -1 || mn.indexOf(q) !== -1);
+                var sc      = parseInt($(this).attr('data-signin-count') || '0', 10);
+                var match = (!q || persona.indexOf(q) !== -1 || mn.indexOf(q) !== -1) && (!activeOnly || sc > 0);
+                $(this).toggle(match);
             });
             $root.find('.pk-year-section').each(function() {
+                if (!filtering) { $(this).show(); return; }
                 var hasVisible =
                     $(this).find('.pk-player-card:visible, .pk-year-table tbody tr:visible').length > 0;
                 $(this).toggle(hasVisible);
                 if (hasVisible) this.open = true;
             });
         });
+    }
+    $('#pk-player-search').on('input', pkApplyPlayerFilters);
+    $('#pk-active-only-btn').on('click', function() {
+        $(this).toggleClass('pk-view-active');
+        pkApplyPlayerFilters();
     });
 
     // ---- Players view toggle (cards / list) ----

--- a/orkui/template/revised-frontend/style/revised.css
+++ b/orkui/template/revised-frontend/style/revised.css
@@ -2535,21 +2535,49 @@ html[data-theme="dark"] .kn-events-loadmore-link:hover {
 	background: #fef3c7; color: #92400e;
 	white-space: nowrap; margin-top: 2px; margin-right: 2px;
 }
-.kn-period-label {
+/* Year-bucketed players list — collapsible per-year sections.
+ * content-visibility:auto lets the browser skip layout/paint for off-screen
+ * sections so we can render every year in the DOM without paying for it until
+ * the user scrolls them into view (or expands them). contain-intrinsic-size
+ * gives the browser a reasonable placeholder height so the scrollbar is stable. */
+.kn-year-section {
+	margin: 14px 0 6px;
+	border-top: 1px solid #e2e8f0;
+	content-visibility: auto;
+	contain-intrinsic-size: 1px 600px;
+}
+.kn-year-section:first-of-type { border-top: 0; margin-top: 0; }
+.kn-year-summary {
+	cursor: pointer;
+	list-style: none;
+	display: flex; align-items: baseline; gap: 10px;
+	padding: 10px 4px;
 	font-size: 11px; font-weight: 700; letter-spacing: 0.07em;
 	color: #a0aec0; text-transform: uppercase;
-	border-bottom: 1px solid #e2e8f0;
-	padding-bottom: 4px; margin: 18px 0 10px;
+	user-select: none;
 }
-.kn-load-more-wrap { text-align: center; padding: 18px 0 8px; }
-.kn-load-more-btn {
-	background: #fff; border: 1.5px solid #cbd5e0; border-radius: 6px;
-	padding: 8px 22px; font-size: 13px; font-weight: 600; color: #4a5568;
-	cursor: pointer; display: inline-flex; align-items: center; gap: 7px;
-	transition: border-color 0.15s, color 0.15s;
+.kn-year-summary::-webkit-details-marker { display: none; }
+.kn-year-summary::before {
+	content: '\25B8'; /* right-pointing triangle */
+	display: inline-block;
+	font-size: 10px;
+	color: #cbd5e0;
+	transition: transform 0.12s ease;
+	transform-origin: 50% 55%;
 }
-.kn-load-more-btn:hover { border-color: var(--kn-accent, #276749); color: var(--kn-accent, #276749); }
-.kn-load-more-hint { display: block; font-size: 11px; color: #a0aec0; margin-top: 6px; }
+.kn-year-section[open] > .kn-year-summary::before { transform: rotate(90deg); }
+.kn-year-summary:hover { color: var(--kn-accent, #276749); }
+.kn-year-summary:hover::before { color: var(--kn-accent, #276749); }
+.kn-year-label { font-size: 12px; }
+.kn-year-count {
+	font-size: 10px; font-weight: 600; letter-spacing: 0.04em;
+	color: #a0aec0;
+	background: #edf2f7;
+	padding: 2px 8px; border-radius: 10px;
+	text-transform: none;
+}
+.kn-year-section .kn-players-grid { padding-top: 4px; }
+.kn-year-table { margin-top: 4px; }
 /* ---- Award entry modal (kn-award-*) ---- */
 .kn-award-type-row { display:grid; grid-template-columns:1fr 1fr; gap:8px; margin-bottom:16px; }
 .kn-award-type-btn { padding:8px 4px; min-height:44px; line-height:1.2; border:2px solid var(--ork-border); border-radius:8px; background:var(--ork-card-bg); font-size:13px; font-weight:600; color:var(--ork-text-secondary); cursor:pointer; transition:all 0.15s; text-align:center; }
@@ -3461,47 +3489,51 @@ html[data-theme="dark"] .pk-stat-tip-text::after { border-top-color: #e2e8f0; }
 	.pk-active-tab-label { display: block; }
 }
 
-/* ---- Period label (Load More separators) ---- */
-.pk-period-label {
-	font-size: 11px;
-	font-weight: 700;
-	letter-spacing: 0.07em;
-	color: #a0aec0;
-	text-transform: uppercase;
-	border-bottom: 1px solid #e2e8f0;
-	padding-bottom: 4px;
-	margin: 18px 0 10px;
+/* ---- Year-bucketed players list (collapsible per-year sections) ----
+ * content-visibility:auto lets the browser skip layout/paint for off-screen
+ * sections so the full roster lives in the DOM without rendering cost until
+ * scrolled into view. contain-intrinsic-size keeps the scrollbar stable. */
+.pk-year-section {
+	margin: 14px 0 6px;
+	border-top: 1px solid #e2e8f0;
+	content-visibility: auto;
+	contain-intrinsic-size: 1px 600px;
 }
-
-/* ---- Load More button ---- */
-.pk-load-more-wrap {
-	text-align: center;
-	padding: 18px 0 8px;
-}
-.pk-load-more-btn {
-	background: #fff;
-	border: 1.5px solid #cbd5e0;
-	border-radius: 6px;
-	padding: 8px 22px;
-	font-size: 13px;
-	font-weight: 600;
-	color: #4a5568;
+.pk-year-section:first-of-type { border-top: 0; margin-top: 0; }
+.pk-year-summary {
 	cursor: pointer;
-	display: inline-flex;
-	align-items: center;
-	gap: 7px;
-	transition: border-color 0.15s, color 0.15s;
+	list-style: none;
+	display: flex; align-items: baseline; gap: 10px;
+	padding: 10px 4px;
+	font-size: 11px; font-weight: 700; letter-spacing: 0.07em;
+	color: #a0aec0; text-transform: uppercase;
+	user-select: none;
 }
-.pk-load-more-btn:hover {
-	border-color: #0891b2;
-	color: #0891b2;
+.pk-year-summary::-webkit-details-marker { display: none; }
+.pk-year-summary::before {
+	content: '\25B8';
+	display: inline-block;
+	font-size: 10px;
+	color: #cbd5e0;
+	transition: transform 0.12s ease;
+	transform-origin: 50% 55%;
 }
-.pk-load-more-hint {
-	display: block;
-	font-size: 11px;
+.pk-year-section[open] > .pk-year-summary::before { transform: rotate(90deg); }
+.pk-year-summary:hover,
+.pk-year-summary:hover::before { color: #0891b2; }
+.pk-year-label { font-size: 12px; }
+.pk-year-count {
+	font-size: 10px;
+	font-weight: 600;
+	letter-spacing: 0.04em;
 	color: #a0aec0;
-	margin-top: 6px;
+	background: #edf2f7;
+	padding: 2px 8px;
+	border-radius: 10px;
+	text-transform: none;
 }
+.pk-year-section .pk-players-grid { padding-top: 4px; }
+.pk-year-table { margin-top: 4px; }
 
 /* ---- Hall of Arms gallery ---- */
 .pk-hoa-search-wrap {
@@ -6784,8 +6816,6 @@ html[data-theme="dark"] #theme_container .kn-description-url,
 html[data-theme="dark"] #theme_container .kn-table a,
 html[data-theme="dark"] #theme_container .kn-report-group a,
 html[data-theme="dark"] #theme_container .kn-prinz-name a,
-html[data-theme="dark"] .kn-load-more-btn,
-html[data-theme="dark"] #theme_container .kn-load-more-btn,
 html[data-theme="dark"] #theme_container .kn-award-success,
 html[data-theme="dark"] #kn-events-cal .fc .fc-list-event-title a {
   color: hsl(calc(var(--kn-hue) + 35), 65%, var(--ork-accent-mid-lightness, 58%));
@@ -6794,15 +6824,26 @@ html[data-theme="dark"] .kn-description-body,
 html[data-theme="dark"] .kn-description-card {
   color: var(--ork-text);
 }
-html[data-theme="dark"] .kn-load-more-btn,
-html[data-theme="dark"] .pk-load-more-btn {
-  background: var(--ork-bg-secondary);
-  border-color: var(--ork-border);
+html[data-theme="dark"] .kn-year-section,
+html[data-theme="dark"] .pk-year-section {
+  border-top-color: var(--ork-border);
+}
+html[data-theme="dark"] .kn-year-summary,
+html[data-theme="dark"] .pk-year-summary {
   color: var(--ork-text-secondary);
 }
-html[data-theme="dark"] .kn-load-more-btn:hover {
-  border-color: hsl(var(--kn-hue), var(--kn-sat), var(--ork-accent-lightness, 65%));
+html[data-theme="dark"] .kn-year-count,
+html[data-theme="dark"] .pk-year-count {
+  background: var(--ork-bg-secondary);
+  color: var(--ork-text-secondary);
+}
+html[data-theme="dark"] .kn-year-summary:hover,
+html[data-theme="dark"] .kn-year-summary:hover::before {
   color: hsl(var(--kn-hue), var(--kn-sat), var(--ork-accent-lightness, 65%));
+}
+html[data-theme="dark"] .pk-year-summary:hover,
+html[data-theme="dark"] .pk-year-summary:hover::before {
+  color: hsl(var(--pk-hue, 195), var(--pk-sat, 80%), var(--ork-accent-lightness, 65%));
 }
 html[data-theme="dark"] .kn-officer-chip.kn-selected,
 html[data-theme="dark"] .kn-rank-pill:hover,

--- a/orkui/template/revised-frontend/style/revised.css
+++ b/orkui/template/revised-frontend/style/revised.css
@@ -2172,11 +2172,15 @@ html[data-theme="dark"] .kn-events-loadmore {
 html[data-theme="dark"] .kn-events-loadmore .kn-events-loadmore-msg strong {
 	color: var(--ork-text, #e2e8f0);
 }
-html[data-theme="dark"] .kn-events-loadmore-link {
+/* Override the late-cascade `.kn-card a` rule that otherwise re-tints this link
+   with --ork-link-bright in dark mode. */
+html[data-theme="dark"] .kn-events-loadmore .kn-events-loadmore-link {
 	background: #38a169;
+	color: #fff !important;
 }
-html[data-theme="dark"] .kn-events-loadmore-link:hover {
+html[data-theme="dark"] .kn-events-loadmore .kn-events-loadmore-link:hover {
 	background: #48bb78;
+	color: #fff !important;
 }
 
 /* Pagination */

--- a/orkui/template/revised-frontend/style/revised.css
+++ b/orkui/template/revised-frontend/style/revised.css
@@ -1030,6 +1030,38 @@ html[data-theme="dark"] .pn-ladder-bar-track { background: var(--ork-bg-tertiary
 	margin-bottom: 14px;
 	display: none;
 }
+
+/* Suggest state: friendlier tone — amber/blue, not an error */
+.pn-form-error.pn-rec-suggest {
+	background: #ebf8ff;
+	border-color: #bee3f8;
+	color: #2c5282;
+}
+.pn-form-error.pn-rec-suggest .pn-rec-suggest-link {
+	color: #2b6cb0;
+	font-weight: 700;
+	text-decoration: underline;
+	cursor: pointer;
+}
+.pn-form-error.pn-rec-suggest .pn-rec-suggest-link:hover {
+	color: #1a4a7a;
+}
+html[data-theme="dark"] .pn-form-error {
+	background: rgba(229, 62, 62, 0.12);
+	border-color: rgba(229, 62, 62, 0.4);
+	color: #feb2b2;
+}
+html[data-theme="dark"] .pn-form-error.pn-rec-suggest {
+	background: rgba(43, 108, 176, 0.18);
+	border-color: rgba(99, 179, 237, 0.5);
+	color: #bee3f8;
+}
+html[data-theme="dark"] .pn-form-error.pn-rec-suggest .pn-rec-suggest-link {
+	color: #90cdf4;
+}
+html[data-theme="dark"] .pn-form-error.pn-rec-suggest .pn-rec-suggest-link:hover {
+	color: #bee3f8;
+}
 .pn-char-count {
 	display: block;
 	text-align: right;
@@ -2089,6 +2121,62 @@ html[data-theme="dark"] .kn-md-help-btn:hover { background:var(--ork-bg-tertiary
 	padding: 30px 10px;
 	font-size: 13px;
 	font-style: italic;
+}
+
+/* Events tab: lazy-load-more footer */
+.kn-events-loadmore {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 12px;
+	flex-wrap: wrap;
+	margin-top: 10px;
+	padding: 10px 14px;
+	border: 1px dashed var(--ork-border, #e2e8f0);
+	border-radius: 6px;
+	background: var(--ork-bg-secondary, #f7fafc);
+	font-size: 12px;
+	color: var(--ork-text-secondary, #718096);
+}
+.kn-events-loadmore .kn-events-loadmore-msg strong {
+	color: var(--ork-text, #2d3748);
+	font-weight: 700;
+}
+.kn-events-loadmore-link {
+	display: inline-flex;
+	align-items: center;
+	padding: 5px 12px;
+	border-radius: 5px;
+	background: var(--kn-accent-mid, #276749);
+	color: #fff;
+	font-weight: 600;
+	text-decoration: none;
+	font-size: 12px;
+	transition: background 0.15s, transform 0.15s;
+}
+.kn-events-loadmore-link:hover {
+	background: #1f5437;
+	color: #fff;
+	text-decoration: none;
+	transform: translateY(-1px);
+}
+.kn-events-loadmore-link[aria-busy="true"] {
+	opacity: 0.7;
+	cursor: default;
+}
+html[data-theme="dark"] .kn-events-loadmore {
+	background: var(--ork-bg-tertiary, #2d3748);
+	border-color: var(--ork-border, #4a5568);
+	color: var(--ork-text-secondary, #a0aec0);
+}
+html[data-theme="dark"] .kn-events-loadmore .kn-events-loadmore-msg strong {
+	color: var(--ork-text, #e2e8f0);
+}
+html[data-theme="dark"] .kn-events-loadmore-link {
+	background: #38a169;
+}
+html[data-theme="dark"] .kn-events-loadmore-link:hover {
+	background: #48bb78;
 }
 
 /* Pagination */
@@ -5745,7 +5833,7 @@ html[data-theme="dark"] .plr-merge-warning { background:rgba(197,48,48,0.15); bo
 .kn-rec-filter-info-btn:hover { color:#2b6cb0; }
 .kn-rec-filter-popover { display:none; position:absolute; left:0; top:calc(100% + 6px); z-index:200; background:#fff; border:1px solid #e2e8f0; border-radius:8px; box-shadow:0 4px 16px rgba(0,0,0,.13); padding:14px 16px; width:300px; font-size:13px; color:#2d3748; }
 .kn-rec-filter-popover.kn-pop-open { display:block; }
-.kn-rec-filter-popover h4 { margin:0 0 8px; font-size:13px; font-weight:700; color:#1a202c; border-bottom:1px solid #e2e8f0; padding-bottom:6px; }
+.kn-rec-filter-popover h4 { margin:0 0 8px; font-size:13px; font-weight:700; color:#1a202c; background:transparent; border:none; border-bottom:1px solid #e2e8f0; border-radius:0; padding:0 0 6px; text-shadow:none; }
 .kn-rec-filter-popover dl { margin:0; }
 .kn-rec-filter-popover dt { font-weight:600; color:#2b6cb0; margin-top:8px; }
 .kn-rec-filter-popover dd { margin:2px 0 0; color:#4a5568; line-height:1.4; }
@@ -6617,6 +6705,21 @@ html[data-theme="dark"] .kn-rec-filter-btn.kn-rec-filter-active {
   border-color: var(--ork-link);
   color: #fff;
 }
+html[data-theme="dark"] .kn-rec-filter-info-btn { color: var(--ork-text-muted); }
+html[data-theme="dark"] .kn-rec-filter-info-btn:hover { color: var(--ork-link-bright); }
+html[data-theme="dark"] .kn-rec-filter-popover {
+  background: var(--ork-card-bg, var(--ork-bg-secondary));
+  border-color: var(--ork-border);
+  color: var(--ork-text);
+  box-shadow: 0 4px 16px rgba(0,0,0,.5);
+}
+html[data-theme="dark"] .kn-rec-filter-popover h4 {
+  color: var(--ork-text);
+  border-bottom-color: var(--ork-border);
+}
+html[data-theme="dark"] .kn-rec-filter-popover dt { color: var(--ork-link-bright); }
+html[data-theme="dark"] .kn-rec-filter-popover dd { color: var(--ork-text-secondary); }
+html[data-theme="dark"] .kn-rec-filter-popover dt small { color: var(--ork-text-muted) !important; }
 html[data-theme="dark"] .kn-rec-export-btn {
   background: var(--ork-bg-secondary);
   border-color: var(--ork-border);

--- a/system/lib/Yapo2/class.YapoMysql.php
+++ b/system/lib/Yapo2/class.YapoMysql.php
@@ -21,11 +21,21 @@ class YapoMysql extends YapoDb {
 		}
 		if (function_exists('apcu_fetch')) {
 			$cached = apcu_fetch('yapo_schema_' . $table, $found);
-			if ($found) {
+			// Treat empty Fields as a poisoned entry (DESCRIBE failed when it was cached) —
+			// drop it and re-fetch.
+			if ($found && !empty($cached['Fields'])) {
 				self::$schema_cache[$table] = $cached;
 				return $cached;
 			}
+			if ($found) {
+				apcu_delete('yapo_schema_' . $table);
+			}
 		}
+		// Clear any leftover bound parameters before DESCRIBE/SHOW KEYS so PDO doesn't
+		// try to bind them to these placeholder-free queries (which causes them to fail
+		// silently and return 0 rows — at which point we'd cache an empty schema and
+		// poison every subsequent INSERT/UPDATE/find on this table for 24 hours).
+		$this->Clear();
 		$Keys = $this->DataSet("SHOW KEYS IN $table");
 		$Fields = $this->DataSet("describe $table");
 		$this->Clear();
@@ -56,7 +66,8 @@ class YapoMysql extends YapoDb {
 
 		$result = array("Keys" => $keys, "Fields" => $fields, "PrimaryKey" => $primary_key);
 		self::$schema_cache[$table] = $result;
-		if (function_exists('apcu_store')) {
+		// Only persist when we got a real schema back — never cache an empty Fields array.
+		if (function_exists('apcu_store') && !empty($fields)) {
 			apcu_store('yapo_schema_' . $table, $result, 86400);
 		}
 		return $result;

--- a/system/lib/ork3/class.Award.php
+++ b/system/lib/ork3/class.Award.php
@@ -7,6 +7,32 @@ class Award  extends Ork3 {
 		$this->award = new yapo($this->db, DB_PREFIX . 'award');
 	}
 
+	/**
+	 * Map of ladder award_id => metadata used to detect when a player has already reached
+	 * the top of that ladder or earned its Master-peerage companion award.
+	 *
+	 * Keep in sync with the $pnOrderToMaster / $pnOrderNames maps in
+	 * orkui/template/revised-frontend/Playernew_index.tpl (Awards tab).
+	 */
+	public static function GetLadderMasterMap() {
+		return [
+			21  => ['MasterAwardIds' => [1],   'LadderName' => 'Order of the Rose',    'MasterName' => 'Master Rose',    'MaxRank' => 10],
+			22  => ['MasterAwardIds' => [2],   'LadderName' => 'Order of the Smith',   'MasterName' => 'Master Smith',   'MaxRank' => 10],
+			23  => ['MasterAwardIds' => [3],   'LadderName' => 'Order of the Lion',    'MasterName' => 'Master Lion',    'MaxRank' => 10],
+			24  => ['MasterAwardIds' => [4],   'LadderName' => 'Order of the Owl',     'MasterName' => 'Master Owl',     'MaxRank' => 10],
+			25  => ['MasterAwardIds' => [5],   'LadderName' => 'Order of the Dragon',  'MasterName' => 'Master Dragon',  'MaxRank' => 10],
+			26  => ['MasterAwardIds' => [6],   'LadderName' => 'Order of the Garber',  'MasterName' => 'Master Garber',  'MaxRank' => 10],
+			27  => ['MasterAwardIds' => [12],  'LadderName' => 'Order of the Warrior', 'MasterName' => 'Warlord',        'MaxRank' => 10],
+			28  => ['MasterAwardIds' => [7],   'LadderName' => 'Order of the Jovius',  'MasterName' => 'Master Jovius',  'MaxRank' => 10],
+			29  => ['MasterAwardIds' => [9],   'LadderName' => 'Order of the Mask',    'MasterName' => 'Master Mask',    'MaxRank' => 10],
+			30  => ['MasterAwardIds' => [8],   'LadderName' => 'Order of the Zodiac',  'MasterName' => 'Master Zodiac',  'MaxRank' => 12],
+			32  => ['MasterAwardIds' => [10],  'LadderName' => 'Order of the Hydra',   'MasterName' => 'Master Hydra',   'MaxRank' => 10],
+			33  => ['MasterAwardIds' => [11],  'LadderName' => 'Order of the Griffin', 'MasterName' => 'Master Griffin', 'MaxRank' => 10],
+			239 => ['MasterAwardIds' => [240], 'LadderName' => 'Order of the Crown',   'MasterName' => 'Master Crown',   'MaxRank' => 10],
+			243 => ['MasterAwardIds' => [244], 'LadderName' => 'Order of Battle',      'MasterName' => 'Battlemaster',   'MaxRank' => 10],
+		];
+	}
+
     public function LookupAward($request) {
         if (valid_id($request['KingdomId']) && valid_id($request['AwardId'])) {
         	$kingdomaward = new yapo($this->db, DB_PREFIX . 'kingdomaward');

--- a/system/lib/ork3/class.Kingdom.php
+++ b/system/lib/ork3/class.Kingdom.php
@@ -99,6 +99,13 @@ class Kingdom  extends Ork3 {
 		return $response;
 	}
 */
+	private static function awardNameLooksLikeOfficer($name) {
+		if (!is_string($name) || $name === '') return false;
+		$prefix = '(Provincial|Baronial|Ducal|Grand\s+Ducal|Shire|Kingdom|Imperial|Principality|Barony|Duchy|Grand\s+Duchy)';
+		$suffix = '(Monarch|Regent|Prime\s+Minister|Champion|Defender|Seneschal|Chancellor|Clerk|GMR|Guildmaster\s+of\s+Reeves|Guild\s+Master\s+of\s+Reeves|General\s+Minister|Sheriff|Baron(ess)?|Grand\s+Duke|Grand\s+Duchess|Duke|Duchess)';
+		return preg_match('/^' . $prefix . '\s+' . $suffix . '\b/i', trim($name)) === 1;
+	}
+
 	public function GetAwardList($request) {
 		if ($request['IsLadder'] == 'Ladder') {
 			$ladder_clause = " and ka.is_ladder = 1";
@@ -128,11 +135,19 @@ class Kingdom  extends Ork3 {
 		if ($r !== false && $r->size() > 0) {
 			$response['Awards'] = array();
 			while ($r->next()) {
-				if (isset($request['OfficerRole']) && $request['OfficerRole'] == 'Awards' && !in_array($r->officer_role, ['none', null])) {
+				$isOfficerRole = !in_array($r->officer_role, ['none', null]);
+				// Some kingdomaward rows are mapped to a non-officer system award (e.g. Custom Award)
+				// or are orphaned (LEFT JOIN -> NULL officer_role) but are clearly officer titles by
+				// name — e.g. "Baronial Guild Master of Reeves", "Imperial Monarch", "Shire Regent".
+				// Treat those as officers so they bucket into the Officers list, not Awards.
+				if (!$isOfficerRole && self::awardNameLooksLikeOfficer($r->kingdom_awardname)) {
+					$isOfficerRole = true;
+				}
+				if (isset($request['OfficerRole']) && $request['OfficerRole'] == 'Awards' && $isOfficerRole) {
 					continue;
-				} else if (isset($request['OfficerRole']) && $request['OfficerRole'] == 'Officers' && in_array($r->officer_role, ['none', null])) {
+				} else if (isset($request['OfficerRole']) && $request['OfficerRole'] == 'Officers' && !$isOfficerRole) {
 					continue;
-				} 
+				}
 
 				$response['Awards'][$r->kingdomaward_id] = array(
 					'KingdomAwardId' => $r->kingdomaward_id,

--- a/system/lib/ork3/class.Player.php
+++ b/system/lib/ork3/class.Player.php
@@ -1738,6 +1738,56 @@ class Player extends Ork3 {
             return InvalidParameter();
         }
 
+		// Block recommendations for a ladder the player has already topped out on
+		// (either via the Master-peerage companion award or by holding the ladder's max rank).
+		// Also block direct recommendations for a Master peerage the player already holds.
+		$ladderMap  = Award::GetLadderMasterMap();
+		$recAwardId = (int)$request['AwardId'];
+		$persona    = $this->mundane->persona;
+		$mid        = (int)$request['MundaneId'];
+
+		// Build reverse map: master_award_id => ['MasterName' => ...]
+		$masterNameById = [];
+		foreach ($ladderMap as $lid => $lInfo) {
+			foreach ((array)$lInfo['MasterAwardIds'] as $mAid) {
+				$masterNameById[(int)$mAid] = $lInfo['MasterName'];
+			}
+		}
+
+		// Case A: recommending a Master peerage the player already holds (any kingdomaward)
+		if ($recAwardId > 0 && isset($masterNameById[$recAwardId])) {
+			$held = $this->db->query(
+				"select a.awards_id from " . DB_PREFIX . "awards a
+				 where a.mundane_id = {$mid} and a.award_id = {$recAwardId} limit 1"
+			);
+			if ($held !== false && $held->size() > 0) {
+				return InvalidParameter($persona . ' has already achieved the rank of ' . $masterNameById[$recAwardId] . '. Maybe consider recommending for a different award?');
+			}
+		}
+
+		// Case B: recommending a ladder where the player has topped out or holds the Master peerage
+		if (isset($ladderMap[$recAwardId])) {
+			$info = $ladderMap[$recAwardId];
+
+			$masterIdsCsv = implode(',', array_map('intval', $info['MasterAwardIds']));
+			$masterHeld   = $this->db->query(
+				"select a.awards_id from " . DB_PREFIX . "awards a
+				 where a.mundane_id = {$mid} and a.award_id in ({$masterIdsCsv}) limit 1"
+			);
+			if ($masterHeld !== false && $masterHeld->size() > 0) {
+				return InvalidParameter($persona . ' has already achieved the rank of ' . $info['MasterName'] . '. Maybe consider recommending for a different award?');
+			}
+
+			$maxRank   = (int)$info['MaxRank'];
+			$topResult = $this->db->query(
+				"select max(a.rank) as max_rank from " . DB_PREFIX . "awards a
+				 where a.mundane_id = {$mid} and a.award_id = {$recAwardId}"
+			);
+			if ($topResult !== false && $topResult->size() > 0 && $topResult->next() && (int)$topResult->max_rank >= $maxRank) {
+				return InvalidParameter($persona . ' has already reached the top rank of ' . $info['LadderName'] . '. Maybe consider recommending for a different award?');
+			}
+		}
+
 		// Custom awards (is_ladder = 0 AND is_title = 0) allow unlimited duplicates
 		// and unlimited recommendations — skip both dedup checks entirely.
 		$isCustomAward = false;

--- a/system/lib/ork3/class.Player.php
+++ b/system/lib/ork3/class.Player.php
@@ -1756,6 +1756,7 @@ class Player extends Ork3 {
 
 		// Case A: recommending a Master peerage the player already holds (any kingdomaward)
 		if ($recAwardId > 0 && isset($masterNameById[$recAwardId])) {
+			$this->db->clear();
 			$held = $this->db->query(
 				"select a.awards_id from " . DB_PREFIX . "awards a
 				 where a.mundane_id = {$mid} and a.award_id = {$recAwardId} limit 1"
@@ -1770,6 +1771,7 @@ class Player extends Ork3 {
 			$info = $ladderMap[$recAwardId];
 
 			$masterIdsCsv = implode(',', array_map('intval', $info['MasterAwardIds']));
+			$this->db->clear();
 			$masterHeld   = $this->db->query(
 				"select a.awards_id from " . DB_PREFIX . "awards a
 				 where a.mundane_id = {$mid} and a.award_id in ({$masterIdsCsv}) limit 1"
@@ -1779,6 +1781,7 @@ class Player extends Ork3 {
 			}
 
 			$maxRank   = (int)$info['MaxRank'];
+			$this->db->clear();
 			$topResult = $this->db->query(
 				"select max(a.rank) as max_rank from " . DB_PREFIX . "awards a
 				 where a.mundane_id = {$mid} and a.award_id = {$recAwardId}"

--- a/system/lib/ork3/class.Report.php
+++ b/system/lib/ork3/class.Report.php
@@ -478,31 +478,104 @@ class Report  extends Ork3 {
 		$r = $this->db->query($sql);
 		$response = array();
 		if ($r !== false && $r->size() > 0) {
-			$response['AwardRecommendations'] = array();
+			// First pass: collect raw rows and the set of (mundane_id, ladder_award_id) we'll need Master-peerage lookups for.
+			$rawRows = array();
+			$ladderMap = Award::GetLadderMasterMap();
+			$masterIdSet = array();
+			foreach ($ladderMap as $lInfo) {
+				foreach ((array)$lInfo['MasterAwardIds'] as $mAid) {
+					$masterIdSet[(int)$mAid] = true;
+				}
+			}
+			$needMundaneIds = array();
 			while ($r->next()) {
+				$row = (object)[
+					'recommendations_id' => $r->recommendations_id,
+					'mundane_id'         => (int)$r->mundane_id,
+					'persona'            => $r->persona,
+					'date_recommended'   => $r->date_recommended,
+					'rank'               => $r->rank,
+					'award_name'         => $r->award_name,
+					'reason'             => $r->reason,
+					'recommended_by_persona' => $r->recommended_by_persona,
+					'recommended_by_id'      => $r->recommended_by_id,
+					'ka_kaward_id'       => (int)$r->ka_kaward_id,
+					'ka_award_id'        => (int)$r->ka_award_id,
+					'recs_award_id'      => (int)$r->award_id,
+					'park_id'            => $r->park_id,
+					'kingdom_id'         => $r->kingdom_id,
+					'park_name'          => $r->park_name,
+					'kingdom_name'       => $r->kingdom_name,
+					'kacount'            => (int)$r->kacount,
+					'awcount'            => (int)$r->awcount,
+					'player_ka_rank'     => (int)$r->player_ka_rank,
+					'player_ka_date'     => $r->player_ka_date,
+				];
+				$recAwardId = $row->ka_award_id ?: $row->recs_award_id;
+				if (isset($ladderMap[$recAwardId])) {
+					$needMundaneIds[$row->mundane_id] = true;
+				}
+				$rawRows[] = $row;
+			}
+
+			// Second pass: batch-fetch Master-peerage holdings for any mundanes whose recs target a ladder.
+			$heldMasters = array(); // mundane_id => [master_award_id => true]
+			if (!empty($needMundaneIds) && !empty($masterIdSet)) {
+				$midCsv = implode(',', array_map('intval', array_keys($needMundaneIds)));
+				$maCsv  = implode(',', array_map('intval', array_keys($masterIdSet)));
+				$mRes = $this->db->query(
+					"SELECT mundane_id, award_id FROM " . DB_PREFIX . "awards
+					 WHERE mundane_id IN ({$midCsv}) AND award_id IN ({$maCsv})"
+				);
+				if ($mRes !== false && $mRes->size() > 0) {
+					while ($mRes->next()) {
+						$heldMasters[(int)$mRes->mundane_id][(int)$mRes->award_id] = true;
+					}
+				}
+			}
+
+			// Custom Award / Custom Title instances share a single base award_id across every
+			// instance (or use a stale award_id with the display name "Custom Award"), so the
+			// awcount subquery over-matches. Detect by displayed award name and skip AlreadyHas.
+			$customNameSet = ['Custom Award' => true, 'Custom Title' => true];
+
+			// Final pass: build response, flipping AlreadyHas when a Master peerage covers a ladder rec.
+			$response['AwardRecommendations'] = array();
+			foreach ($rawRows as $row) {
+				$recAwardId = $row->ka_award_id ?: $row->recs_award_id;
+				$isCustom   = isset($customNameSet[trim((string)$row->award_name)]);
+				$alreadyHas = $isCustom ? false : ($row->kacount > 0 || $row->awcount > 0);
+				$coveredByMaster = false;
+				if (!$isCustom && !$alreadyHas && isset($ladderMap[$recAwardId])) {
+					foreach ((array)$ladderMap[$recAwardId]['MasterAwardIds'] as $mAid) {
+						if (!empty($heldMasters[$row->mundane_id][(int)$mAid])) {
+							$alreadyHas = true;
+							$coveredByMaster = true;
+							break;
+						}
+					}
+				}
 				$response['AwardRecommendations'][] = array(
-						'RecommendationsId' => $r->recommendations_id,
-						'MundaneId' => $r->mundane_id,
-						'Persona' => $r->persona,
-						'DateRecommended' => $r->date_recommended,
-						'Rank' => $r->rank,
-						'AwardName' => $r->award_name,
-						'Reason' => $r->reason,
-						'RecommendedByName' => $r->recommended_by_persona,
-						'RecommendedById' => $r->recommended_by_id,
-						'KingdomAwardId' => (int)$r->ka_kaward_id,
-						'ParkId' => $r->park_id,
-						'KingdomId' => $r->kingdom_id,
-						'ParkName' => $r->park_name,
-						'KingdomName' => $r->kingdom_name,
-						// Custom awards (base Award with is_ladder=0 AND is_title=0) can legitimately
-						// be held many times, so they must never be filtered out as "already has".
-						'AlreadyHas' => ((int)$r->a_is_ladder === 0 && (int)$r->a_is_title === 0)
-							? false
-							: ($r->kacount > 0 || $r->awcount > 0),
-						'CurrentRank' => ($r->kacount > 0 || $r->awcount > 0) ? (int)$r->player_ka_rank : null,
-						'CurrentRankDate' => ($r->kacount > 0 || $r->awcount > 0) ? $r->player_ka_date : null,
-					);
+					'RecommendationsId' => $row->recommendations_id,
+					'MundaneId' => $row->mundane_id,
+					'Persona' => $row->persona,
+					'DateRecommended' => $row->date_recommended,
+					'Rank' => $row->rank,
+					'AwardName' => $row->award_name,
+					'Reason' => $row->reason,
+					'RecommendedByName' => $row->recommended_by_persona,
+					'RecommendedById' => $row->recommended_by_id,
+					'KingdomAwardId' => $row->ka_kaward_id,
+					'AwardId' => $recAwardId,
+					'ParkId' => $row->park_id,
+					'KingdomId' => $row->kingdom_id,
+					'ParkName' => $row->park_name,
+					'KingdomName' => $row->kingdom_name,
+					'AlreadyHas' => $alreadyHas,
+					'CoveredByMaster' => $coveredByMaster,
+					'CurrentRank' => $alreadyHas ? ($row->player_ka_rank ?: null) : null,
+					'CurrentRankDate' => $alreadyHas ? $row->player_ka_date : null,
+				);
 			}
 			$response['Status'] = Success();
 		} else {

--- a/system/lib/ork3/class.Report.php
+++ b/system/lib/ork3/class.Report.php
@@ -1191,7 +1191,8 @@ class Report  extends Ork3 {
 									where
 										$native_populace
 										$waivered_peeps
-										date >= '$per_period'
+										a.kingdom_id = '$escaped_kingdom_id'
+										and date >= '$per_period'
 										and a.mundane_id > 0
 									group by date_year, date_week3, mundane_id, a.park_id) mundanesbyweek
 								on p.park_id = mundanesbyweek.park_id
@@ -1233,7 +1234,8 @@ class Report  extends Ork3 {
 						SELECT a.date_year, a.date_month, a.park_id,
 						       COUNT(DISTINCT a.mundane_id) AS monthly_unique
 						FROM " . DB_PREFIX . "attendance a
-						WHERE a.date > '$monthly_period'
+						WHERE a.kingdom_id = '$escaped_kingdom_id'
+						  AND a.date > '$monthly_period'
 						  AND a.mundane_id > 0
 						GROUP BY a.date_year, a.date_month, a.park_id
 					) sub

--- a/system/lib/ork3/class.SearchService.php
+++ b/system/lib/ork3/class.SearchService.php
@@ -302,14 +302,31 @@ class SearchService extends Ork3 {
 			(is_null($p_id)?$park_id:$p_id) );
 	}
   
-	public function Player($type, $search, $limit=15, $kingdom_id = null, $park_id = null, $waivered = null, $persona_required = true) {
+	public function Player($type, $search, $limit=15, $kingdom_id = null, $park_id = null, $waivered = null, $token = null, $persona_required = true) {
     	list($search, $kingdom_id, $park_id) = $this->magic_search($search, $kingdom_id, $park_id);
-				
+
+		// ORK admins may search by mundane info regardless of a player's restricted flag.
+		// IsAuthorized/HasAuthority run yapo internally which leaves bound parameters on the
+		// shared DB handle; clear them so the next raw query in this function doesn't try
+		// to bind them.
+		$is_ork_admin = false;
+		if (!empty($token)) {
+			$_caller_uid = Ork3::$Lib->authorization->IsAuthorized($token);
+			if ($_caller_uid > 0 && Ork3::$Lib->authorization->HasAuthority($_caller_uid, AUTH_ADMIN, null, null)) {
+				$is_ork_admin = true;
+			}
+		}
+		$this->db->clear();
+		// Restricted gate fragments for the WHERE clause — empty wrapper for admins so the
+		// gate effectively disappears.
+		$_rg_open  = $is_ork_admin ? '(' : '(m.restricted = 0 AND (';
+		$_rg_close = $is_ork_admin ? ')' : '))';
+
 		$searchtokens = preg_split("/[\s,-]+/", $search ?? '');
     	$opt = array("1");
         $limit = min(valid_id($limit)?$limit:15, 100);
 		switch (strtoupper($type)) {
-			case 'PERSONA': 
+			case 'PERSONA':
 				if (count($searchtokens) > 0)
 					$s = implode(' or ', array_map(function($t) { return "`persona` like '%" . mysql_real_escape_string($t) . "%'"; }, $searchtokens));
 			    	$order = "order by m.active DESC, persona,surname,given_name";
@@ -317,7 +334,7 @@ class SearchService extends Ork3 {
 				break;
 			case 'MUNDANE':
 				if (count($searchtokens) > 0)
-					$s = implode(' or ', array_map(function($t) { return "(m.restricted = 0 AND (`given_name` like '%" . mysql_real_escape_string($t) . "%' or `surname` like '%" . mysql_real_escape_string($t) . "%'))"; }, $searchtokens));
+					$s = implode(' or ', array_map(function($t) use ($_rg_open, $_rg_close) { return $_rg_open . "`given_name` like '%" . mysql_real_escape_string($t) . "%' or `surname` like '%" . mysql_real_escape_string($t) . "%'" . $_rg_close; }, $searchtokens));
 				    $order = "order by m.active DESC, surname,given_name";
                     $opt[] = "(length(`surname`) > 0 or length(`given_name`) > 0)";
 				break;
@@ -332,7 +349,7 @@ class SearchService extends Ork3 {
 				$s = "match(`given_name`, `surname`, `other_name`, `username`, `persona`) against ('" . mysql_real_escape_string($zztop) . "' in boolean mode)
 				and (`username` like '%" . mysql_real_escape_string($search) . "%'
 				or `other_name` like '%" . mysql_real_escape_string($search) . "%' or `persona` like '%" . mysql_real_escape_string($search) . "%'
-				or (m.restricted = 0 AND (`given_name` like '%" . mysql_real_escape_string($search) . "%' or `surname` like '%" . mysql_real_escape_string($search) . "%' or concat(`given_name`,' ',`surname`) like '%" . mysql_real_escape_string($search) . "%')))";
+				or " . $_rg_open . "`given_name` like '%" . mysql_real_escape_string($search) . "%' or `surname` like '%" . mysql_real_escape_string($search) . "%' or concat(`given_name`,' ',`surname`) like '%" . mysql_real_escape_string($search) . "%'" . $_rg_close . ")";
 			break;
 		}
         if ($persona_required === true) {


### PR DESCRIPTION
## Summary

Bundle of four player/kingdom/park-profile fixes and enhancements. Now also includes the player-list optimization that was previously open as PR #468 (closed in favor of consolidating here).

## Changes

### `df549fb` — Year-bucketed player roster with content-visibility lazy paint

Replaces the 6-month "Load More" reveal on the Kingdom and Park **Players** tabs with collapsible per-year `<details>` sections.

- Full roster lives in the DOM up-front; `content-visibility: auto` + `contain-intrinsic-size` keep off-screen years from being laid out or painted
- Most recent year expanded by default; search spans every year and auto-opens any section with matches
- **Kingdom SQL**: drop redundant `ork_park` join in the `last_signin` subquery (`ork_attendance` has its own `kingdom_id`); push the suspended/active filter into the subquery so we don't aggregate over departed players; scope the last-class join (`la`) to the current kingdom so a player's class from a different kingdom on the same date can't bleed in or duplicate rows under `GROUP_CONCAT`
- **Park SQL**: push the suspended/active filter into the `last_signin` subquery
- The 2026-04-11 covering indexes already support these queries

### `90bf7fc` — Route officer-titled kingdom awards to Officers list, not Awards

The Add Award modal's **Awards** dropdown was leaking officer titles like `Baronial Guild Master of Reeves`, `Imperial Monarch`, `Shire Regent` whenever the underlying `ork_award` row had `officer_role='none'` (e.g. mapped to Custom Award) or was orphaned (no matching `ork_award`, LEFT JOIN → NULL `officer_role`).

`GetAwardList` now name-pattern-matches kingdom awards whose names follow the officer-prefix + officer-role pattern (Provincial / Baronial / Ducal / Grand Ducal / Shire / Kingdom / Imperial / Principality / Barony / Duchy / Grand Duchy followed by Monarch / Regent / Prime Minister / Champion / Defender / Seneschal / Chancellor / Clerk / GMR / Guild(master\|Master) of Reeves / General Minister / Sheriff / Baron(ess) / Duke / Duchess) and treats them as officers regardless of `officer_role`, so they bucket into the **Officer Titles** list instead of Awards.

### `875a6f4` — `events_more` URL used `&window=` instead of `?window=`

The Kingdom-events Load-more handler built the URL with `&window=` instead of `?window=`, so the value never reached `\$_GET['window']` and every click re-fetched the first 12-month window. One-character fix.

### `3e5cb31` — Award recommendation ladder/peerage validation + Kingdom events Load-more

**Award recommendation: ladder & peerage validation**

Stops recommendations a player can no longer climb, both server- and client-side.

- **`Award::GetLadderMasterMap()`** — single source of truth for the 14 ladder award_ids, their Master companion ids, max ranks, and display names
- **`Player::SaveRecommendation`** — server-side guard rejects recs for a Master peerage already held, and ladder recs where the player either already holds the matching Master or is at the ladder's max rank
- **`Report::GetAwardRecommendations`** — refactored to two-pass: collects rows, batch-fetches Master-peerage holdings, then sets `AlreadyHas=true` (and new `CoveredByMaster`) when a ladder rec is covered by a Master. Adds a "Custom Award/Custom Title" exemption so the `awcount` subquery doesn't over-match those
- **`Model_Award`** — Master-peerage `<option>`s now carry `data-award-id` and `data-peerage='Master'` for client-side detection
- **Player profile (Awards tab)** — picker change handler runs `pnApplyLadderSuggestion()`. Two states:
  - **Block** (red error, submit disabled) when player already holds the Master peerage
  - **Suggest** (friendly amber/blue panel + clickable link) when player has topped the ladder — clicking swaps the picker to the Master option
- Recommendation toast prefers `Detail` over the noisier `Error: Detail` concatenation
- "Non-Ladder" filter copy on Kingdom & Park rec helps broadened to mention Master/Noble/Knight/custom awards

**Kingdom events: lazy load-more**

- New JSON endpoint `Kingdom/events_more/{id}?window=N` returns events in 12-month windows (1..10)
- Events table now always rendered (hidden when empty) with a footer showing count + months and a **Load more** link
- Client appends rows, reapplies filter toggles, refreshes pagination/calendar, and removes the link when no more windows remain
- Dark-mode styling for the new footer plus dark-mode polish for the rec-filter help popover

## Test plan

- [ ] Kingdom profile → **Players** tab: full roster renders, year sections collapse/expand, search hits across years and auto-opens matched sections; off-screen years aren't painted until scrolled near (DevTools → Rendering → "Paint flashing")
- [ ] Park profile → **Players** tab: same checks
- [ ] Verify suspended/inactive players are excluded from kingdom + park rosters
- [ ] Verify a player active in multiple kingdoms shows only the current kingdom's class data on the kingdom roster
- [ ] Add Award modal on Kingdom profile (Nine Blades, Dragonspine, Tal Dagore, Viridian Outlands): Imperial / Baronial / Ducal / Shire / Kingdom officer-titled entries appear under **Officer Titles**, not Awards → OTHER
- [ ] Add Award modal on Park profile: same check
- [ ] On a player at the top rank of a ladder (no Master yet), open Add Recommendation, pick that ladder award → suggest panel appears with link to the Master peerage; clicking the link swaps the picker
- [ ] On a player who already holds a Master peerage, pick that ladder OR pick the Master directly → block panel + disabled submit
- [ ] Server-side: bypass the client check and POST a SaveRecommendation for a covered ladder/Master → returns `InvalidParameter` with a friendly message
- [ ] Player profile Recommendations tab: ladder recs covered by a Master peerage now show as `AlreadyHas` (no duplicate work for officers)
- [ ] Custom Award / Custom Title recs no longer falsely show `AlreadyHas` due to over-matching on the base `award_id`
- [ ] Kingdomnew Events tab with > 12 months of events: click **Load more** → next 12-month window appended, count updates, link clears once 10 windows loaded
- [ ] Kingdomnew Events tab with no events: empty-state shown; **Load more** still works and reveals the table when later windows have rows
- [ ] Verify dark mode on: rec suggest/block panels, kn-events-loadmore footer, kn-rec-filter-popover

🤖 Generated with [Claude Code](https://claude.com/claude-code)