### PR TITLE
Enhancement: Player list optimization

### DIFF
--- a/orkui/controller/controller.Kingdom.php
+++ b/orkui/controller/controller.Kingdom.php
@@ -223,10 +223,16 @@ class Controller_Kingdom extends Controller {
 					MAX(a.date) AS last_signin,
 					SUM(a.date >= DATE_SUB(CURDATE(), INTERVAL 6 MONTH)) AS signin_count
 				FROM ork_attendance a
-				INNER JOIN ork_park kp ON kp.park_id = a.park_id AND kp.kingdom_id = {$kid}
+				INNER JOIN ork_mundane mm
+					ON mm.mundane_id = a.mundane_id
+				   AND mm.suspended = 0 AND mm.active = 1
+				WHERE a.kingdom_id = {$kid}
 				GROUP BY a.mundane_id
 			) sub ON sub.mundane_id = m.mundane_id
-			LEFT JOIN ork_attendance la ON la.mundane_id = m.mundane_id AND la.date = sub.last_signin
+			LEFT JOIN ork_attendance la
+				ON la.mundane_id = m.mundane_id
+			   AND la.date       = sub.last_signin
+			   AND la.kingdom_id = {$kid}
 			LEFT JOIN ork_class c ON la.class_id = c.class_id
 			LEFT JOIN ork_officer o ON o.mundane_id = m.mundane_id AND o.park_id = m.park_id
 			WHERE m.suspended = 0 AND m.active = 1

--- a/orkui/controller/controller.Park.php
+++ b/orkui/controller/controller.Park.php
@@ -171,10 +171,13 @@ class Controller_Park extends Controller
 				GROUP_CONCAT(DISTINCT o.role ORDER BY o.role SEPARATOR ', ') AS officer_roles
 			FROM ork_mundane m
 			INNER JOIN (
-				SELECT mundane_id, MAX(date) AS last_signin
-				FROM ork_attendance
-				WHERE park_id = {$pid}
-				GROUP BY mundane_id
+				SELECT a.mundane_id, MAX(a.date) AS last_signin
+				FROM ork_attendance a
+				INNER JOIN ork_mundane mm
+					ON mm.mundane_id = a.mundane_id
+				   AND mm.suspended = 0 AND mm.active = 1
+				WHERE a.park_id = {$pid}
+				GROUP BY a.mundane_id
 			) sub ON sub.mundane_id = m.mundane_id
 			LEFT JOIN ork_attendance a6 ON a6.mundane_id = m.mundane_id
 				AND a6.park_id = {$pid}

--- a/orkui/template/revised-frontend/Kingdomnew_index.tpl
+++ b/orkui/template/revised-frontend/Kingdomnew_index.tpl
@@ -843,28 +843,7 @@
 			</div>
 			<div id="kn-players-loading" style="text-align:center;padding:32px;color:#a0aec0"><i class="fas fa-spinner fa-spin"></i> Loading players&hellip;</div>
 			<div id="kn-players-cards" style="display:none"></div>
-			<div id="kn-players-list" style="display:none">
-				<table class="kn-table" id="kn-players-table">
-					<thead>
-						<tr>
-							<th data-sorttype="text">Persona</th>
-							<th data-sorttype="text">Park</th>
-							<th data-sorttype="numeric">Sign-ins</th>
-							<th data-sorttype="date">Last Visit</th>
-							<th data-sorttype="text">Last Class</th>
-							<th data-sorttype="text">Role</th>
-						</tr>
-					</thead>
-					<tbody id="kn-players-tbody"></tbody>
-				</table>
-				<div id="kn-players-list-more" style="display:none">
-					<div class="kn-load-more-wrap kn-load-more-list" data-next="1">
-						<button class="kn-load-more-btn" onclick="knLoadMoreList('kn-players-table', 'kn-players-tmpl', this)"><i class="fas fa-chevron-down"></i> Load More...</button>
-						<span class="kn-load-more-hint" id="kn-players-list-hint"></span>
-					</div>
-				</div>
-				<div class="kn-pagination" id="kn-players-table-pages"></div>
-			</div>
+			<div id="kn-players-list" style="display:none"></div>
 		</div><!-- /kn-tab-players -->
 
 		</div><!-- /kn-tabs -->
@@ -2055,67 +2034,84 @@ html[data-theme="dark"] .kn-btn-danger { background: #fc8181; color: #1a202c; bo
 			.then(function(r) { return r.json(); })
 			.then(function(data) {
 				knPlayersLoaded = true;
-				var players  = data.players || [];
-				var nowTs    = Math.floor(Date.now() / 1000);
-				var periods  = {};
-				players.forEach(function(p) {
-					var ts     = new Date((p.lastSignin || '1970-01-01') + 'T00:00:00').getTime() / 1000;
-					var period = Math.max(0, Math.floor((nowTs - ts) / (30.44 * 24 * 3600 * 6)));
-					if (!periods[period]) periods[period] = [];
-					periods[period].push(p);
-				});
-				var periodKeys = Object.keys(periods).map(Number).sort(function(a,b){return a-b;});
-				var active = (periods[0] || []).length, total = players.length;
+				var players = data.players || [];
+				var total   = players.length;
 
-				// Update tab count
+				// Bucket by year of last sign-in. Use a sentinel "Inactive" bucket for
+				// players whose last_signin is the 1970 default (never attended).
+				var byYear = {};
+				var nowYear = new Date().getFullYear();
+				var sixMoCutoff = Date.now() - 6 * 30.44 * 24 * 3600 * 1000;
+				var activeRecent = 0;
+				players.forEach(function(p) {
+					var raw = p.lastSignin || '1970-01-01';
+					var key;
+					if (raw === '1970-01-01' || raw.indexOf('1970') === 0) {
+						key = 'never';
+					} else {
+						key = raw.slice(0, 4); // YYYY
+					}
+					(byYear[key] = byYear[key] || []).push(p);
+					var ts = new Date(raw + 'T00:00:00').getTime();
+					if (ts >= sixMoCutoff) activeRecent++;
+				});
+
+				// Sort keys: real years descending (newest first), 'never' last.
+				var yearKeys = Object.keys(byYear).filter(function(k){ return k !== 'never'; })
+					.sort(function(a,b){ return b.localeCompare(a); });
+				if (byYear.never) yearKeys.push('never');
+
+				// Update tab count + summary line
 				var tabCount = document.getElementById('kn-players-tab-count');
 				if (tabCount) tabCount.textContent = '(' + total + ')';
-				// Update summary line
 				var summEl = document.getElementById('kn-players-summary');
-				if (summEl) summEl.textContent = active + ' active member' + (active!==1?'s':'') + ' (past 6 months)' + (total > active ? ' · ' + total + ' total' : '');
+				if (summEl) {
+					summEl.textContent = activeRecent + ' active member' + (activeRecent!==1?'s':'')
+						+ ' (past 6 months)' + (total > activeRecent ? ' · ' + total + ' total' : '');
+				}
 
-				// Build cards HTML
+				// Build year-bucketed cards + list sections in one pass.
 				var cardsEl = document.getElementById('kn-players-cards');
-				if (cardsEl) {
-					var html = '<div class="kn-players-grid">' + (periods[0]||[]).map(function(p){return knPlayerCardHtml(p,uir);}).join('') + '</div>';
-					periodKeys.slice(1).forEach(function(period) {
-						html += '<div class="kn-period-block" id="kn-players-block-' + period + '" style="display:none">'
-							+ '<div class="kn-period-label">' + (period*6) + '–' + ((period+1)*6) + ' months ago</div>'
-							+ '<div class="kn-players-grid">' + periods[period].map(function(p){return knPlayerCardHtml(p,uir);}).join('') + '</div>'
-							+ '</div>';
-					});
-					if (periodKeys.length > 1) {
-						html += '<div class="kn-load-more-wrap" data-next="1" data-group="kn-players">'
-							+ '<button class="kn-load-more-btn" onclick="knLoadMoreCards(\'kn-players\',this)"><i class="fas fa-chevron-down"></i> Load More...</button>'
-							+ '<span class="kn-load-more-hint">Showing ' + active + ' of ' + total + ' members</span>'
-							+ '</div>';
-					}
-					cardsEl.innerHTML = html;
-					cardsEl.style.display = '';
-				}
+				var listEl  = document.getElementById('kn-players-list');
+				var cardsHtml = [];
+				var listHtml  = [];
+				yearKeys.forEach(function(yk, idx) {
+					var bucket = byYear[yk];
+					var label  = (yk === 'never') ? 'No recorded sign-ins' : yk;
+					if (yk !== 'never' && yk == nowYear) label = yk + ' (current)';
+					var openAttr = idx === 0 ? ' open' : '';
+					var count    = bucket.length;
+					var summary  =
+						'<summary class="kn-year-summary">'
+						+ '<span class="kn-year-label">' + label + '</span>'
+						+ '<span class="kn-year-count">' + count + ' member' + (count!==1?'s':'') + '</span>'
+						+ '</summary>';
 
-				// Build list tbody + templates
-				var tbody = document.getElementById('kn-players-tbody');
-				if (tbody) {
-					tbody.innerHTML = (periods[0]||[]).map(function(p){return knPlayerRowHtml(p,uir);}).join('');
-					var table = document.getElementById('kn-players-table');
-					if (table) {
-						periodKeys.slice(1).forEach(function(period) {
-							var tmpl = document.createElement('template');
-							tmpl.id = 'kn-players-tmpl-' + period;
-							tmpl.innerHTML = periods[period].map(function(p){return knPlayerRowHtml(p,uir);}).join('');
-							table.parentNode.insertBefore(tmpl, table.nextSibling);
-						});
-					}
-					if (periodKeys.length > 1) {
-						var moreWrap = document.getElementById('kn-players-list-more');
-						if (moreWrap) {
-							moreWrap.style.display = '';
-							var hint = document.getElementById('kn-players-list-hint');
-							if (hint) hint.textContent = 'Showing ' + active + ' of ' + total + ' members';
-						}
-					}
-				}
+					cardsHtml.push(
+						'<details class="kn-year-section"' + openAttr + ' data-year="' + yk + '">'
+						+ summary
+						+ '<div class="kn-players-grid">'
+						+ bucket.map(function(p){ return knPlayerCardHtml(p, uir); }).join('')
+						+ '</div></details>'
+					);
+					listHtml.push(
+						'<details class="kn-year-section"' + openAttr + ' data-year="' + yk + '">'
+						+ summary
+						+ '<table class="kn-table kn-year-table"><thead><tr>'
+						+ '<th data-sorttype="text">Persona</th>'
+						+ '<th data-sorttype="text">Park</th>'
+						+ '<th data-sorttype="numeric">Sign-ins</th>'
+						+ '<th data-sorttype="date">Last Visit</th>'
+						+ '<th data-sorttype="text">Last Class</th>'
+						+ '<th data-sorttype="text">Role</th>'
+						+ '</tr></thead><tbody>'
+						+ bucket.map(function(p){ return knPlayerRowHtml(p, uir); }).join('')
+						+ '</tbody></table></details>'
+					);
+				});
+
+				if (cardsEl) { cardsEl.innerHTML = cardsHtml.join(''); cardsEl.style.display = ''; }
+				if (listEl)  { listEl.innerHTML  = listHtml.join('');  /* keeps display:none until view toggle */ }
 
 				// Hide spinner
 				var loadEl = document.getElementById('kn-players-loading');
@@ -2137,23 +2133,36 @@ html[data-theme="dark"] .kn-btn-danger { background: #fc8181; color: #1a202c; bo
 		if (searchInput) {
 			searchInput.addEventListener('input', function() {
 				var q = this.value.trim().toLowerCase();
-				var tbody = document.getElementById('kn-players-tbody');
-				if (tbody) {
-					tbody.querySelectorAll('tr').forEach(function(row) {
+				var roots = [
+					document.getElementById('kn-players-cards'),
+					document.getElementById('kn-players-list')
+				];
+				roots.forEach(function(root) {
+					if (!root) return;
+					// Cards
+					root.querySelectorAll('.kn-player-card').forEach(function(card) {
+						var nameEl = card.querySelector('.kn-player-name');
+						var pName  = nameEl ? nameEl.textContent.toLowerCase() : '';
+						var mn     = (card.dataset.mundaneName || '').toLowerCase();
+						card.style.display = (!q || pName.indexOf(q) !== -1 || mn.indexOf(q) !== -1) ? '' : 'none';
+					});
+					// List rows
+					root.querySelectorAll('.kn-year-table tbody tr').forEach(function(row) {
 						var persona = row.cells[0] ? row.cells[0].textContent.toLowerCase() : '';
-						var mundane = (row.dataset.mundaneName || '').toLowerCase();
-						row.style.display = (!q || persona.indexOf(q) !== -1 || mundane.indexOf(q) !== -1) ? '' : 'none';
+						var mn      = (row.dataset.mundaneName || '').toLowerCase();
+						row.style.display = (!q || persona.indexOf(q) !== -1 || mn.indexOf(q) !== -1) ? '' : 'none';
 					});
-				}
-				var cards = document.getElementById('kn-players-cards');
-				if (cards) {
-					cards.querySelectorAll('.kn-player-card').forEach(function(card) {
-						var persona = card.querySelector('.kn-player-name');
-						var pName = persona ? persona.textContent.toLowerCase() : '';
-						var mundane = (card.dataset.mundaneName || '').toLowerCase();
-						card.style.display = (!q || pName.indexOf(q) !== -1 || mundane.indexOf(q) !== -1) ? '' : 'none';
+					// Auto-open + collapse year sections based on visible content during search
+					root.querySelectorAll('.kn-year-section').forEach(function(sec) {
+						if (!q) return; // leave default open/closed state alone when search is cleared
+						var hasMatch = sec.querySelector('.kn-player-card:not([style*="display: none"]), .kn-year-table tbody tr:not([style*="display: none"])');
+						sec.style.display = hasMatch ? '' : 'none';
+						if (hasMatch) sec.open = true;
 					});
-				}
+					if (!q) {
+						root.querySelectorAll('.kn-year-section').forEach(function(sec) { sec.style.display = ''; });
+					}
+				});
 			});
 		}
 	});

--- a/orkui/template/revised-frontend/Parknew_index.tpl
+++ b/orkui/template/revised-frontend/Parknew_index.tpl
@@ -38,23 +38,34 @@
 		? 'https://maps.google.com/maps?q=@' . $parkLat . ',' . $parkLng
 		: null;
 
-	// Group all players by 6-month period (0 = 0–6 months ago, 1 = 6–12, etc.)
-	$allPlayers = $park_players ?? [];
-	$nowTs      = time();
-	$playerPeriods  = [];
-	$heraldryPeriods = [];
+	// Group all players by year of last sign-in (newest year first; 'never' last).
+	// Also separately track players whose last signin is within the past 6 months
+	// (for the "active member" stat) and 12 months (for the Heraldry hall of arms).
+	$allPlayers      = $park_players ?? [];
+	$nowTs           = time();
+	$nowYear         = (int)date('Y');
+	$sixMoCutoff     = strtotime('-6 months');
+	$twelveMoCutoff  = strtotime('-12 months');
+	$playersByYear   = [];   // key: 'YYYY' or 'never', value: array of players
+	$playerList      = [];   // active in past 6 months
+	$hoaPlayers12    = [];   // heraldry holders active in past 12 months
+	$totalHeraldry   = 0;
 	foreach ($allPlayers as $p) {
-		$ts = strtotime($p['LastSignin']);
-		$period = max(0, (int)floor(($nowTs - $ts) / (30.44 * 24 * 3600) / 6));
-		$playerPeriods[$period][] = $p;
-		if ($p['HasHeraldry']) $heraldryPeriods[$period][] = $p;
+		$ts  = strtotime($p['LastSignin']);
+		$key = ($ts && $ts > 0 && date('Y', $ts) !== '1970') ? date('Y', $ts) : 'never';
+		$playersByYear[$key][] = $p;
+		if (!empty($p['HasHeraldry'])) {
+			$totalHeraldry++;
+			if ($ts >= $twelveMoCutoff) $hoaPlayers12[] = $p;
+		}
+		if ($ts >= $sixMoCutoff) $playerList[] = $p;
 	}
-	ksort($playerPeriods);
-	ksort($heraldryPeriods);
-
-	$playerList    = $playerPeriods[0] ?? [];  // 0–6 months (used for stats row count)
-	$totalHeraldry = array_sum(array_map('count', $heraldryPeriods));
-	$hoaPlayers12  = array_merge($heraldryPeriods[0] ?? [], $heraldryPeriods[1] ?? []);
+	// Sort: real years descending (newest first); 'never' bucket goes last.
+	uksort($playersByYear, function ($a, $b) {
+		if ($a === 'never') return 1;
+		if ($b === 'never') return -1;
+		return strcmp($b, $a);
+	});
 
 	$firstTab = 'about';
 
@@ -159,7 +170,7 @@
 	}
 
 	// Active Players: last sign-in within the past 6 months — matches the Players tab subtitle
-	$activePlayersYear = count($playerPeriods[0] ?? []);
+	$activePlayersYear = count($playerList);
 ?>
 
 <link rel="stylesheet" href="<?= HTTP_TEMPLATE ?>revised-frontend/style/revised.css?v=<?= filemtime(DIR_TEMPLATE . 'revised-frontend/style/revised.css') ?>">
@@ -677,7 +688,7 @@
 				<?php if (count($allPlayers) > 0): ?>
 					<div class="pk-players-toolbar">
 						<span class="pk-players-toolbar-left">
-							<?= count($playerPeriods[0] ?? []) ?> active member<?= count($playerPeriods[0] ?? []) != 1 ? 's' : '' ?> (past 6 months)<?php if (count($allPlayers) > count($playerPeriods[0] ?? [])): ?> &middot; <?= count($allPlayers) ?> total<?php endif; ?>
+							<?= count($playerList) ?> active member<?= count($playerList) != 1 ? 's' : '' ?> (past 6 months)<?php if (count($allPlayers) > count($playerList)): ?> &middot; <?= count($allPlayers) ?> total<?php endif; ?>
 						</span>
 						<div class="pk-players-toolbar-right">
 							<div class="pk-player-search-wrap">
@@ -707,23 +718,20 @@
 						</div>
 					</div>
 
-					<!-- Card view (default) -->
-					<div id="pk-players-cards">
-						<!-- Period 0 (0–6 months) always visible -->
-						<div class="pk-players-grid">
-							<?php foreach ($playerPeriods[0] ?? [] as $p): ?>
-							<?php
-								$initial = htmlspecialchars(strtoupper(mb_substr($p['Persona'], 0, 1)));
-								$heraldryBgSrc = $p['HasHeraldry']
-									? HTTP_PLAYER_HERALDRY . Common::resolve_image_ext(DIR_PLAYER_HERALDRY, sprintf('%06d', $p['MundaneId']))
-									: null;
-								if ($p['HasImage']) {
-									$avatarSrc = HTTP_PLAYER_IMAGE . Common::resolve_image_ext(DIR_PLAYER_IMAGE, sprintf('%06d', $p['MundaneId']));
-								} elseif ($p['HasHeraldry']) {
-									$avatarSrc = $heraldryBgSrc;
-								} else {
-									$avatarSrc = null;
-								}
+					<?php
+						// Renderers reused for each year section.
+						$pkRenderCard = function (array $p) {
+							$initial = htmlspecialchars(strtoupper(mb_substr($p['Persona'], 0, 1)));
+							$heraldryBgSrc = $p['HasHeraldry']
+								? HTTP_PLAYER_HERALDRY . Common::resolve_image_ext(DIR_PLAYER_HERALDRY, sprintf('%06d', $p['MundaneId']))
+								: null;
+							if ($p['HasImage']) {
+								$avatarSrc = HTTP_PLAYER_IMAGE . Common::resolve_image_ext(DIR_PLAYER_IMAGE, sprintf('%06d', $p['MundaneId']));
+							} elseif ($p['HasHeraldry']) {
+								$avatarSrc = $heraldryBgSrc;
+							} else {
+								$avatarSrc = null;
+							}
 							?>
 							<a class="pk-player-card<?= $heraldryBgSrc ? ' pk-player-card-hbg' : '' ?>"
 							   <?= $heraldryBgSrc ? 'style="--hbg: url(\'' . htmlspecialchars($heraldryBgSrc) . '\')"'  : '' ?>
@@ -732,10 +740,7 @@
 								<div class="pk-player-card-top">
 									<div class="pk-player-avatar">
 										<?php if ($avatarSrc): ?>
-											<img src="<?= htmlspecialchars($avatarSrc) ?>"
-											     alt=""
-											     loading="lazy"
-											     onerror="pkAvatarFallback(this,'<?= $initial ?>')">
+											<img src="<?= htmlspecialchars($avatarSrc) ?>" alt="" loading="lazy" onerror="pkAvatarFallback(this,'<?= $initial ?>')">
 										<?php else: ?>
 											<?= $initial ?>
 										<?php endif; ?>
@@ -751,119 +756,18 @@
 								</div>
 								<div class="pk-player-stats">
 									<span><i class="fas fa-check-circle" style="color:#68d391;width:14px"></i> <?= $p['SigninCount'] ?> sign-in<?= $p['SigninCount'] != 1 ? 's' : '' ?></span>
-									<span><i class="fas fa-calendar-check" style="color:#63b3ed;width:14px"></i> <?= date('M j', strtotime($p['LastSignin'])) ?></span>
+									<span><i class="fas fa-calendar-check" style="color:#63b3ed;width:14px"></i> <?= date('M j, Y', strtotime($p['LastSignin'])) ?></span>
 									<?php if (!empty($p['LastClass'])): ?>
 										<span><i class="fas fa-shield-alt" style="color:#b794f4;width:14px"></i> <?= htmlspecialchars($p['LastClass']) ?></span>
 									<?php endif; ?>
 								</div>
 							</a>
-							<?php endforeach; ?>
-						</div>
+							<?php
+						};
 
-						<!-- Period 1+ (hidden; revealed by Load More) -->
-						<?php $_pkCardIdx = 1; foreach (array_slice($playerPeriods, 1, null, true) as $pkPeriod => $pkPeriodPlayers): ?>
-						<div class="pk-period-block" id="pk-players-block-<?= $_pkCardIdx ?>" style="display:none">
-							<div class="pk-period-label"><?= $pkPeriod * 6 ?>–<?= ($pkPeriod + 1) * 6 ?> months ago</div>
-							<div class="pk-players-grid">
-								<?php foreach ($pkPeriodPlayers as $p): ?>
-								<?php
-									$initial = htmlspecialchars(strtoupper(mb_substr($p['Persona'], 0, 1)));
-									$heraldryBgSrc = $p['HasHeraldry']
-										? HTTP_PLAYER_HERALDRY . Common::resolve_image_ext(DIR_PLAYER_HERALDRY, sprintf('%06d', $p['MundaneId']))
-										: null;
-									if ($p['HasImage']) {
-										$avatarSrc = HTTP_PLAYER_IMAGE . Common::resolve_image_ext(DIR_PLAYER_IMAGE, sprintf('%06d', $p['MundaneId']));
-									} elseif ($p['HasHeraldry']) {
-										$avatarSrc = $heraldryBgSrc;
-									} else {
-										$avatarSrc = null;
-									}
-								?>
-								<a class="pk-player-card<?= $heraldryBgSrc ? ' pk-player-card-hbg' : '' ?>"
-								   <?= $heraldryBgSrc ? 'style="--hbg: url(\'' . htmlspecialchars($heraldryBgSrc) . '\')"'  : '' ?>
-								   <?= !empty($p['MundaneName']) ? 'data-mundane-name="' . htmlspecialchars(strtolower($p['MundaneName'])) . '"' : '' ?>
-								   href="<?= UIR ?>Player/profile/<?= $p['MundaneId'] ?>">
-									<div class="pk-player-card-top">
-										<div class="pk-player-avatar">
-											<?php if ($avatarSrc): ?>
-												<img src="<?= htmlspecialchars($avatarSrc) ?>"
-												     loading="lazy"
-												     alt=""
-												     onerror="pkAvatarFallback(this,'<?= $initial ?>')">
-											<?php else: ?>
-												<?= $initial ?>
-											<?php endif; ?>
-										</div>
-										<div>
-											<div class="pk-player-name"><?= htmlspecialchars($p['Persona']) ?></div>
-											<?php if (!empty($p['OfficerRoles'])): ?>
-												<?php foreach (explode(', ', $p['OfficerRoles']) as $role): ?>
-													<span class="pk-officer-pill"><?= htmlspecialchars(trim($role)) ?></span>
-												<?php endforeach; ?>
-											<?php endif; ?>
-										</div>
-									</div>
-									<div class="pk-player-stats">
-										<span><i class="fas fa-check-circle" style="color:#68d391;width:14px"></i> <?= $p['SigninCount'] ?> sign-in<?= $p['SigninCount'] != 1 ? 's' : '' ?></span>
-										<span><i class="fas fa-calendar-check" style="color:#63b3ed;width:14px"></i> <?= date('M j', strtotime($p['LastSignin'])) ?></span>
-										<?php if (!empty($p['LastClass'])): ?>
-											<span><i class="fas fa-shield-alt" style="color:#b794f4;width:14px"></i> <?= htmlspecialchars($p['LastClass']) ?></span>
-										<?php endif; ?>
-									</div>
-								</a>
-								<?php endforeach; ?>
-							</div>
-						</div>
-						<?php $_pkCardIdx++; endforeach; ?>
-
-						<?php if (count($playerPeriods) > 1): ?>
-						<div class="pk-load-more-wrap" data-next="1" data-group="pk-players">
-							<button class="pk-load-more-btn" onclick="pkLoadMoreCards('pk-players', this)">
-								<i class="fas fa-chevron-down"></i> Load More...
-							</button>
-							<span class="pk-load-more-hint">Showing <?= count($playerPeriods[0] ?? []) ?> of <?= count($allPlayers) ?> members</span>
-						</div>
-						<?php endif; ?>
-					</div><!-- /pk-players-cards -->
-
-					<!-- List view (hidden by default) -->
-					<div id="pk-players-list" style="display:none">
-						<table class="pk-table" id="pk-players-table">
-							<thead>
-								<tr>
-									<th data-sorttype="text">Persona</th>
-									<th data-sorttype="numeric">Sign-ins</th>
-									<th data-sorttype="date">Last Visit</th>
-									<th data-sorttype="text">Last Class</th>
-									<th data-sorttype="text">Role</th>
-								</tr>
-							</thead>
-							<tbody>
-								<?php foreach ($playerPeriods[0] ?? [] as $p): ?>
-								<tr <?= !empty($p['MundaneName']) ? 'data-mundane-name="' . htmlspecialchars(strtolower($p['MundaneName'])) . '"' : '' ?> onclick='window.location.href="<?= UIR ?>Player/profile/<?= $p['MundaneId'] ?>"'>
-									<td>
-										<?= htmlspecialchars($p['Persona']) ?>
-										<?php if (!empty($p['OfficerRoles'])): ?>
-											<?php foreach (explode(', ', $p['OfficerRoles']) as $role): ?>
-												<span class="pk-officer-pill"><?= htmlspecialchars(trim($role)) ?></span>
-											<?php endforeach; ?>
-										<?php endif; ?>
-									</td>
-									<td data-sortval="<?= $p['SigninCount'] ?>"><?= $p['SigninCount'] ?></td>
-									<td class="pk-date-col" data-sortval="<?= $p['LastSignin'] ?>">
-										<?= date('M j, Y', strtotime($p['LastSignin'])) ?>
-									</td>
-									<td><?= htmlspecialchars($p['LastClass'] ?? '') ?></td>
-									<td><?= htmlspecialchars($p['OfficerRoles'] ?? '') ?></td>
-								</tr>
-								<?php endforeach; ?>
-							</tbody>
-						</table>
-						<!-- Hidden row templates for older periods -->
-						<?php $_pkListIdx = 1; foreach (array_slice($playerPeriods, 1, null, true) as $pkPeriod => $pkPeriodPlayers): ?>
-						<template id="pk-players-tmpl-<?= $_pkListIdx ?>">
-							<?php foreach ($pkPeriodPlayers as $p): ?>
-							<tr onclick='window.location.href="<?= UIR ?>Player/profile/<?= $p['MundaneId'] ?>"'>
+						$pkRenderRow = function (array $p) {
+							?>
+							<tr <?= !empty($p['MundaneName']) ? 'data-mundane-name="' . htmlspecialchars(strtolower($p['MundaneName'])) . '"' : '' ?> onclick='window.location.href="<?= UIR ?>Player/profile/<?= $p['MundaneId'] ?>"'>
 								<td>
 									<?= htmlspecialchars($p['Persona']) ?>
 									<?php if (!empty($p['OfficerRoles'])): ?>
@@ -873,24 +777,58 @@
 									<?php endif; ?>
 								</td>
 								<td data-sortval="<?= $p['SigninCount'] ?>"><?= $p['SigninCount'] ?></td>
-								<td class="pk-date-col" data-sortval="<?= $p['LastSignin'] ?>">
-									<?= date('M j, Y', strtotime($p['LastSignin'])) ?>
-								</td>
+								<td class="pk-date-col" data-sortval="<?= $p['LastSignin'] ?>"><?= date('M j, Y', strtotime($p['LastSignin'])) ?></td>
 								<td><?= htmlspecialchars($p['LastClass'] ?? '') ?></td>
 								<td><?= htmlspecialchars($p['OfficerRoles'] ?? '') ?></td>
 							</tr>
-							<?php endforeach; ?>
-						</template>
-						<?php $_pkListIdx++; endforeach; ?>
-						<?php if (count($playerPeriods) > 1): ?>
-						<div class="pk-load-more-wrap pk-load-more-list" data-next="1">
-							<button class="pk-load-more-btn" onclick="pkLoadMoreList('pk-players-table', 'pk-players-tmpl', this)">
-								<i class="fas fa-chevron-down"></i> Load More...
-							</button>
-							<span class="pk-load-more-hint">Showing <?= count($playerPeriods[0] ?? []) ?> of <?= count($allPlayers) ?> members</span>
-						</div>
-						<?php endif; ?>
-						<div class="pk-pagination" id="pk-players-table-pages"></div>
+							<?php
+						};
+
+						$pkYearLabel = function ($year) use ($nowYear) {
+							if ($year === 'never') return 'No recorded sign-ins';
+							return ((int)$year === $nowYear) ? ($year . ' (current)') : (string)$year;
+						};
+					?>
+
+					<!-- Card view (default) — one details/year section -->
+					<div id="pk-players-cards">
+						<?php $_pkIdx = 0; foreach ($playersByYear as $_pkYear => $_pkYearPlayers): ?>
+						<details class="pk-year-section"<?= $_pkIdx === 0 ? ' open' : '' ?> data-year="<?= htmlspecialchars((string)$_pkYear) ?>">
+							<summary class="pk-year-summary">
+								<span class="pk-year-label"><?= htmlspecialchars($pkYearLabel($_pkYear)) ?></span>
+								<span class="pk-year-count"><?= count($_pkYearPlayers) ?> member<?= count($_pkYearPlayers) != 1 ? 's' : '' ?></span>
+							</summary>
+							<div class="pk-players-grid">
+								<?php foreach ($_pkYearPlayers as $p) { $pkRenderCard($p); } ?>
+							</div>
+						</details>
+						<?php $_pkIdx++; endforeach; ?>
+					</div><!-- /pk-players-cards -->
+
+					<!-- List view (hidden by default) — one details/year section, each with its own table -->
+					<div id="pk-players-list" style="display:none">
+						<?php $_pkIdx = 0; foreach ($playersByYear as $_pkYear => $_pkYearPlayers): ?>
+						<details class="pk-year-section"<?= $_pkIdx === 0 ? ' open' : '' ?> data-year="<?= htmlspecialchars((string)$_pkYear) ?>">
+							<summary class="pk-year-summary">
+								<span class="pk-year-label"><?= htmlspecialchars($pkYearLabel($_pkYear)) ?></span>
+								<span class="pk-year-count"><?= count($_pkYearPlayers) ?> member<?= count($_pkYearPlayers) != 1 ? 's' : '' ?></span>
+							</summary>
+							<table class="pk-table pk-year-table">
+								<thead>
+									<tr>
+										<th data-sorttype="text">Persona</th>
+										<th data-sorttype="numeric">Sign-ins</th>
+										<th data-sorttype="date">Last Visit</th>
+										<th data-sorttype="text">Last Class</th>
+										<th data-sorttype="text">Role</th>
+									</tr>
+								</thead>
+								<tbody>
+									<?php foreach ($_pkYearPlayers as $p) { $pkRenderRow($p); } ?>
+								</tbody>
+							</table>
+						</details>
+						<?php $_pkIdx++; endforeach; ?>
 					</div><!-- /pk-players-list -->
 				<?php else: ?>
 					<div class="pk-empty">No players found</div>

--- a/orkui/template/revised-frontend/script/revised.js
+++ b/orkui/template/revised-frontend/script/revised.js
@@ -2300,43 +2300,6 @@ function knAvatarFallback(img, initial) {
     img.parentElement.innerText = initial;
 }
 
-// ---- Load More: card view (reveals next hidden period block) ----
-function knLoadMoreCards(group, btn) {
-    var $wrap = $(btn).closest('.kn-load-more-wrap');
-    var next  = parseInt($wrap.attr('data-next') || '1');
-    var $block = $('#' + group + '-block-' + next);
-    if ($block.length) {
-        $block.show();
-        var newNext = next + 1;
-        $wrap.attr('data-next', newNext);
-        if (!$('#' + group + '-block-' + newNext).length) {
-            $wrap.hide();
-        }
-    } else {
-        $wrap.hide();
-    }
-}
-
-// ---- Load More: list view (appends template rows to table, re-paginates) ----
-function knLoadMoreList(tableId, tmplBase, btn) {
-    var $wrap  = $(btn).closest('.kn-load-more-wrap');
-    var next   = parseInt($wrap.attr('data-next') || '1');
-    var tmpl   = document.getElementById(tmplBase + '-' + next);
-    if (tmpl) {
-        var $tbody = $('#' + tableId + ' tbody');
-        var frag = document.importNode(tmpl.content, true);
-        $(frag.querySelectorAll('tr')).appendTo($tbody);
-        var newNext = next + 1;
-        $wrap.attr('data-next', newNext);
-        knPaginate($('#' + tableId), 1);
-        if (!document.getElementById(tmplBase + '-' + newNext)) {
-            $wrap.hide();
-        }
-    } else {
-        $wrap.hide();
-    }
-}
-
 // ---- Activate a tab by name (used by buttons + links) ----
 function knActivateTab(tab) {
     $('.kn-tab-nav li').removeClass('kn-tab-active');
@@ -2631,25 +2594,37 @@ $(document).ready(function() {
         }
     });
 
-    // ---- Players: search (filters all .kn-player-card across all periods) ----
+    // ---- Players: search across every year section (cards + list rows) ----
+    // The DOM is fully populated up-front; content-visibility:auto on each year
+    // section keeps off-screen ones cheap. Search filters in place and force-opens
+    // any year section that has matches.
     $('#kn-player-search').on('input', function() {
         var q = $(this).val().trim().toLowerCase();
+        var $roots = $('#kn-players-cards, #kn-players-list');
         if (q === '') {
-            $('.kn-period-block').show();
-            $('.kn-player-card').show();
-        } else {
-            // Show all period blocks first so cards inside are visible/searchable
-            $('.kn-period-block').show();
-            $('.kn-player-card').each(function() {
-                var name = $(this).find('.kn-player-name').text().toLowerCase();
-                $(this).toggle(name.indexOf(q) !== -1);
-            });
-            // Hide period blocks with no visible cards
-            $('.kn-period-block').each(function() {
-                var hasVisible = $(this).find('.kn-player-card:visible').length > 0;
-                $(this).toggle(hasVisible);
-            });
+            $roots.find('.kn-player-card, .kn-year-table tbody tr').show();
+            $roots.find('.kn-year-section').show();
+            return;
         }
+        $roots.each(function() {
+            var $root = $(this);
+            $root.find('.kn-player-card').each(function() {
+                var name = $(this).find('.kn-player-name').text().toLowerCase();
+                var mn   = ($(this).attr('data-mundane-name') || '').toLowerCase();
+                $(this).toggle(name.indexOf(q) !== -1 || mn.indexOf(q) !== -1);
+            });
+            $root.find('.kn-year-table tbody tr').each(function() {
+                var persona = (this.cells[0] ? this.cells[0].textContent : '').toLowerCase();
+                var mn      = ($(this).attr('data-mundane-name') || '').toLowerCase();
+                $(this).toggle(persona.indexOf(q) !== -1 || mn.indexOf(q) !== -1);
+            });
+            $root.find('.kn-year-section').each(function() {
+                var hasVisible =
+                    $(this).find('.kn-player-card:visible, .kn-year-table tbody tr:visible').length > 0;
+                $(this).toggle(hasVisible);
+                if (hasVisible) this.open = true;
+            });
+        });
     });
 
     // ---- Default sort + initial pagination ----
@@ -2662,8 +2637,6 @@ $(document).ready(function() {
 
     // [TOURNAMENTS HIDDEN] knSortDesc($('#kn-tournaments-table'), 0, 'date');
     // [TOURNAMENTS HIDDEN] knPaginate($('#kn-tournaments-table'), 1);
-
-    knPaginate($('#kn-players-table'), 1);
 
 });
 (function() {
@@ -5354,50 +5327,6 @@ function pkAvatarFallback(img, initial) {
     img.parentElement.innerText = initial;
 }
 
-// ---- Load More: card view (reveals next hidden period block) ----
-// group: prefix string like 'pk-players' or 'pk-hoa'
-// btn:   the button element inside .pk-load-more-wrap[data-next][data-group]
-function pkLoadMoreCards(group, btn) {
-    var $wrap = $(btn).closest('.pk-load-more-wrap');
-    var next  = parseInt($wrap.attr('data-next') || '1');
-    var $block = $('#' + group + '-block-' + next);
-    if ($block.length) {
-        $block.show();
-        var newNext = next + 1;
-        $wrap.attr('data-next', newNext);
-        if (!$('#' + group + '-block-' + newNext).length) {
-            $wrap.hide(); // no more periods to load
-        }
-    } else {
-        $wrap.hide();
-    }
-}
-
-// ---- Load More: list view (appends template rows to table, re-paginates) ----
-// tableId:  id of the <table> element
-// tmplBase: id prefix of <template> elements (e.g. 'pk-players-tmpl')
-// btn:      the button element inside .pk-load-more-wrap[data-next]
-function pkLoadMoreList(tableId, tmplBase, btn) {
-    var $wrap  = $(btn).closest('.pk-load-more-wrap');
-    var next   = parseInt($wrap.attr('data-next') || '1');
-    var tmpl   = document.getElementById(tmplBase + '-' + next);
-    if (tmpl) {
-        var $tbody = $('#' + tableId + ' tbody');
-        // Clone template content and append to tbody
-        var frag = document.importNode(tmpl.content, true);
-        $(frag.querySelectorAll('tr')).appendTo($tbody);
-        var newNext = next + 1;
-        $wrap.attr('data-next', newNext);
-        // Re-paginate from page 1 with the expanded row set
-        pkPaginate($('#' + tableId), 1);
-        if (!document.getElementById(tmplBase + '-' + newNext)) {
-            $wrap.hide();
-        }
-    } else {
-        $wrap.hide();
-    }
-}
-
 // ---- Hero color from heraldry ----
 // Samples the heraldry image via Canvas to find its dominant non-white, non-black
 // color and applies a darkened version as the hero background.
@@ -5640,30 +5569,36 @@ $(document).ready(function() {
         pkPaginate($table, page);
     });
 
-    // ---- Player search (filters cards + list rows across all periods) ----
+    // ---- Player search across every year section (cards + list rows) ----
+    // The DOM holds every player up-front; content-visibility:auto on each year
+    // section keeps off-screen ones cheap. Search filters in place and force-opens
+    // any year section that has matches.
     $('#pk-player-search').on('input', function() {
         var q = $(this).val().trim().toLowerCase();
+        var $roots = $('#pk-players-cards, #pk-players-list');
         if (q === '') {
-            $('.pk-period-block').show();
-            $('.pk-player-card').show();
-        } else {
-            $('.pk-period-block').show();
-            $('.pk-player-card').each(function() {
-                var name = $(this).find('.pk-player-name').text().toLowerCase();
-                var mundane = ($(this).data('mundane-name') || '').toLowerCase();
-                $(this).toggle(name.indexOf(q) !== -1 || mundane.indexOf(q) !== -1);
-            });
-            // Hide period blocks with no visible cards
-            $('.pk-period-block').each(function() {
-                var hasVisible = $(this).find('.pk-player-card:visible').length > 0;
-                $(this).toggle(hasVisible);
-            });
+            $roots.find('.pk-player-card, .pk-year-table tbody tr').show();
+            $roots.find('.pk-year-section').show();
+            return;
         }
-        // Also filter list view rows
-        $('#pk-players-table tbody tr').each(function() {
-            var name = $(this).find('td:first').text().toLowerCase();
-            var mundane = ($(this).data('mundane-name') || '').toLowerCase();
-            $(this).toggle(!q || name.indexOf(q) !== -1 || mundane.indexOf(q) !== -1);
+        $roots.each(function() {
+            var $root = $(this);
+            $root.find('.pk-player-card').each(function() {
+                var name = $(this).find('.pk-player-name').text().toLowerCase();
+                var mn   = ($(this).attr('data-mundane-name') || '').toLowerCase();
+                $(this).toggle(name.indexOf(q) !== -1 || mn.indexOf(q) !== -1);
+            });
+            $root.find('.pk-year-table tbody tr').each(function() {
+                var persona = (this.cells[0] ? this.cells[0].textContent : '').toLowerCase();
+                var mn      = ($(this).attr('data-mundane-name') || '').toLowerCase();
+                $(this).toggle(persona.indexOf(q) !== -1 || mn.indexOf(q) !== -1);
+            });
+            $root.find('.pk-year-section').each(function() {
+                var hasVisible =
+                    $(this).find('.pk-player-card:visible, .pk-year-table tbody tr:visible').length > 0;
+                $(this).toggle(hasVisible);
+                if (hasVisible) this.open = true;
+            });
         });
     });
 
@@ -5688,8 +5623,6 @@ $(document).ready(function() {
 
     pkSortDesc($('#pk-tournaments-table'), 2, 'date');
     pkPaginate($('#pk-tournaments-table'), 1);
-
-    pkPaginate($('#pk-players-table'), 1);
 
 });
 (function() {

--- a/orkui/template/revised-frontend/style/revised.css
+++ b/orkui/template/revised-frontend/style/revised.css
@@ -2447,21 +2447,49 @@ html[data-theme="dark"] .kn-md-help-btn:hover { background:var(--ork-bg-tertiary
 	background: #fef3c7; color: #92400e;
 	white-space: nowrap; margin-top: 2px; margin-right: 2px;
 }
-.kn-period-label {
+/* Year-bucketed players list — collapsible per-year sections.
+ * content-visibility:auto lets the browser skip layout/paint for off-screen
+ * sections so we can render every year in the DOM without paying for it until
+ * the user scrolls them into view (or expands them). contain-intrinsic-size
+ * gives the browser a reasonable placeholder height so the scrollbar is stable. */
+.kn-year-section {
+	margin: 14px 0 6px;
+	border-top: 1px solid #e2e8f0;
+	content-visibility: auto;
+	contain-intrinsic-size: 1px 600px;
+}
+.kn-year-section:first-of-type { border-top: 0; margin-top: 0; }
+.kn-year-summary {
+	cursor: pointer;
+	list-style: none;
+	display: flex; align-items: baseline; gap: 10px;
+	padding: 10px 4px;
 	font-size: 11px; font-weight: 700; letter-spacing: 0.07em;
 	color: #a0aec0; text-transform: uppercase;
-	border-bottom: 1px solid #e2e8f0;
-	padding-bottom: 4px; margin: 18px 0 10px;
+	user-select: none;
 }
-.kn-load-more-wrap { text-align: center; padding: 18px 0 8px; }
-.kn-load-more-btn {
-	background: #fff; border: 1.5px solid #cbd5e0; border-radius: 6px;
-	padding: 8px 22px; font-size: 13px; font-weight: 600; color: #4a5568;
-	cursor: pointer; display: inline-flex; align-items: center; gap: 7px;
-	transition: border-color 0.15s, color 0.15s;
+.kn-year-summary::-webkit-details-marker { display: none; }
+.kn-year-summary::before {
+	content: '\25B8'; /* right-pointing triangle */
+	display: inline-block;
+	font-size: 10px;
+	color: #cbd5e0;
+	transition: transform 0.12s ease;
+	transform-origin: 50% 55%;
 }
-.kn-load-more-btn:hover { border-color: var(--kn-accent, #276749); color: var(--kn-accent, #276749); }
-.kn-load-more-hint { display: block; font-size: 11px; color: #a0aec0; margin-top: 6px; }
+.kn-year-section[open] > .kn-year-summary::before { transform: rotate(90deg); }
+.kn-year-summary:hover { color: var(--kn-accent, #276749); }
+.kn-year-summary:hover::before { color: var(--kn-accent, #276749); }
+.kn-year-label { font-size: 12px; }
+.kn-year-count {
+	font-size: 10px; font-weight: 600; letter-spacing: 0.04em;
+	color: #a0aec0;
+	background: #edf2f7;
+	padding: 2px 8px; border-radius: 10px;
+	text-transform: none;
+}
+.kn-year-section .kn-players-grid { padding-top: 4px; }
+.kn-year-table { margin-top: 4px; }
 /* ---- Award entry modal (kn-award-*) ---- */
 .kn-award-type-row { display:grid; grid-template-columns:1fr 1fr; gap:8px; margin-bottom:16px; }
 .kn-award-type-btn { padding:8px 4px; min-height:44px; line-height:1.2; border:2px solid var(--ork-border); border-radius:8px; background:var(--ork-card-bg); font-size:13px; font-weight:600; color:var(--ork-text-secondary); cursor:pointer; transition:all 0.15s; text-align:center; }
@@ -3373,47 +3401,51 @@ html[data-theme="dark"] .pk-stat-tip-text::after { border-top-color: #e2e8f0; }
 	.pk-active-tab-label { display: block; }
 }
 
-/* ---- Period label (Load More separators) ---- */
-.pk-period-label {
-	font-size: 11px;
-	font-weight: 700;
-	letter-spacing: 0.07em;
-	color: #a0aec0;
-	text-transform: uppercase;
-	border-bottom: 1px solid #e2e8f0;
-	padding-bottom: 4px;
-	margin: 18px 0 10px;
+/* ---- Year-bucketed players list (collapsible per-year sections) ----
+ * content-visibility:auto lets the browser skip layout/paint for off-screen
+ * sections so the full roster lives in the DOM without rendering cost until
+ * scrolled into view. contain-intrinsic-size keeps the scrollbar stable. */
+.pk-year-section {
+	margin: 14px 0 6px;
+	border-top: 1px solid #e2e8f0;
+	content-visibility: auto;
+	contain-intrinsic-size: 1px 600px;
 }
-
-/* ---- Load More button ---- */
-.pk-load-more-wrap {
-	text-align: center;
-	padding: 18px 0 8px;
-}
-.pk-load-more-btn {
-	background: #fff;
-	border: 1.5px solid #cbd5e0;
-	border-radius: 6px;
-	padding: 8px 22px;
-	font-size: 13px;
-	font-weight: 600;
-	color: #4a5568;
+.pk-year-section:first-of-type { border-top: 0; margin-top: 0; }
+.pk-year-summary {
 	cursor: pointer;
-	display: inline-flex;
-	align-items: center;
-	gap: 7px;
-	transition: border-color 0.15s, color 0.15s;
+	list-style: none;
+	display: flex; align-items: baseline; gap: 10px;
+	padding: 10px 4px;
+	font-size: 11px; font-weight: 700; letter-spacing: 0.07em;
+	color: #a0aec0; text-transform: uppercase;
+	user-select: none;
 }
-.pk-load-more-btn:hover {
-	border-color: #0891b2;
-	color: #0891b2;
+.pk-year-summary::-webkit-details-marker { display: none; }
+.pk-year-summary::before {
+	content: '\25B8';
+	display: inline-block;
+	font-size: 10px;
+	color: #cbd5e0;
+	transition: transform 0.12s ease;
+	transform-origin: 50% 55%;
 }
-.pk-load-more-hint {
-	display: block;
-	font-size: 11px;
+.pk-year-section[open] > .pk-year-summary::before { transform: rotate(90deg); }
+.pk-year-summary:hover,
+.pk-year-summary:hover::before { color: #0891b2; }
+.pk-year-label { font-size: 12px; }
+.pk-year-count {
+	font-size: 10px;
+	font-weight: 600;
+	letter-spacing: 0.04em;
 	color: #a0aec0;
-	margin-top: 6px;
+	background: #edf2f7;
+	padding: 2px 8px;
+	border-radius: 10px;
+	text-transform: none;
 }
+.pk-year-section .pk-players-grid { padding-top: 4px; }
+.pk-year-table { margin-top: 4px; }
 
 /* ---- Hall of Arms gallery ---- */
 .pk-hoa-search-wrap {
@@ -6681,8 +6713,6 @@ html[data-theme="dark"] #theme_container .kn-description-url,
 html[data-theme="dark"] #theme_container .kn-table a,
 html[data-theme="dark"] #theme_container .kn-report-group a,
 html[data-theme="dark"] #theme_container .kn-prinz-name a,
-html[data-theme="dark"] .kn-load-more-btn,
-html[data-theme="dark"] #theme_container .kn-load-more-btn,
 html[data-theme="dark"] #theme_container .kn-award-success,
 html[data-theme="dark"] #kn-events-cal .fc .fc-list-event-title a {
   color: hsl(calc(var(--kn-hue) + 35), 65%, var(--ork-accent-mid-lightness, 58%));
@@ -6691,15 +6721,26 @@ html[data-theme="dark"] .kn-description-body,
 html[data-theme="dark"] .kn-description-card {
   color: var(--ork-text);
 }
-html[data-theme="dark"] .kn-load-more-btn,
-html[data-theme="dark"] .pk-load-more-btn {
-  background: var(--ork-bg-secondary);
-  border-color: var(--ork-border);
+html[data-theme="dark"] .kn-year-section,
+html[data-theme="dark"] .pk-year-section {
+  border-top-color: var(--ork-border);
+}
+html[data-theme="dark"] .kn-year-summary,
+html[data-theme="dark"] .pk-year-summary {
   color: var(--ork-text-secondary);
 }
-html[data-theme="dark"] .kn-load-more-btn:hover {
-  border-color: hsl(var(--kn-hue), var(--kn-sat), var(--ork-accent-lightness, 65%));
+html[data-theme="dark"] .kn-year-count,
+html[data-theme="dark"] .pk-year-count {
+  background: var(--ork-bg-secondary);
+  color: var(--ork-text-secondary);
+}
+html[data-theme="dark"] .kn-year-summary:hover,
+html[data-theme="dark"] .kn-year-summary:hover::before {
   color: hsl(var(--kn-hue), var(--kn-sat), var(--ork-accent-lightness, 65%));
+}
+html[data-theme="dark"] .pk-year-summary:hover,
+html[data-theme="dark"] .pk-year-summary:hover::before {
+  color: hsl(var(--pk-hue, 195), var(--pk-sat, 80%), var(--ork-accent-lightness, 65%));
 }
 html[data-theme="dark"] .kn-officer-chip.kn-selected,
 html[data-theme="dark"] .kn-rank-pill:hover,


### PR DESCRIPTION
## Summary

Replaces the 6-month "Load More" reveal on the Kingdom and Park **Players** tabs with collapsible per-year `<details>` sections. The full roster lives in the DOM up-front; `content-visibility: auto` + `contain-intrinsic-size` keep off-screen years from being laid out or painted, and the most recent year is expanded by default. Search spans every year and auto-opens any section with matches.

## Changes

**Frontend (Kingdom + Park Players tab)**
- Per-year `<details>` sections replace the rolling "Load More" window — entire roster in DOM, lazy-painted via `content-visibility: auto`
- Most recent year expanded by default; older years collapsed
- Search now spans the full roster and auto-expands any year with a match
- Drops the load-more controller JS in favor of a smaller open/filter handler

**Backend SQL tightening**
- **Kingdom roster**:
  - Drop redundant `ork_park` join in the `last_signin` subquery (`ork_attendance` already carries `kingdom_id`)
  - Push the `suspended/active` filter into the subquery so we don't aggregate over departed players
  - Scope the last-class join (`la`) to the current kingdom so a player's class from a different kingdom on the same date can't bleed in or duplicate rows under `GROUP_CONCAT`
- **Park roster**: push the `suspended/active` filter into the `last_signin` subquery

The 2026-04-11 covering indexes already support these queries.

## Test plan
- [ ] Kingdom profile → Players tab: full roster renders, year sections collapse/expand, search hits across years and auto-opens matched sections
- [ ] Park profile → Players tab: same checks
- [ ] Verify suspended/inactive players are excluded
- [ ] Verify a player active in multiple kingdoms shows only the current kingdom's class data on the kingdom roster
- [ ] Scroll a long roster — confirm off-screen years aren't painted until scrolled near (DevTools → Rendering → "Paint flashing")

🤖 Generated with [Claude Code](https://claude.com/claude-code)