### PR TITLE
Feature: Mask II Org Enhancements

### DIFF
--- a/db-migrations/2026-05-16-ork-park-design.sql
+++ b/db-migrations/2026-05-16-ork-park-design.sql
@@ -1,0 +1,64 @@
+-- Park profile customization: 1:1 design fields table mirroring the
+-- ork_mundane_design pattern. Always-present row per park (backfilled,
+-- and seeded on park creation in the SetPark create path).
+--
+-- Field set is the subset of player design that makes sense for an org:
+--   * about_text + our_history  (Markdown — replaces player about_persona/about_story split;
+--                                 our_history replaces the per-character "About <Persona>" block)
+--   * color_primary / color_accent / color_secondary  (hero color, gradient stop, accent for tabs/links)
+--   * hero_overlay  ('low' | 'med' | 'high' | 'vignette')
+--   * name_font  (Google-fonts key for the park name in the hero — same font set as Player)
+--   * milestone_config  (JSON — visibility toggles + compact/newest-first settings)
+--
+-- Skipped from player: name_prefix/suffix/comma, pronunciation_guide (per spec ask),
+-- photo_focus_*, show_beltline, show_mundane_*, show_email — none apply to a park.
+--
+-- Engine note: ork_park is MyISAM in legacy state. To support the FK below
+-- (and match the InnoDB conversion already done on ork_mundane for the player
+-- design tables), convert ork_park to InnoDB first. ork_park is ~1k rows with
+-- no FULLTEXT indexes, so the conversion is fast and safe. Idempotent: no-op
+-- when already InnoDB so reruns are safe.
+
+SET @engine := (
+    SELECT ENGINE FROM information_schema.TABLES
+    WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'ork_park'
+);
+SET @sql := IF( @engine IS NOT NULL AND @engine <> 'InnoDB',
+                'ALTER TABLE ork_park ENGINE=InnoDB',
+                'DO 0' );
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+CREATE TABLE IF NOT EXISTS ork_park_design (
+    park_id           int(11)            NOT NULL PRIMARY KEY,
+    about_text        text               NULL,
+    our_history       text               NULL,
+    color_primary     varchar(7)         NULL,
+    color_accent      varchar(7)         NULL,
+    color_secondary   varchar(7)         NULL,
+    hero_overlay      varchar(10)        NOT NULL DEFAULT 'med',
+    name_font         varchar(100)       NULL,
+    milestone_config  text               NULL,
+    CONSTRAINT fk_park_design_park
+        FOREIGN KEY (park_id) REFERENCES ork_park (park_id)
+        ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- Backfill: every existing park gets a default-valued row so reads can
+-- assume the row exists (no PHP-side fallback maze).
+INSERT IGNORE INTO ork_park_design (park_id)
+SELECT park_id FROM ork_park;
+
+-- Preserve legacy About content: copy ork_park.description into about_text
+-- so the new editable About field starts populated with whatever was already
+-- visible. about_text becomes the source of truth going forward; the legacy
+-- description column is still updated by the existing Edit Details modal but
+-- the public profile reads from about_text.
+UPDATE ork_park_design d
+JOIN ork_park p ON d.park_id = p.park_id
+SET d.about_text = p.description
+WHERE (d.about_text IS NULL OR d.about_text = '')
+  AND p.description IS NOT NULL
+  AND p.description <> ''
+  AND TRIM(p.description) <> '';

--- a/db-migrations/2026-05-16-ork-park-milestones.sql
+++ b/db-migrations/2026-05-16-ork-park-milestones.sql
@@ -1,0 +1,34 @@
+-- Custom park milestones, mirroring ork_player_milestones.
+-- Rows are officer-authored and shown on the park profile timeline.
+-- Derived milestones (first attendance, attendance count crossings, etc.)
+-- are computed at read time and not stored.
+--
+-- NOTE: This migration depends on the ork_park engine conversion performed
+-- in 2026-05-16-ork-park-design.sql. Run that migration first. As a
+-- defensive guard, we re-issue the same idempotent InnoDB convert here
+-- so the FK below succeeds even if the design migration was skipped.
+
+SET @engine := (
+    SELECT ENGINE FROM information_schema.TABLES
+    WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'ork_park'
+);
+SET @sql := IF( @engine IS NOT NULL AND @engine <> 'InnoDB',
+                'ALTER TABLE ork_park ENGINE=InnoDB',
+                'DO 0' );
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+CREATE TABLE IF NOT EXISTS ork_park_milestones (
+    milestone_id     int(11)        NOT NULL PRIMARY KEY AUTO_INCREMENT,
+    park_id          int(11)        NOT NULL,
+    icon             varchar(50)    NOT NULL DEFAULT 'fa-star',
+    description      varchar(500)   NOT NULL DEFAULT '',
+    milestone_date   date           NOT NULL,
+    created_at       timestamp      NOT NULL DEFAULT current_timestamp(),
+    updated_at       timestamp      NOT NULL DEFAULT current_timestamp() ON UPDATE current_timestamp(),
+    KEY idx_park_milestone_park_date (park_id, milestone_date),
+    CONSTRAINT fk_park_milestone_park
+        FOREIGN KEY (park_id) REFERENCES ork_park (park_id)
+        ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/db-migrations/2026-05-17-org-design-extras.sql
+++ b/db-migrations/2026-05-17-org-design-extras.sql
@@ -1,0 +1,36 @@
+-- Phase 2 org customizations: tagline, social links, announcement banner
+-- (all 3 orgs), plus unit recruitment+how-to-join and kingdom reign banner.
+--
+-- All columns added to the *_design tables (system-of-record stays the
+-- main org table; presentational/cosmetic settings live in design).
+--
+-- social_links: JSON object keyed by platform slug. Empty/missing keys
+-- are not rendered. Recognized slugs (frontend convention):
+--   discord, facebook, instagram, threads, bluesky, twitter, youtube, amtwiki
+-- Storing as TEXT (utf8mb4) so platform list can grow without schema changes.
+--
+-- announcement_until: when NOT NULL, the announcement only renders while
+-- CURDATE() <= announcement_until. NULL = renders indefinitely.
+
+ALTER TABLE ork_park_design
+    ADD COLUMN IF NOT EXISTS tagline             VARCHAR(160) NULL          AFTER name_font,
+    ADD COLUMN IF NOT EXISTS social_links        TEXT         NULL          AFTER tagline,
+    ADD COLUMN IF NOT EXISTS announcement        TEXT         NULL          AFTER social_links,
+    ADD COLUMN IF NOT EXISTS announcement_until  DATE         NULL          AFTER announcement;
+
+ALTER TABLE ork_kingdom_design
+    ADD COLUMN IF NOT EXISTS tagline                VARCHAR(160) NULL       AFTER name_font,
+    ADD COLUMN IF NOT EXISTS social_links           TEXT         NULL       AFTER tagline,
+    ADD COLUMN IF NOT EXISTS announcement           TEXT         NULL       AFTER social_links,
+    ADD COLUMN IF NOT EXISTS announcement_until     DATE         NULL       AFTER announcement,
+    ADD COLUMN IF NOT EXISTS monarch_reign_started  DATE         NULL       AFTER announcement_until,
+    ADD COLUMN IF NOT EXISTS regent_reign_started   DATE         NULL       AFTER monarch_reign_started,
+    ADD COLUMN IF NOT EXISTS reign_lore             TEXT         NULL       AFTER regent_reign_started;
+
+ALTER TABLE ork_unit_design
+    ADD COLUMN IF NOT EXISTS tagline             VARCHAR(160) NULL          AFTER name_font,
+    ADD COLUMN IF NOT EXISTS social_links        TEXT         NULL          AFTER tagline,
+    ADD COLUMN IF NOT EXISTS announcement        TEXT         NULL          AFTER social_links,
+    ADD COLUMN IF NOT EXISTS announcement_until  DATE         NULL          AFTER announcement,
+    ADD COLUMN IF NOT EXISTS recruitment_status  VARCHAR(20)  NULL          AFTER announcement_until,
+    ADD COLUMN IF NOT EXISTS how_to_join         TEXT         NULL          AFTER recruitment_status;

--- a/db-migrations/2026-05-17-ork-kingdom-design.sql
+++ b/db-migrations/2026-05-17-ork-kingdom-design.sql
@@ -1,0 +1,55 @@
+-- Kingdom profile customization: 1:1 design fields table mirroring the
+-- ork_park_design pattern (which itself mirrors ork_mundane_design). One row
+-- per kingdom (backfilled, and seeded on kingdom creation). Applies to both
+-- Kingdoms and Principalities since both share the ork_kingdom table.
+--
+-- Field set is the same subset as ork_park_design (org-relevant):
+--   * about_text + our_history  (Markdown)
+--   * color_primary / color_accent / color_secondary  (hero color, gradient stop, accent)
+--   * hero_overlay  ('low' | 'med' | 'high' | 'vignette')
+--   * name_font  (Google-fonts key for the kingdom name in the hero)
+--   * milestone_config  (JSON — visibility toggles + newest-first)
+--
+-- Engine note: ork_kingdom is MyISAM in legacy state. Convert to InnoDB so
+-- the FK below succeeds. No FULLTEXT indexes exist on ork_kingdom (verified).
+-- Idempotent: no-op when already InnoDB so reruns are safe.
+
+SET @engine := (
+    SELECT ENGINE FROM information_schema.TABLES
+    WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'ork_kingdom'
+);
+SET @sql := IF( @engine IS NOT NULL AND @engine <> 'InnoDB',
+                'ALTER TABLE ork_kingdom ENGINE=InnoDB',
+                'DO 0' );
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+CREATE TABLE IF NOT EXISTS ork_kingdom_design (
+    kingdom_id        int(11)            NOT NULL PRIMARY KEY,
+    about_text        text               NULL,
+    our_history       text               NULL,
+    color_primary     varchar(7)         NULL,
+    color_accent      varchar(7)         NULL,
+    color_secondary   varchar(7)         NULL,
+    hero_overlay      varchar(10)        NOT NULL DEFAULT 'med',
+    name_font         varchar(100)       NULL,
+    milestone_config  text               NULL,
+    CONSTRAINT fk_kingdom_design_kingdom
+        FOREIGN KEY (kingdom_id) REFERENCES ork_kingdom (kingdom_id)
+        ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- Backfill: every existing kingdom (including principalities) gets a default-valued
+-- row so reads can assume the row exists.
+INSERT IGNORE INTO ork_kingdom_design (kingdom_id)
+SELECT kingdom_id FROM ork_kingdom;
+
+-- Preserve legacy About content: copy ork_kingdom.description into about_text.
+UPDATE ork_kingdom_design d
+JOIN ork_kingdom k ON d.kingdom_id = k.kingdom_id
+SET d.about_text = k.description
+WHERE (d.about_text IS NULL OR d.about_text = '')
+  AND k.description IS NOT NULL
+  AND k.description <> ''
+  AND TRIM(k.description) <> '';

--- a/db-migrations/2026-05-17-ork-kingdom-milestones.sql
+++ b/db-migrations/2026-05-17-ork-kingdom-milestones.sql
@@ -1,0 +1,34 @@
+-- Custom kingdom milestones, mirroring ork_park_milestones.
+-- Rows are officer-authored and shown on the kingdom profile timeline.
+-- Derived milestones (first attendance, attendance count crossings, etc.)
+-- are computed at read time from ork_attendance scoped by kingdom_id.
+--
+-- NOTE: Depends on the ork_kingdom engine conversion performed in
+-- 2026-05-17-ork-kingdom-design.sql. Run that migration first. As a
+-- defensive guard, we re-issue the same idempotent InnoDB convert here
+-- so the FK below succeeds even if the design migration was skipped.
+
+SET @engine := (
+    SELECT ENGINE FROM information_schema.TABLES
+    WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'ork_kingdom'
+);
+SET @sql := IF( @engine IS NOT NULL AND @engine <> 'InnoDB',
+                'ALTER TABLE ork_kingdom ENGINE=InnoDB',
+                'DO 0' );
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+CREATE TABLE IF NOT EXISTS ork_kingdom_milestones (
+    milestone_id     int(11)        NOT NULL PRIMARY KEY AUTO_INCREMENT,
+    kingdom_id       int(11)        NOT NULL,
+    icon             varchar(50)    NOT NULL DEFAULT 'fa-star',
+    description      varchar(500)   NOT NULL DEFAULT '',
+    milestone_date   date           NOT NULL,
+    created_at       timestamp      NOT NULL DEFAULT current_timestamp(),
+    updated_at       timestamp      NOT NULL DEFAULT current_timestamp() ON UPDATE current_timestamp(),
+    KEY idx_kingdom_milestone_kingdom_date (kingdom_id, milestone_date),
+    CONSTRAINT fk_kingdom_milestone_kingdom
+        FOREIGN KEY (kingdom_id) REFERENCES ork_kingdom (kingdom_id)
+        ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/db-migrations/2026-05-17-ork-unit-design.sql
+++ b/db-migrations/2026-05-17-ork-unit-design.sql
@@ -1,0 +1,60 @@
+-- Unit profile customization: 1:1 design fields table mirroring ork_park_design.
+-- Always-present row per unit (backfilled, and seeded on unit creation in the
+-- CreateUnit path).
+--
+-- Field set matches Park: about_text + our_history (Markdown), color_primary /
+-- color_accent / color_secondary, hero_overlay, name_font, milestone_config (JSON).
+--
+-- Engine note: ork_unit is MyISAM in legacy state. Convert to InnoDB first so
+-- the FK below succeeds. Idempotent: no-op when already InnoDB.
+
+SET @engine := (
+    SELECT ENGINE FROM information_schema.TABLES
+    WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'ork_unit'
+);
+SET @sql := IF( @engine IS NOT NULL AND @engine <> 'InnoDB',
+                'ALTER TABLE ork_unit ENGINE=InnoDB',
+                'DO 0' );
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+CREATE TABLE IF NOT EXISTS ork_unit_design (
+    unit_id           int(11)            NOT NULL PRIMARY KEY,
+    about_text        text               NULL,
+    our_history       text               NULL,
+    color_primary     varchar(7)         NULL,
+    color_accent      varchar(7)         NULL,
+    color_secondary   varchar(7)         NULL,
+    hero_overlay      varchar(10)        NOT NULL DEFAULT 'med',
+    name_font         varchar(100)       NULL,
+    milestone_config  text               NULL,
+    CONSTRAINT fk_unit_design_unit
+        FOREIGN KEY (unit_id) REFERENCES ork_unit (unit_id)
+        ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- Backfill: every existing unit gets a default-valued row so reads can
+-- assume the row exists (no PHP-side fallback maze).
+INSERT IGNORE INTO ork_unit_design (unit_id)
+SELECT unit_id FROM ork_unit;
+
+-- Preserve legacy About content: copy ork_unit.description into about_text
+-- so the new editable About field starts populated.
+UPDATE ork_unit_design d
+JOIN ork_unit u ON d.unit_id = u.unit_id
+SET d.about_text = u.description
+WHERE (d.about_text IS NULL OR d.about_text = '')
+  AND u.description IS NOT NULL
+  AND u.description <> ''
+  AND TRIM(u.description) <> '';
+
+-- Unit-specific: ork_unit has a native history column — backfill our_history
+-- from it so the legacy History section migrates into the new design field.
+UPDATE ork_unit_design d
+JOIN ork_unit u ON d.unit_id = u.unit_id
+SET d.our_history = u.history
+WHERE (d.our_history IS NULL OR d.our_history = '')
+  AND u.history IS NOT NULL
+  AND u.history <> ''
+  AND TRIM(u.history) <> '';

--- a/db-migrations/2026-05-17-ork-unit-milestones.sql
+++ b/db-migrations/2026-05-17-ork-unit-milestones.sql
@@ -1,0 +1,33 @@
+-- Custom unit milestones, mirroring ork_park_milestones.
+-- Rows are officer-authored and shown on the unit profile timeline.
+-- Derived milestones (first member activity) are computed at read time and not stored.
+--
+-- NOTE: This migration depends on the ork_unit engine conversion performed
+-- in 2026-05-17-ork-unit-design.sql. Run that migration first. As a
+-- defensive guard, we re-issue the same idempotent InnoDB convert here
+-- so the FK below succeeds even if the design migration was skipped.
+
+SET @engine := (
+    SELECT ENGINE FROM information_schema.TABLES
+    WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'ork_unit'
+);
+SET @sql := IF( @engine IS NOT NULL AND @engine <> 'InnoDB',
+                'ALTER TABLE ork_unit ENGINE=InnoDB',
+                'DO 0' );
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+CREATE TABLE IF NOT EXISTS ork_unit_milestones (
+    milestone_id     int(11)        NOT NULL PRIMARY KEY AUTO_INCREMENT,
+    unit_id          int(11)        NOT NULL,
+    icon             varchar(50)    NOT NULL DEFAULT 'fa-star',
+    description      varchar(500)   NOT NULL DEFAULT '',
+    milestone_date   date           NOT NULL,
+    created_at       timestamp      NOT NULL DEFAULT current_timestamp(),
+    updated_at       timestamp      NOT NULL DEFAULT current_timestamp() ON UPDATE current_timestamp(),
+    KEY idx_unit_milestone_unit_date (unit_id, milestone_date),
+    CONSTRAINT fk_unit_milestone_unit
+        FOREIGN KEY (unit_id) REFERENCES ork_unit (unit_id)
+        ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/orkui/controller/controller.Kingdom.php
+++ b/orkui/controller/controller.Kingdom.php
@@ -639,6 +639,26 @@ class Controller_Kingdom extends Controller {
 		$this->data['PronounList']          = $this->Pronoun->fetch_pronoun_list();
 		$this->data['PronounOptionsCreate'] = $this->Pronoun->fetch_pronoun_option_list(null);
 		$this->data['IcsUrl'] = UIR . 'Kingdom/ics/' . $kingdom_id;
+
+		// Custom + derived milestones, merged into one timeline-ready array.
+		$_custom  = $this->Kingdom->get_kingdom_milestones((int)$kingdom_id);
+		$_derived = $this->Kingdom->get_derived_kingdom_milestones((int)$kingdom_id);
+		$milestones = [];
+		foreach (($_custom['Milestones'] ?? []) as $m) {
+			$milestones[] = [
+				'MilestoneId'   => (int)$m['MilestoneId'],
+				'Type'          => 'custom',
+				'Icon'          => $m['Icon'],
+				'Description'   => $m['Description'],
+				'MilestoneDate' => $m['MilestoneDate'],
+				'IsDerived'     => false,
+			];
+		}
+		foreach (($_derived['Milestones'] ?? []) as $m) {
+			$milestones[] = $m + ['MilestoneId' => 0, 'IsDerived' => true];
+		}
+		usort($milestones, function($a, $b) { return strcmp($a['MilestoneDate'], $b['MilestoneDate']); });
+		$this->data['Milestones'] = $milestones;
 	}
 
 	// ------------------------------------------------------------------ ICS helpers

--- a/orkui/controller/controller.KingdomAjax.php
+++ b/orkui/controller/controller.KingdomAjax.php
@@ -634,6 +634,56 @@ class Controller_KingdomAjax extends Controller {
 				? json_encode(['status' => 0, 'taken' => true,  'name' => $rs->name])
 				: json_encode(['status' => 0, 'taken' => false]);
 
+		} elseif ($action === 'savedesign') {
+			$this->load_model('Kingdom');
+			$payload = ['Token' => $this->session->token, 'KingdomId' => $kingdom_id];
+			foreach (['AboutText','OurHistory','ColorPrimary','ColorAccent','ColorSecondary','HeroOverlay','NameFont','MilestoneConfig','Tagline','SocialLinks','Announcement','AnnouncementUntil','MonarchReignStarted','RegentReignStarted','ReignLore'] as $f) {
+				if (array_key_exists($f, $_POST)) $payload[$f] = (string)$_POST[$f];
+			}
+			$r = $this->Kingdom->set_kingdom_design($payload);
+			require_once(DIR_LIB . 'ork3/class.ProfanityFilter.php');
+			$_isProf = ($r['Status'] != 0 && ($r['Error'] ?? '') === ProfanityFilter::ERROR_MESSAGE);
+			echo ($r['Status'] == 0)
+				? json_encode(['status' => 0])
+				: ($_isProf
+					? json_encode(['status' => $r['Status'], 'error' => $r['Error'], 'field' => $r['Detail'] ?? ''])
+					: json_encode(['status' => $r['Status'], 'error' => rtrim(($r['Error'] ?? 'Error') . ': ' . ($r['Detail'] ?? ''), ': '), 'field' => $r['Detail'] ?? '']));
+
+		} elseif ($action === 'addmilestone') {
+			$this->load_model('Kingdom');
+			$description = trim($_POST['Description']   ?? '');
+			$icon        = trim($_POST['Icon']          ?? 'fa-star');
+			$msDate      = trim($_POST['MilestoneDate'] ?? '');
+			if (!strlen($description)) { echo json_encode(['status' => 1, 'error' => 'Description is required.', 'field' => '']); exit; }
+			if (!strlen($msDate) || !strtotime($msDate)) { echo json_encode(['status' => 1, 'error' => 'A valid date is required.', 'field' => '']); exit; }
+			$r = $this->Kingdom->add_kingdom_milestone([
+				'Token'         => $this->session->token,
+				'KingdomId'     => $kingdom_id,
+				'Icon'          => $icon,
+				'Description'   => $description,
+				'MilestoneDate' => $msDate,
+			]);
+			require_once(DIR_LIB . 'ork3/class.ProfanityFilter.php');
+			$_isProf = ($r['Status'] != 0 && ($r['Error'] ?? '') === ProfanityFilter::ERROR_MESSAGE);
+			echo ($r['Status'] == 0)
+				? json_encode(['status' => 0, 'milestoneId' => (int)($r['Detail'] ?? 0)])
+				: ($_isProf
+					? json_encode(['status' => $r['Status'], 'error' => $r['Error'], 'field' => $r['Detail'] ?? ''])
+					: json_encode(['status' => $r['Status'], 'error' => rtrim(($r['Error'] ?? 'Error') . ': ' . ($r['Detail'] ?? ''), ': '), 'field' => $r['Detail'] ?? '']));
+
+		} elseif ($action === 'deletemilestone') {
+			$this->load_model('Kingdom');
+			$milestone_id = (int)($_POST['MilestoneId'] ?? 0);
+			if (!valid_id($milestone_id)) { echo json_encode(['status' => 1, 'error' => 'Invalid milestone ID.', 'field' => '']); exit; }
+			$r = $this->Kingdom->delete_kingdom_milestone([
+				'Token'       => $this->session->token,
+				'KingdomId'   => $kingdom_id,
+				'MilestoneId' => $milestone_id,
+			]);
+			echo ($r['Status'] == 0)
+				? json_encode(['status' => 0])
+				: json_encode(['status' => $r['Status'], 'error' => rtrim(($r['Error'] ?? 'Error') . ': ' . ($r['Detail'] ?? ''), ': '), 'field' => '']);
+
 		} else {
 			echo json_encode(['status' => 1, 'error' => 'Unknown action']);
 		}

--- a/orkui/controller/controller.Park.php
+++ b/orkui/controller/controller.Park.php
@@ -281,6 +281,26 @@ class Controller_Park extends Controller
 		$this->data['CanMergePlayers'] = $uid > 0
 			&& Ork3::$Lib->authorization->HasAuthority($uid, AUTH_PARK, (int)$park_id, AUTH_CREATE);
 
+		// Custom + derived milestones, merged into one timeline-ready array.
+		$_custom  = $this->Park->get_park_milestones((int)$park_id);
+		$_derived = $this->Park->get_derived_park_milestones((int)$park_id);
+		$milestones = [];
+		foreach (($_custom['Milestones'] ?? []) as $m) {
+			$milestones[] = [
+				'MilestoneId'   => (int)$m['MilestoneId'],
+				'Type'          => 'custom',
+				'Icon'          => $m['Icon'],
+				'Description'   => $m['Description'],
+				'MilestoneDate' => $m['MilestoneDate'],
+				'IsDerived'     => false,
+			];
+		}
+		foreach (($_derived['Milestones'] ?? []) as $m) {
+			$milestones[] = $m + ['MilestoneId' => 0, 'IsDerived' => true];
+		}
+		usort($milestones, function($a, $b) { return strcmp($a['MilestoneDate'], $b['MilestoneDate']); });
+		$this->data['Milestones'] = $milestones;
+
 		$knConfigs  = Common::get_configs($this->session->kingdom_id, CFG_KINGDOM);
 		$recsPublic = isset($knConfigs['AwardRecsPublic'])
 			? (bool)(int)$knConfigs['AwardRecsPublic']['Value']

--- a/orkui/controller/controller.ParkAjax.php
+++ b/orkui/controller/controller.ParkAjax.php
@@ -439,6 +439,53 @@ class Controller_ParkAjax extends Controller {
 				? json_encode(['status' => 0, 'tournamentId' => (int)($r['Detail'] ?? 0)])
 				: json_encode(['status' => $r['Status'], 'error' => ($r['Error'] ?? 'Error') . ': ' . ($r['Detail'] ?? '')]);
 
+		} elseif ($action === 'savedesign') {
+			$payload = ['Token' => $this->session->token, 'ParkId' => $park_id];
+			foreach (['AboutText','OurHistory','ColorPrimary','ColorAccent','ColorSecondary','HeroOverlay','NameFont','MilestoneConfig','Tagline','SocialLinks','Announcement','AnnouncementUntil'] as $f) {
+				if (array_key_exists($f, $_POST)) $payload[$f] = (string)$_POST[$f];
+			}
+			$r = $this->Park->set_park_design($payload);
+			require_once(DIR_LIB . 'ork3/class.ProfanityFilter.php');
+			$_isProf = ($r['Status'] != 0 && ($r['Error'] ?? '') === ProfanityFilter::ERROR_MESSAGE);
+			echo ($r['Status'] == 0)
+				? json_encode(['status' => 0])
+				: ($_isProf
+					? json_encode(['status' => $r['Status'], 'error' => $r['Error'], 'field' => $r['Detail'] ?? ''])
+					: json_encode(['status' => $r['Status'], 'error' => rtrim(($r['Error'] ?? 'Error') . ': ' . ($r['Detail'] ?? ''), ': '), 'field' => $r['Detail'] ?? '']));
+
+		} elseif ($action === 'addmilestone') {
+			$description = trim($_POST['Description']   ?? '');
+			$icon        = trim($_POST['Icon']          ?? 'fa-star');
+			$msDate      = trim($_POST['MilestoneDate'] ?? '');
+			if (!strlen($description)) { echo json_encode(['status' => 1, 'error' => 'Description is required.']); exit; }
+			if (!strlen($msDate) || !strtotime($msDate)) { echo json_encode(['status' => 1, 'error' => 'A valid date is required.']); exit; }
+			$r = $this->Park->add_park_milestone([
+				'Token'         => $this->session->token,
+				'ParkId'        => $park_id,
+				'Icon'          => $icon,
+				'Description'   => $description,
+				'MilestoneDate' => $msDate,
+			]);
+			require_once(DIR_LIB . 'ork3/class.ProfanityFilter.php');
+			$_isProf = ($r['Status'] != 0 && ($r['Error'] ?? '') === ProfanityFilter::ERROR_MESSAGE);
+			echo ($r['Status'] == 0)
+				? json_encode(['status' => 0, 'milestoneId' => (int)($r['Detail'] ?? 0)])
+				: ($_isProf
+					? json_encode(['status' => $r['Status'], 'error' => $r['Error'], 'field' => $r['Detail'] ?? ''])
+					: json_encode(['status' => $r['Status'], 'error' => rtrim(($r['Error'] ?? 'Error') . ': ' . ($r['Detail'] ?? ''), ': '), 'field' => $r['Detail'] ?? '']));
+
+		} elseif ($action === 'deletemilestone') {
+			$milestone_id = (int)($_POST['MilestoneId'] ?? 0);
+			if (!valid_id($milestone_id)) { echo json_encode(['status' => 1, 'error' => 'Invalid milestone ID.']); exit; }
+			$r = $this->Park->delete_park_milestone([
+				'Token'       => $this->session->token,
+				'ParkId'      => $park_id,
+				'MilestoneId' => $milestone_id,
+			]);
+			echo ($r['Status'] == 0)
+				? json_encode(['status' => 0])
+				: json_encode(['status' => $r['Status'], 'error' => rtrim(($r['Error'] ?? 'Error') . ': ' . ($r['Detail'] ?? ''), ': '), 'field' => '']);
+
 		} else {
 			echo json_encode(['status' => 1, 'error' => 'Unknown action']);
 		}

--- a/orkui/controller/controller.Unit.php
+++ b/orkui/controller/controller.Unit.php
@@ -174,6 +174,62 @@ class Controller_Unit extends Controller {
 						$r = $this->Unit->convert_to_company($unit_id_int);
 					}
 					break;
+				case 'save_design':
+					header('Content-Type: application/json');
+					$req = array(
+						'Token'           => $this->session->token,
+						'UnitId'          => $unit_id_int,
+					);
+					foreach (['AboutText','OurHistory','ColorPrimary','ColorAccent','ColorSecondary','HeroOverlay','NameFont','MilestoneConfig','Tagline','SocialLinks','Announcement','AnnouncementUntil','RecruitmentStatus','HowToJoin'] as $_f) {
+						if (isset($_POST[$_f])) $req[$_f] = (string)$_POST[$_f];
+					}
+					$r2 = $this->Unit->set_unit_design($req);
+					if ($r2['Status'] == 0) {
+						echo json_encode(array('status' => 0));
+					} else {
+						echo json_encode(array(
+							'status' => (int)$r2['Status'],
+							'error'  => $r2['Error']  ?? 'Save failed.',
+							'field'  => $r2['Detail'] ?? '',
+						));
+					}
+					exit;
+				case 'add_milestone':
+					header('Content-Type: application/json');
+					$r2 = $this->Unit->add_unit_milestone(array(
+						'Token'         => $this->session->token,
+						'UnitId'        => $unit_id_int,
+						'Description'   => (string)($this->request->Description ?? ''),
+						'MilestoneDate' => (string)($this->request->MilestoneDate ?? ''),
+						'Icon'          => (string)($this->request->Icon ?? 'fa-star'),
+					));
+					if ($r2['Status'] == 0) {
+						echo json_encode(array('status' => 0, 'milestoneId' => (int)($r2['Detail'] ?? 0)));
+					} else {
+						echo json_encode(array(
+							'status' => (int)$r2['Status'],
+							'error'  => $r2['Error']  ?? 'Failed to add milestone.',
+							'field'  => $r2['Detail'] ?? '',
+						));
+					}
+					exit;
+				case 'delete_milestone':
+					header('Content-Type: application/json');
+					$r2 = $this->Unit->delete_unit_milestone(array(
+						'Token'       => $this->session->token,
+						'UnitId'      => $unit_id_int,
+						'MilestoneId' => (int)($this->request->MilestoneId ?? 0),
+					));
+					if ($r2['Status'] == 0) {
+						echo json_encode(array('status' => 0));
+					} else {
+						echo json_encode(array(
+							'status' => (int)$r2['Status'],
+							'error'  => $r2['Error']  ?? 'Failed to delete milestone.',
+							'field'  => $r2['Detail'] ?? '',
+						));
+					}
+					exit;
 			}
 			if (isset($r)) {
 				if ($r['Status'] == 0) {
@@ -187,6 +243,24 @@ class Controller_Unit extends Controller {
 
 		$this->data['Unit_heraldryurl'] = $this->Unit->get_heraldry($unit_id);
 		$this->data['Unit'] = $this->Unit->get_unit_details($unit_id);
+		$_custom  = $this->Unit->get_unit_milestones($unit_id_int);
+		$_derived = $this->Unit->get_derived_unit_milestones($unit_id_int);
+		$milestones = [];
+		foreach (($_custom['Milestones'] ?? []) as $m) {
+			$milestones[] = [
+				'MilestoneId'   => (int)$m['MilestoneId'],
+				'Type'          => 'custom',
+				'Icon'          => $m['Icon'],
+				'Description'   => $m['Description'],
+				'MilestoneDate' => $m['MilestoneDate'],
+				'IsDerived'     => false,
+			];
+		}
+		foreach (($_derived['Milestones'] ?? []) as $m) {
+			$milestones[] = $m + ['MilestoneId' => 0, 'IsDerived' => true];
+		}
+		usort($milestones, function($a, $b) { return strcmp($a['MilestoneDate'], $b['MilestoneDate']); });
+		$this->data['Milestones'] = $milestones;
 		// Parse scope (kingdom/park) from the unit list session ref for player search scoping
 		$_ref = $this->session->unit_list_ref ?? '';
 		$_scope_kingdom_id = null;

--- a/orkui/model/model.Kingdom.php
+++ b/orkui/model/model.Kingdom.php
@@ -127,6 +127,26 @@ class Model_Kingdom extends Model {
 		return $this->Heraldry->RemoveKingdomHeraldry($request);
 	}
 
+	function set_kingdom_design($request) {
+		return $this->Kingdom->SetKingdomDesign($request);
+	}
+
+	function get_kingdom_milestones($kingdom_id) {
+		return $this->Kingdom->GetKingdomMilestones(array('KingdomId' => $kingdom_id));
+	}
+
+	function get_derived_kingdom_milestones($kingdom_id) {
+		return $this->Kingdom->GetDerivedKingdomMilestones(array('KingdomId' => $kingdom_id));
+	}
+
+	function add_kingdom_milestone($request) {
+		return $this->Kingdom->AddKingdomMilestone($request);
+	}
+
+	function delete_kingdom_milestone($request) {
+		return $this->Kingdom->DeleteKingdomMilestone($request);
+	}
+
 }
 
 ?>

--- a/orkui/model/model.Park.php
+++ b/orkui/model/model.Park.php
@@ -89,7 +89,27 @@ class Model_Park extends Model {
 	function get_park_parkdays($park_id) {
 		return $this->Park->GetParkDays(array('ParkId'=>$park_id));
 	}
-	
+
+	function set_park_design($request) {
+		return $this->Park->SetParkDesign($request);
+	}
+
+	function get_park_milestones($park_id) {
+		return $this->Park->GetParkMilestones(array('ParkId' => $park_id));
+	}
+
+	function get_derived_park_milestones($park_id) {
+		return $this->Park->GetDerivedParkMilestones(array('ParkId' => $park_id));
+	}
+
+	function add_park_milestone($request) {
+		return $this->Park->AddParkMilestone($request);
+	}
+
+	function delete_park_milestone($request) {
+		return $this->Park->DeleteParkMilestone($request);
+	}
+
 }
 
 

--- a/orkui/model/model.Unit.php
+++ b/orkui/model/model.Unit.php
@@ -90,7 +90,27 @@ class Model_Unit extends Model {
 				'Authorizations' => $this->Report->GetAuthorizations(array ( 'Type' => AUTH_UNIT, 'Id' => $unit_id, 'Token' => $this->session->token ))
 			);
 	}
-	
+
+	function set_unit_design($request) {
+		return $this->Unit->SetUnitDesign($request);
+	}
+
+	function get_unit_milestones($unit_id) {
+		return $this->Unit->GetUnitMilestones(array('UnitId' => $unit_id));
+	}
+
+	function get_derived_unit_milestones($unit_id) {
+		return $this->Unit->GetDerivedUnitMilestones(array('UnitId' => $unit_id));
+	}
+
+	function add_unit_milestone($request) {
+		return $this->Unit->AddUnitMilestone($request);
+	}
+
+	function delete_unit_milestone($request) {
+		return $this->Unit->DeleteUnitMilestone($request);
+	}
+
 }
 
 ?>

--- a/orkui/template/default/Unit_index.tpl
+++ b/orkui/template/default/Unit_index.tpl
@@ -30,10 +30,93 @@ $_base_url   = UIR . "Unit/index/$_unit_id";
 
 $_type_icon  = $_type === 'Company' ? 'fa-shield-alt' : ($_type === 'Household' ? 'fa-home' : 'fa-users');
 $_hero_color = $_type === 'Company' ? '#1a3654' : ($_type === 'Household' ? '#2d1b54' : '#1a365d');
+
+/* ── Unit design (header, About, Our History, Milestones) ──────────────── */
+$_about_text   = (string)($_unit['AboutText']  ?? '');
+$_our_history  = (string)($_unit['OurHistory'] ?? '');
+if (trim($_about_text)  === '') { $_about_text  = (string)$_desc; }
+if (trim($_our_history) === '') { $_our_history = (string)$_history; }
+
+$_un_color_primary   = trim((string)($_unit['ColorPrimary']   ?? ''));
+$_un_color_accent    = trim((string)($_unit['ColorAccent']    ?? ''));
+$_un_color_secondary = trim((string)($_unit['ColorSecondary'] ?? ''));
+$_un_overlay         = strtolower(trim((string)($_unit['HeroOverlay'] ?? 'med')));
+if (!in_array($_un_overlay, ['low','med','high','vignette'], true)) $_un_overlay = 'med';
+$_un_name_font       = trim((string)($_unit['NameFont'] ?? ''));
+$_un_milestone_cfg   = [];
+if (!empty($_unit['MilestoneConfig'])) {
+	$_mc = json_decode((string)$_unit['MilestoneConfig'], true);
+	if (is_array($_mc)) $_un_milestone_cfg = $_mc;
+}
+$_un_ms_visible = function($type) use ($_un_milestone_cfg) {
+	if (!array_key_exists($type, $_un_milestone_cfg)) return true;
+	return !empty($_un_milestone_cfg[$type]);
+};
+$_un_ms_newest_first = !empty($_un_milestone_cfg['newest_first']);
+
+$_un_all_ms = is_array($Milestones ?? null) ? $Milestones : [];
+$_un_visible_ms = [];
+foreach ($_un_all_ms as $_msr) {
+	$_t = $_msr['Type'] ?? 'custom';
+	if ($_un_ms_visible($_t)) $_un_visible_ms[] = $_msr;
+}
+if ($_un_ms_newest_first) $_un_visible_ms = array_reverse($_un_visible_ms);
+$_un_has_ms = count($_un_visible_ms) > 0;
+
+$_un_overlay_opacity = ['low' => 0.06, 'med' => 0.13, 'high' => 0.28, 'vignette' => 0.45][$_un_overlay] ?? 0.13;
+$_un_hero_font_css = $_un_name_font !== '' ? ("'" . str_replace("'", '', $_un_name_font) . "'") : '';
+
+/* ── Phase 2 customizations: tagline, social links, announcement, recruitment, how-to-join ── */
+$_unTagline            = trim((string)($_unit['Tagline'] ?? ''));
+$_unAnnouncement       = trim((string)($_unit['Announcement'] ?? ''));
+$_unAnnouncementUntil  = trim((string)($_unit['AnnouncementUntil'] ?? ''));
+$_unShowAnnouncement   = ($_unAnnouncement !== '');
+if ($_unShowAnnouncement && $_unAnnouncementUntil !== '' && $_unAnnouncementUntil !== '0000-00-00') {
+	$_unShowAnnouncement = (strtotime($_unAnnouncementUntil) >= strtotime(date('Y-m-d')));
+}
+$_unSocialRaw   = (string)($_unit['SocialLinks'] ?? '');
+$_unSocialLinks = [];
+if ($_unSocialRaw !== '') {
+	$_sl = json_decode($_unSocialRaw, true);
+	if (is_array($_sl)) {
+		foreach ($_sl as $_k => $_v) {
+			$_v = trim((string)$_v);
+			if ($_v !== '' && preg_match('#^https?://#i', $_v)) {
+				$_unSocialLinks[(string)$_k] = $_v;
+			}
+		}
+	}
+}
+$_unSocialPlatforms = [
+	'discord'   => ['label'=>'Discord',   'icon'=>'fab fa-discord',         'bg'=>'#5865f2', 'placeholder'=>'https://discord.gg/...'],
+	'facebook'  => ['label'=>'Facebook',  'icon'=>'fab fa-facebook',        'bg'=>'#1877f2', 'placeholder'=>'https://facebook.com/...'],
+	'instagram' => ['label'=>'Instagram', 'icon'=>'fab fa-instagram',       'bg'=>'#e4405f', 'placeholder'=>'https://instagram.com/...'],
+	'threads'   => ['label'=>'Threads',   'icon'=>'fab fa-square-threads',  'bg'=>'#000000', 'placeholder'=>'https://threads.net/@...'],
+	'bluesky'   => ['label'=>'Bluesky',   'icon'=>'fas fa-cloud',           'bg'=>'#1185fe', 'placeholder'=>'https://bsky.app/profile/...'],
+	'twitter'   => ['label'=>'Twitter',   'icon'=>'fab fa-twitter',         'bg'=>'#1da1f2', 'placeholder'=>'https://twitter.com/...'],
+	'youtube'   => ['label'=>'YouTube',   'icon'=>'fab fa-youtube',         'bg'=>'#ff0000', 'placeholder'=>'https://youtube.com/@...'],
+	'amtwiki'   => ['label'=>'Amtwiki',   'icon'=>'fas fa-book',            'bg'=>'#4a5568', 'placeholder'=>'https://amtwiki.net/...'],
+];
+$_unHasSocial = false;
+foreach ($_unSocialPlatforms as $_slug => $_meta) {
+	if (!empty($_unSocialLinks[$_slug])) { $_unHasSocial = true; break; }
+}
+$_unRecruitmentStatus = strtolower(trim((string)($_unit['RecruitmentStatus'] ?? '')));
+if (!in_array($_unRecruitmentStatus, ['open','invite','closed'], true)) $_unRecruitmentStatus = '';
+$_unRecruitMeta = [
+	'open'   => ['label'=>'Recruiting',  'icon'=>'fa-door-open', 'bg'=>'#48bb78', 'bgDark'=>'#22543d'],
+	'invite' => ['label'=>'Invite Only', 'icon'=>'fa-envelope',  'bg'=>'#ed8936', 'bgDark'=>'#7b341e'],
+	'closed' => ['label'=>'Closed',      'icon'=>'fa-lock',      'bg'=>'#718096', 'bgDark'=>'#2d3748'],
+];
+$_unHowToJoin = (string)($_unit['HowToJoin'] ?? '');
 ?>
 <link rel="stylesheet" href="<?=HTTP_TEMPLATE?>revised-frontend/style/revised.css?v=<?=filemtime(DIR_TEMPLATE.'revised-frontend/style/revised.css')?>">
 <link rel="stylesheet" href="https://cdn.datatables.net/1.13.8/css/jquery.dataTables.min.css">
 <link rel="stylesheet" href="https://cdn.datatables.net/buttons/2.4.2/css/buttons.dataTables.min.css">
+
+<?php if ($_un_name_font !== ''): ?>
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=<?= rawurlencode($_un_name_font) ?>&display=swap">
+<?php endif; ?>
 
 <style>
 /* ── Unit Hero ───────────────────────────────────────────── */
@@ -315,12 +398,377 @@ html:not([data-theme="light"]):not([data-theme="dark"]) .un-hero-name {
 	#un-roster-table th:nth-child(5),
 	#un-roster-table td:nth-child(5) { display: none; }
 }
+
+/* ── Unit design: hero customization ─────────────────────── */
+<?php if ($_un_color_primary): ?>
+.un-hero {
+	background-color: <?= htmlspecialchars($_un_color_primary) ?> !important;
+<?php if ($_un_color_secondary && $_un_color_secondary !== $_un_color_primary): ?>
+	background: linear-gradient(135deg, <?= htmlspecialchars($_un_color_primary) ?>, <?= htmlspecialchars($_un_color_secondary) ?>) !important;
+<?php endif; ?>
+}
+html[data-theme="dark"] .un-hero {
+	background-color: <?= htmlspecialchars($_un_color_primary) ?> !important;
+<?php if ($_un_color_secondary && $_un_color_secondary !== $_un_color_primary): ?>
+	background: linear-gradient(135deg, <?= htmlspecialchars($_un_color_primary) ?>, <?= htmlspecialchars($_un_color_secondary) ?>) !important;
+<?php endif; ?>
+	filter: brightness(0.85);
+}
+<?php endif; ?>
+<?php if ($_un_color_accent): ?>
+:root { --un-accent: <?= htmlspecialchars($_un_color_accent) ?>; }
+.un-type-badge { border-color: <?= htmlspecialchars($_un_color_accent) ?>; color: <?= htmlspecialchars($_un_color_accent) ?>; background: rgba(255,255,255,0.95); }
+.un-about-edit-btn:hover, .un-card-edit-btn:hover { color: <?= htmlspecialchars($_un_color_accent) ?>; }
+<?php endif; ?>
+.un-hero-bg { opacity: <?= $_un_overlay_opacity ?> !important; }
+<?php if ($_un_overlay === 'vignette'): ?>
+.un-hero-bg {
+	-webkit-mask-image: radial-gradient(ellipse at center, rgba(0,0,0,0.95) 38%, rgba(0,0,0,0) 78%);
+	        mask-image: radial-gradient(ellipse at center, rgba(0,0,0,0.95) 38%, rgba(0,0,0,0) 78%);
+}
+<?php endif; ?>
+<?php if ($_un_name_font !== '' && $_un_hero_font_css !== ''): ?>
+.un-hero-name { font-family: <?= $_un_hero_font_css ?>, 'Cinzel', serif !important; letter-spacing: 0.02em; }
+<?php endif; ?>
+
+/* ── Unit design: About markdown + Our History + Milestones ── */
+.un-about-text { line-height: 1.6; font-size: 13px; color: var(--ork-text-secondary); }
+.un-about-text h1, .un-about-text h2, .un-about-text h3, .un-about-text h4 {
+	margin-top: 1.1em; margin-bottom: 0.4em;
+	background: transparent; border: none; padding: 0; border-radius: 0; text-shadow: none;
+}
+.un-about-section-head {
+	display: flex; align-items: center; justify-content: space-between;
+	gap: 8px; margin-bottom: 6px;
+}
+.un-about-edit-btn {
+	background: transparent; border: 1px solid transparent; color: #a0aec0;
+	padding: 4px 8px; border-radius: 6px; cursor: pointer; font-size: 12px;
+	display: inline-flex; align-items: center; gap: 4px;
+	transition: background 0.15s, color 0.15s, border-color 0.15s;
+}
+.un-about-edit-btn:hover { background: rgba(49,130,206,0.08); color: #2b6cb0; border-color: rgba(49,130,206,0.25); }
+html[data-theme="dark"] .un-about-edit-btn { color: var(--ork-text-muted); }
+html[data-theme="dark"] .un-about-edit-btn:hover { background: var(--ork-bg-tertiary); color: var(--ork-link); border-color: var(--ork-border); }
+.un-about-edit-btn[data-tip] { position: relative; }
+.un-about-edit-btn[data-tip]::after {
+	content: attr(data-tip); position: absolute; bottom: calc(100% + 6px); right: 0;
+	background: #2d3748; color: #fff; font-size: 11px; font-style: italic; white-space: nowrap;
+	padding: 4px 10px; border-radius: 4px; pointer-events: none; opacity: 0;
+	transition: opacity 0s; z-index: 500;
+}
+.un-about-edit-btn[data-tip]:hover::after { opacity: 1; transition-delay: 0.4s; }
+html[data-theme="dark"] .un-about-edit-btn[data-tip]::after { background: var(--ork-bg-tertiary); color: var(--ork-text); border: 1px solid var(--ork-border); }
+
+.un-fullwidth-section {
+	background: #fff; border: 1px solid #e2e8f0; border-radius: 8px;
+	padding: 18px 22px; margin-bottom: 20px;
+}
+html[data-theme="dark"] .un-fullwidth-section { background: var(--ork-card-bg); border-color: var(--ork-border); }
+.un-fullwidth-head {
+	display: flex; align-items: center; justify-content: space-between;
+	margin-bottom: 10px;
+}
+.un-fullwidth-title {
+	font-size: 13px; font-weight: 700; color: #4a5568;
+	text-transform: uppercase; letter-spacing: 0.5px;
+	margin: 0;
+	background: transparent; border: none; padding: 0; border-radius: 0; text-shadow: none;
+	display: flex; align-items: center; gap: 8px;
+}
+html[data-theme="dark"] .un-fullwidth-title { color: var(--ork-text-secondary); }
+
+/* Milestones timeline */
+.un-timeline { position: relative; padding-left: 32px; margin-top: 6px; }
+.un-timeline::before {
+	content: ''; position: absolute; left: 11px; top: 4px; bottom: 4px; width: 2px;
+	background: linear-gradient(to bottom, #cbd5e0, #cbd5e0 60%, transparent);
+}
+html[data-theme="dark"] .un-timeline::before { background: linear-gradient(to bottom, var(--ork-border), var(--ork-border) 60%, transparent); }
+.un-timeline-row {
+	position: relative; display: flex; align-items: center; gap: 12px;
+	margin-bottom: 14px; min-height: 24px;
+}
+.un-timeline-dot {
+	position: absolute; left: -25px; top: 50%; transform: translateY(-50%);
+	width: 24px; height: 24px; border-radius: 50%;
+	background: #ebf8ff; color: #2b6cb0; display: flex; align-items: center; justify-content: center;
+	font-size: 11px; border: 2px solid #fff; box-shadow: 0 0 0 1px #cbd5e0;
+}
+.un-timeline-row.un-ms-derived .un-timeline-dot { background: #faf5ff; color: #6b46c1; box-shadow: 0 0 0 1px #d6bcfa; }
+html[data-theme="dark"] .un-timeline-dot { background: var(--ork-bg-tertiary); color: var(--ork-link); border-color: var(--ork-card-bg); box-shadow: 0 0 0 1px var(--ork-border); }
+.un-timeline-content {
+	flex: 1; display: flex; align-items: baseline; gap: 10px; flex-wrap: wrap;
+	font-size: 13px;
+}
+.un-timeline-date { color: #718096; font-size: 11px; font-weight: 600; min-width: 80px; }
+html[data-theme="dark"] .un-timeline-date { color: var(--ork-text-muted); }
+.un-timeline-desc { color: #2d3748; }
+html[data-theme="dark"] .un-timeline-desc { color: var(--ork-text); }
+.un-timeline-row.un-ms-derived .un-timeline-desc { color: #553c9a; }
+html[data-theme="dark"] .un-timeline-row.un-ms-derived .un-timeline-desc { color: hsl(265, 60%, 75%); }
+.un-timeline-empty {
+	font-size: 12px; color: #a0aec0; font-style: italic;
+	padding: 6px 0;
+}
+
+/* ── Tabs (About / Members) ──────────────────────────────── */
+.un-tabs {
+	background: var(--ork-card-bg);
+	border: 1px solid #cbd5e0;
+	border-radius: 8px;
+	box-shadow: 0 2px 8px rgba(0,0,0,0.10);
+	overflow: hidden;
+	min-height: 50vh;
+	margin-top: 4px;
+}
+html[data-theme="dark"] .un-tabs { border-color: var(--ork-border); }
+.un-tab-nav {
+	list-style: none;
+	margin: 0; padding: 0;
+	display: flex;
+	border-bottom: 2px solid var(--ork-border, #e2e8f0);
+	background: var(--ork-bg-secondary);
+	flex-wrap: nowrap;
+	overflow-x: auto;
+	overflow-y: hidden;
+}
+.un-tab-nav li {
+	padding: 12px 18px;
+	cursor: pointer;
+	font-size: 13px;
+	font-weight: 600;
+	color: #718096;
+	border-bottom: 2px solid transparent;
+	margin-bottom: -2px;
+	transition: color 0.15s, border-color 0.15s, background 0.15s;
+	white-space: nowrap;
+	display: flex;
+	align-items: center;
+	gap: 6px;
+	flex-shrink: 0;
+}
+.un-tab-nav li:hover { color: var(--un-accent, #2b6cb0); background: #edf2f7; }
+.un-tab-nav li.un-tab-active {
+	color: var(--un-accent, #2b6cb0);
+	border-bottom-color: var(--un-accent, #2b6cb0);
+	background: var(--ork-card-bg);
+}
+.un-tab-count { font-size: 11px; color: #a0aec0; font-weight: 500; }
+.un-tab-panel { padding: 18px 20px; }
+html[data-theme="dark"] .un-tab-nav { background: var(--ork-bg-secondary); border-color: var(--ork-border); }
+html[data-theme="dark"] .un-tab-nav li { color: var(--ork-text-secondary); }
+html[data-theme="dark"] .un-tab-nav li:hover:not(.un-tab-active) { background: var(--ork-bg-tertiary); color: var(--ork-text); }
+html[data-theme="dark"] .un-tab-nav li.un-tab-active { background: var(--ork-card-bg); color: var(--un-accent, var(--ork-link)); border-bottom-color: var(--un-accent, var(--ork-link)); }
+html[data-theme="dark"] .un-tab-count { color: var(--ork-text-muted); }
+
+/* About tab inner sections — section dividers */
+.un-about-section { margin-bottom: 6px; }
+.un-tab-panel .un-fullwidth-section {
+	background: transparent; border: none; box-shadow: none;
+	padding: 0; margin-bottom: 0;
+}
+.un-tab-panel .un-fullwidth-section + .un-fullwidth-section,
+.un-tab-panel .un-about-section + .un-fullwidth-section {
+	margin-top: 18px; padding-top: 18px; border-top: 1px dashed #e2e8f0;
+}
+html[data-theme="dark"] .un-tab-panel .un-fullwidth-section + .un-fullwidth-section,
+html[data-theme="dark"] .un-tab-panel .un-about-section + .un-fullwidth-section { border-top-color: var(--ork-border); }
+
+/* Managers section inside About tab — officer-style list */
+.un-managers-list { list-style: none; margin: 0; padding: 0; }
+.un-managers-list li {
+	font-size: 13px; padding: 6px 0; border-bottom: 1px solid #f0f0f0;
+	display: flex; align-items: center; justify-content: space-between; gap: 8px;
+}
+.un-managers-list li:last-child { border-bottom: none; }
+html[data-theme="dark"] .un-managers-list li { border-bottom-color: var(--ork-border); }
+.un-mgr-info { display: flex; flex-direction: column; gap: 1px; min-width: 0; }
+.un-mgr-role { font-size: 10px; color: #718096; text-transform: uppercase; letter-spacing: 0.04em; font-weight: 700; }
+html[data-theme="dark"] .un-mgr-role { color: var(--ork-text-muted); }
+.un-mgr-name a { color: var(--ork-link); text-decoration: none; font-weight: 500; }
+.un-mgr-name a:hover { text-decoration: underline; }
+.un-managers-empty { font-size: 12px; color: var(--ork-text-muted); font-style: italic; margin: 0; padding: 4px 0; }
+
+/* Members tab — section header sits flush at top */
+#un-tab-members .un-section-header { margin-bottom: 14px; }
+#un-tab-members .un-roster-card {
+	border: none; box-shadow: none; background: transparent;
+}
+
+/* Mobile: tab panel padding tightens */
+@media (max-width: 768px) {
+	.un-tab-panel { padding: 14px 14px; }
+	.un-tab-nav li { padding: 10px 14px; font-size: 12px; }
+}
+
+/* ── Phase 2: Tagline ─────────────────────────────────── */
+.un-tagline {
+	margin: 6px 0 0;
+	font-size: 14px;
+	font-style: italic;
+	color: rgba(255,255,255,0.92);
+	text-shadow: 0 1px 2px rgba(0,0,0,0.35);
+	line-height: 1.35;
+	max-width: 100%;
+}
+@media (max-width: 768px) {
+	.un-tagline { font-size: 13px; }
+}
+
+/* ── Phase 2: Announcement Banner ─────────────────────── */
+.un-announcement {
+	display: flex; align-items: flex-start; gap: 10px;
+	background: #fef3c7;
+	border: 1px solid #fcd34d;
+	border-left: 4px solid #d97706;
+	color: #92400e;
+	padding: 12px 16px;
+	border-radius: 8px;
+	margin-bottom: 12px;
+	font-size: 13.5px;
+	line-height: 1.45;
+}
+.un-announcement i { color: #d97706; flex-shrink: 0; font-size: 16px; margin-top: 2px; }
+.un-announcement .un-ann-text { flex: 1; word-break: break-word; white-space: pre-wrap; }
+html[data-theme="dark"] .un-announcement {
+	background: rgba(217,119,6,0.12);
+	border-color: rgba(217,119,6,0.45);
+	border-left-color: #f59e0b;
+	color: #fde68a;
+}
+html[data-theme="dark"] .un-announcement i { color: #f59e0b; }
+
+/* ── Phase 2: Recruitment Pill ────────────────────────── */
+.un-recruit-pill {
+	display: inline-flex; align-items: center; gap: 5px;
+	font-size: 11px; font-weight: 700; letter-spacing: 0.05em;
+	text-transform: uppercase; color: #fff;
+	border-radius: 4px; padding: 3px 8px;
+	margin-left: 6px;
+	border: 1px solid rgba(255,255,255,0.18);
+	box-shadow: 0 1px 2px rgba(0,0,0,0.18);
+}
+.un-recruit-pill i { font-size: 11px; }
+.un-recruit-open   { background: #48bb78; }
+.un-recruit-invite { background: #ed8936; }
+.un-recruit-closed { background: #718096; }
+html[data-theme="dark"] .un-recruit-open   { background: #22543d; border-color: rgba(255,255,255,0.12); }
+html[data-theme="dark"] .un-recruit-invite { background: #7b341e; border-color: rgba(255,255,255,0.12); }
+html[data-theme="dark"] .un-recruit-closed { background: #2d3748; border-color: rgba(255,255,255,0.12); }
+
+/* ── Phase 2: Connect — compact strip in About tab ───── */
+.un-connect-block {
+	display: flex; align-items: center; gap: 14px; flex-wrap: wrap;
+	margin-bottom: 18px; padding: 10px 14px;
+	background: #f7fafc; border: 1px solid #e2e8f0; border-radius: 8px;
+}
+html[data-theme="dark"] .un-connect-block { background: var(--ork-bg-secondary); border-color: var(--ork-border); }
+.un-connect-subhead {
+	display: flex; align-items: center; gap: 8px;
+	font-size: 11px; text-transform: uppercase; letter-spacing: 0.08em;
+	color: #718096; font-weight: 600;
+}
+html[data-theme="dark"] .un-connect-subhead { color: var(--ork-text-muted); }
+.un-connect-subhead i { opacity: 0.7; }
+.un-connect-edit {
+	background: transparent; border: 0; cursor: pointer; color: #a0aec0; font-size: 11px; padding: 2px 6px; border-radius: 4px;
+}
+.un-connect-edit:hover { background: rgba(49,130,206,0.08); color: #2b6cb0; }
+html[data-theme="dark"] .un-connect-edit:hover { background: var(--ork-bg-tertiary); color: var(--ork-link); }
+.un-connect-pills { display: flex; flex-wrap: wrap; gap: 8px; }
+.un-connect-pill {
+	width: 32px; height: 32px; border-radius: 50%;
+	display: inline-flex; align-items: center; justify-content: center;
+	color: #fff !important; text-decoration: none !important;
+	font-size: 13px; line-height: 1;
+	background: var(--un-accent, #4a5568);
+	transition: transform 0.12s, box-shadow 0.12s;
+	position: relative;
+}
+.un-connect-pill:hover { transform: scale(1.08); box-shadow: 0 3px 10px rgba(0,0,0,0.18); }
+.un-connect-pill[data-tip]::after {
+	content: attr(data-tip); position: absolute; bottom: calc(100% + 6px); left: 50%; transform: translateX(-50%);
+	background: #2d3748; color: #fff; font-size: 11px; white-space: nowrap;
+	padding: 3px 8px; border-radius: 4px; pointer-events: none; opacity: 0;
+	transition: opacity 0.12s; z-index: 600;
+}
+.un-connect-pill[data-tip]:hover::after { opacity: 1; transition-delay: 0.3s; }
+html[data-theme="dark"] .un-connect-pill[data-tip]::after {
+	background: var(--ork-bg-tertiary); color: var(--ork-text); border: 1px solid var(--ork-border);
+}
+.un-connect-empty {
+	display: inline-flex; font-size: 11px; color: #a0aec0; text-decoration: none;
+	padding: 4px 8px; border: 1px dashed #cbd5e0; border-radius: 999px;
+}
+.un-connect-empty:hover { color: #2b6cb0; border-color: #2b6cb0; }
+html[data-theme="dark"] .un-connect-empty { color: var(--ork-text-muted); border-color: var(--ork-border); }
+
+/* ── Phase 2: How to Join section ─────────────────────── */
+.un-howto-section .un-fullwidth-title i { color: #38a169; }
+html[data-theme="dark"] .un-howto-section .un-fullwidth-title i { color: #68d391; }
+
+/* ── Phase 2: Design modal — social inputs ────────────── */
+.un-dm-social-list { display: flex; flex-direction: column; gap: 8px; }
+.un-dm-social-row {
+	display: grid;
+	grid-template-columns: 120px 1fr;
+	gap: 10px;
+	align-items: center;
+}
+.un-dm-social-label {
+	display: inline-flex; align-items: center; gap: 8px;
+	font-size: 12px; font-weight: 600; color: #4a5568;
+}
+html[data-theme="dark"] .un-dm-social-label { color: var(--ork-text-secondary); }
+.un-dm-social-icon {
+	display: inline-flex; align-items: center; justify-content: center;
+	width: 22px; height: 22px; border-radius: 50%;
+	color: #fff; font-size: 11px;
+}
+@media (max-width: 600px) {
+	.un-dm-social-row { grid-template-columns: 1fr; gap: 4px; }
+}
+
+/* ── Phase 2: Design modal — recruitment radio row ────── */
+.un-dm-recruit-row { display: flex; flex-wrap: wrap; gap: 6px; }
+.un-dm-recruit-opt {
+	display: inline-flex; align-items: center; gap: 6px;
+	padding: 7px 12px;
+	border: 1px solid #e2e8f0;
+	border-radius: 6px;
+	background: #fff;
+	font-size: 12px; font-weight: 600;
+	color: #4a5568; cursor: pointer;
+	transition: background 0.12s, border-color 0.12s, color 0.12s;
+}
+.un-dm-recruit-opt:hover { border-color: #cbd5e0; }
+.un-dm-recruit-opt.un-active { background: #2b6cb0; color: #fff; border-color: #2b6cb0; }
+html[data-theme="dark"] .un-dm-recruit-opt { background: var(--ork-bg-tertiary); border-color: var(--ork-border); color: var(--ork-text-secondary); }
+html[data-theme="dark"] .un-dm-recruit-opt.un-active { background: var(--ork-link); color: var(--ork-bg-secondary); border-color: var(--ork-link); }
+
+/* ── Phase 2: Design modal — section divider ──────────── */
+.un-dm-section-title {
+	font-size: 11px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.06em;
+	color: #718096; margin: 18px 0 8px; padding-top: 14px;
+	border-top: 1px solid #edf2f7;
+}
+.un-dm-section-title:first-child { margin-top: 0; padding-top: 0; border-top: none; }
+html[data-theme="dark"] .un-dm-section-title { color: var(--ork-text-muted); border-top-color: var(--ork-border); }
+
 </style>
 
 <?php if ($_err): ?>
 <div class="un-error-banner">
 	<i class="fas fa-exclamation-circle"></i>
 	<?=htmlspecialchars($_err)?>
+</div>
+<?php endif; ?>
+
+<?php if ($_unShowAnnouncement): ?>
+<div class="un-announcement" role="status">
+	<i class="fas fa-bullhorn"></i>
+	<div class="un-ann-text"><?= htmlspecialchars($_unAnnouncement) ?></div>
 </div>
 <?php endif; ?>
 
@@ -337,7 +785,7 @@ html:not([data-theme="light"]):not([data-theme="dark"]) .un-hero-name {
 					alt="<?=htmlspecialchars($_name)?>">
 			</div>
 <?php if ($_can_edit): ?>
-			<button class="un-heraldry-edit-btn" onclick="unOpenHeraldryModal()" title="Update heraldry">
+			<button class="un-heraldry-edit-btn" onclick="unOpenHeraldryModal()" data-tip="Update heraldry">
 				<i class="fas fa-camera"></i>
 			</button>
 <?php endif; ?>
@@ -345,11 +793,22 @@ html:not([data-theme="light"]):not([data-theme="dark"]) .un-hero-name {
 
 		<!-- Name / type -->
 		<div class="un-hero-info">
-			<div class="un-type-badge">
-				<i class="fas <?=$_type_icon?>"></i>
-				<?=htmlspecialchars($_type)?>
+			<div>
+				<span class="un-type-badge">
+					<i class="fas <?=$_type_icon?>"></i>
+					<?=htmlspecialchars($_type)?>
+				</span>
+<?php if ($_unRecruitmentStatus !== ''): $_rm = $_unRecruitMeta[$_unRecruitmentStatus]; ?>
+				<span class="un-recruit-pill un-recruit-<?= htmlspecialchars($_unRecruitmentStatus) ?>" data-tip="Recruitment status">
+					<i class="fas <?= htmlspecialchars($_rm['icon']) ?>"></i>
+					<?= htmlspecialchars($_rm['label']) ?>
+				</span>
+<?php endif; ?>
 			</div>
 			<h1 class="un-hero-name"><?=htmlspecialchars($_name)?></h1>
+<?php if ($_unTagline !== ''): ?>
+			<p class="un-tagline"><?= htmlspecialchars($_unTagline) ?></p>
+<?php endif; ?>
 		</div>
 
 		<!-- Actions -->
@@ -362,6 +821,9 @@ html:not([data-theme="light"]):not([data-theme="dark"]) .un-hero-name {
 <?php if ($_can_edit): ?>
 			<button class="pn-btn pn-btn-white" onclick="unOpenModal('un-modal-details')">
 				<i class="fas fa-pen"></i><span class="un-btn-label"> Edit Details</span>
+			</button>
+			<button class="pn-btn pn-btn-white" onclick="unOpenDesignModal()">
+				<i class="fas fa-palette"></i><span class="un-btn-label"> Design</span>
 			</button>
 <?php endif; ?>
 		</div>
@@ -383,94 +845,194 @@ html:not([data-theme="light"]):not([data-theme="dark"]) .un-hero-name {
 	</div>
 </div>
 
-<!-- ── Sidebar + Main ────────────────────────────────────── -->
-<div class="pn-layout">
+<!-- ── Tabs ─────────────────────────────────────────────── -->
+<div class="un-tabs">
 
-	<!-- Sidebar -->
-	<aside class="pn-sidebar">
+	<ul class="un-tab-nav">
+		<li data-untab="about" class="un-tab-active"><i class="fas fa-info-circle"></i> About</li>
+		<li data-untab="members"><i class="fas fa-users"></i> Members <span class="un-tab-count">(<?=$_total?>)</span></li>
+	</ul>
 
-<?php if (trimlen($_desc) > 0 || $_can_edit): ?>
-		<div class="pn-card">
-			<h4 style="display:flex;align-items:center;justify-content:space-between;">
-				<span><i class="fas fa-align-left"></i> About</span>
+	<!-- ── About tab ─────────────────────────────────────── -->
+	<div class="un-tab-panel un-tab-active" id="un-tab-about">
+
+<?php if ($_unHasSocial || $_can_edit): ?>
+		<div class="un-connect-block">
+			<div class="un-connect-subhead">
+				<span><i class="fas fa-share-alt"></i> Connect</span>
 				<?php if ($_can_edit): ?>
-				<button class="pn-card-edit-btn" onclick="unOpenModal('un-modal-details')" title="Edit details">
-					<i class="fas fa-pen"></i>
-				</button>
+				<button class="un-connect-edit" type="button" onclick="unOpenDesignModal('about')" data-tip="Edit social links"><i class="fas fa-pencil-alt"></i></button>
 				<?php endif; ?>
-			</h4>
-			<div class="kn-description-body" style="font-size:13px;color:var(--ork-text-secondary);">
-				<?=un_markdown($_desc)?>
 			</div>
+			<?php if ($_unHasSocial): ?>
+			<div class="un-connect-pills">
+				<?php foreach ($_unSocialPlatforms as $_slug => $_meta):
+					if (empty($_unSocialLinks[$_slug])) continue;
+				?>
+				<a class="un-connect-pill" href="<?= htmlspecialchars($_unSocialLinks[$_slug]) ?>" target="_blank" rel="noopener noreferrer" data-tip="<?= htmlspecialchars($_meta['label']) ?>">
+					<i class="<?= htmlspecialchars($_meta['icon']) ?>"></i>
+				</a>
+				<?php endforeach; ?>
+			</div>
+			<?php elseif ($_can_edit): ?>
+			<a href="#" class="un-connect-empty" onclick="event.preventDefault();unOpenDesignModal('about')">+ Add</a>
+			<?php endif; ?>
 		</div>
 <?php endif; ?>
 
-<?php if (trimlen($_history) > 0 || $_can_edit): ?>
-		<div class="pn-card">
-			<h4 style="display:flex;align-items:center;justify-content:space-between;">
-				<span><i class="fas fa-scroll"></i> History</span>
+<?php if (trim($_about_text) !== '' || $_can_edit): ?>
+		<div class="un-about-section">
+			<div class="un-fullwidth-head">
+				<h3 class="un-fullwidth-title"><i class="fas fa-align-left"></i> About</h3>
 				<?php if ($_can_edit): ?>
-				<button class="pn-card-edit-btn" onclick="unOpenModal('un-modal-details')" title="Edit details">
-					<i class="fas fa-pen"></i>
+				<button class="un-about-edit-btn" onclick="unOpenDesignModal('about')" data-tip="Edit About">
+					<i class="fas fa-pencil-alt"></i> Edit
 				</button>
 				<?php endif; ?>
-			</h4>
-			<div class="kn-description-body" style="font-size:13px;color:var(--ork-text-secondary);">
-				<?=un_markdown($_history)?>
 			</div>
+			<?php if (trim($_about_text) !== ''): ?>
+			<div class="un-about-text kn-description-body">
+				<?= un_markdown($_about_text) ?>
+			</div>
+			<?php elseif ($_can_edit): ?>
+			<div class="un-timeline-empty" style="text-align:left">
+				No About content yet. <a href="#" onclick="event.preventDefault();unOpenDesignModal('about')">Add some</a>.
+			</div>
+			<?php endif; ?>
+		</div>
+<?php endif; ?>
+
+<?php if (trim($_unHowToJoin) !== '' || $_can_edit): ?>
+		<div class="un-fullwidth-section un-howto-section">
+			<div class="un-fullwidth-head">
+				<h3 class="un-fullwidth-title"><i class="fas fa-handshake"></i> How to Join</h3>
+				<?php if ($_can_edit): ?>
+				<button class="un-about-edit-btn" onclick="unOpenDesignModal('about')" data-tip="Edit How to Join">
+					<i class="fas fa-pencil-alt"></i> Edit
+				</button>
+				<?php endif; ?>
+			</div>
+			<?php if (trim($_unHowToJoin) !== ''): ?>
+			<div class="un-about-text kn-description-body"><?= un_markdown($_unHowToJoin) ?></div>
+			<?php elseif ($_can_edit): ?>
+			<div class="un-timeline-empty" style="text-align:left">
+				No how-to-join info yet. <a href="#" onclick="event.preventDefault();unOpenDesignModal('about')">Add some</a> to help prospective members understand the process.
+			</div>
+			<?php endif; ?>
+		</div>
+<?php endif; ?>
+
+<?php if (trim($_our_history) !== '' || $_can_edit): ?>
+		<!-- Our History -->
+		<div class="un-fullwidth-section">
+			<div class="un-fullwidth-head">
+				<h3 class="un-fullwidth-title"><i class="fas fa-scroll"></i> Our History</h3>
+				<?php if ($_can_edit): ?>
+				<button class="un-about-edit-btn" onclick="unOpenDesignModal('about')" data-tip="Edit Our History">
+					<i class="fas fa-pencil-alt"></i> Edit
+				</button>
+				<?php endif; ?>
+			</div>
+			<?php if (trim($_our_history) !== ''): ?>
+			<div class="un-about-text kn-description-body"><?= un_markdown($_our_history) ?></div>
+			<?php elseif ($_can_edit): ?>
+			<div class="un-timeline-empty">
+				Share the founding story, past officers, or notable moments. <a href="#" onclick="event.preventDefault();unOpenDesignModal('about')">Add Our History</a>.
+			</div>
+			<?php endif; ?>
+		</div>
+<?php endif; ?>
+
+<?php if ($_un_has_ms || $_can_edit): ?>
+		<!-- Milestones -->
+		<div class="un-fullwidth-section">
+			<div class="un-fullwidth-head">
+				<h3 class="un-fullwidth-title"><i class="fas fa-stream"></i> Milestones</h3>
+				<?php if ($_can_edit): ?>
+				<button class="un-about-edit-btn" onclick="unOpenDesignModal('milestones')" data-tip="Manage milestones">
+					<i class="fas fa-pencil-alt"></i> Manage
+				</button>
+				<?php endif; ?>
+			</div>
+			<?php if ($_un_has_ms): ?>
+			<div class="un-timeline">
+				<?php foreach ($_un_visible_ms as $_msr): ?>
+				<div class="un-timeline-row<?= !empty($_msr['IsDerived']) ? ' un-ms-derived' : '' ?>">
+					<div class="un-timeline-dot">
+						<i class="fas <?= htmlspecialchars(preg_replace('/[^a-z0-9-]/','', (string)($_msr['Icon'] ?? 'fa-star')) ?: 'fa-star') ?>"></i>
+					</div>
+					<div class="un-timeline-content">
+						<span class="un-timeline-date"><?= !empty($_msr['MilestoneDate']) && $_msr['MilestoneDate'] !== '0000-00-00' ? date('M j, Y', strtotime($_msr['MilestoneDate'])) : '' ?></span>
+						<span class="un-timeline-desc"><?= htmlspecialchars((string)($_msr['Description'] ?? '')) ?></span>
+					</div>
+				</div>
+				<?php endforeach; ?>
+			</div>
+			<?php elseif ($_can_edit): ?>
+			<div class="un-timeline-empty">
+				No milestones yet. <a href="#" onclick="event.preventDefault();unOpenDesignModal('milestones')">Add the first one</a> — founding date, leadership changes, notable events.
+			</div>
+			<?php endif; ?>
 		</div>
 <?php endif; ?>
 
 <?php
 $_auths = $Unit['Authorizations']['Authorizations'] ?? [];
-if ($_can_edit && (count($_auths) > 0 || true)):
+if ($_can_edit || count($_auths) > 0):
 ?>
-		<div class="pn-card">
-			<h4 style="display:flex;align-items:center;justify-content:space-between;">
-				<span><i class="fas fa-user-shield"></i> Managers</span>
-				<button class="pn-card-edit-btn" onclick="unOpenModal('un-modal-add-manager')" title="Add manager">
-					<i class="fas fa-plus"></i>
+		<!-- Managers -->
+		<div class="un-fullwidth-section">
+			<div class="un-fullwidth-head">
+				<h3 class="un-fullwidth-title"><i class="fas fa-user-shield"></i> Managers</h3>
+				<?php if ($_can_edit): ?>
+				<button class="un-about-edit-btn" onclick="unOpenModal('un-modal-add-manager')" data-tip="Add manager">
+					<i class="fas fa-plus"></i> Add
 				</button>
-			</h4>
+				<?php endif; ?>
+			</div>
 <?php if (count($_auths) > 0): ?>
-			<ul class="kn-officer-list">
+			<ul class="un-managers-list">
 <?php foreach ($_auths as $_auth):
-	$__aid      = (int)$_auth['AuthorizationId'];
-	$__mgr_js   = addslashes($_auth['Persona'] ?: $_auth['UserName']);
+	$__aid    = (int)$_auth['AuthorizationId'];
+	$__mgr_js = addslashes($_auth['Persona'] ?: $_auth['UserName']);
 ?>
 				<li>
-					<span class="kn-officer-role" style="font-size:10px;">Manager</span>
-					<span class="kn-officer-name" style="display:flex;align-items:center;justify-content:space-between;">
-						<a href="<?=UIR?>Player/profile/<?=(int)$_auth['MundaneId']?>">
-							<?=htmlspecialchars($_auth['Persona'] ?: $_auth['UserName'])?>
-						</a>
-						<form method="post" action="<?=htmlspecialchars($_base_url)?>" id="un-mgr-form-<?=$__aid?>" style="display:none">
-							<input type="hidden" name="Action" value="deleteauth">
-							<input type="hidden" name="AuthorizationId" value="<?=$__aid?>">
-						</form>
-						<button class="pn-btn pn-btn-ghost pn-btn-sm"
-							onclick="pnConfirm({title:'Remove Manager',message:'Remove <?=$__mgr_js?> as a manager?',confirmText:'Remove',danger:true},function(){document.getElementById('un-mgr-form-<?=$__aid?>').submit()})"
-							title="Remove manager" style="color:#e53e3e;">
-							<i class="fas fa-times"></i>
-						</button>
-					</span>
+					<div class="un-mgr-info">
+						<span class="un-mgr-role">Manager</span>
+						<span class="un-mgr-name">
+							<a href="<?=UIR?>Player/profile/<?=(int)$_auth['MundaneId']?>">
+								<?=htmlspecialchars($_auth['Persona'] ?: $_auth['UserName'])?>
+							</a>
+						</span>
+					</div>
+					<?php if ($_can_edit): ?>
+					<form method="post" action="<?=htmlspecialchars($_base_url)?>" id="un-mgr-form-<?=$__aid?>" style="display:none">
+						<input type="hidden" name="Action" value="deleteauth">
+						<input type="hidden" name="AuthorizationId" value="<?=$__aid?>">
+					</form>
+					<button class="pn-btn pn-btn-ghost pn-btn-sm"
+						onclick="pnConfirm({title:'Remove Manager',message:'Remove <?=$__mgr_js?> as a manager?',confirmText:'Remove',danger:true},function(){document.getElementById('un-mgr-form-<?=$__aid?>').submit()})"
+						data-tip="Remove manager" style="color:#e53e3e;">
+						<i class="fas fa-times"></i>
+					</button>
+					<?php endif; ?>
 				</li>
 <?php endforeach; ?>
 			</ul>
 <?php else: ?>
-			<p style="font-size:12px;color:var(--ork-text-muted);font-style:italic;margin:0;">No managers assigned.</p>
+			<p class="un-managers-empty">No managers assigned.</p>
 <?php endif; ?>
 		</div>
 <?php endif; ?>
 
-	</aside>
+	</div><!-- /un-tab-about -->
 
-	<!-- Main: roster -->
-	<div class="pn-main">
+	<!-- ── Members tab ───────────────────────────────────── -->
+	<div class="un-tab-panel" id="un-tab-members" style="display:none">
 
 		<div class="un-section-header">
 			<div class="un-section-title">
-				<i class="fas fa-users"></i> Members
+				<i class="fas fa-users"></i> Members <span class="un-tab-count">(<?=$_total?>)</span>
 			</div>
 <?php if ($_can_edit): ?>
 			<button class="pn-btn pn-btn-primary pn-btn-sm" onclick="unOpenModal('un-modal-add-member')">
@@ -558,17 +1120,17 @@ if ($_can_edit && (count($_auths) > 0 || true)):
 						<div class="un-action-btns">
 							<button class="pn-btn pn-btn-ghost pn-btn-sm"
 								onclick="unOpenEditMember(<?=$_um_id?>, '<?=$_role_esc?>', '<?=$_title_esc?>')"
-								title="Edit role / title">
+								data-tip="Edit role / title">
 								<i class="fas fa-pen"></i>
 							</button>
 							<button class="pn-btn pn-btn-ghost pn-btn-sm"
 								onclick="pnConfirm({title:'Retire Member',message:'Retire <?=$_persona_js?> from the unit?',confirmText:'Retire',danger:true},function(){document.getElementById('un-retire-form-<?=$_um_id?>').submit()})"
-								title="Retire member" style="color:#c05621;">
+								data-tip="Retire member" style="color:#c05621;">
 								<i class="fas fa-user-minus"></i>
 							</button>
 							<button class="pn-btn pn-btn-ghost pn-btn-sm"
 								onclick="pnConfirm({title:'Remove Member',message:'Permanently remove <?=$_persona_js?> from the unit?',confirmText:'Remove',danger:true},function(){document.getElementById('un-remove-form-<?=$_um_id?>').submit()})"
-								title="Remove member" style="color:#e53e3e;">
+								data-tip="Remove member" style="color:#e53e3e;">
 								<i class="fas fa-times"></i>
 							</button>
 						</div>
@@ -581,9 +1143,10 @@ if ($_can_edit && (count($_auths) > 0 || true)):
 <?php endif; ?>
 		</div><!-- /un-roster-card -->
 
-	</div><!-- /pn-main -->
+	</div><!-- /un-tab-members -->
 
-</div><!-- /pn-layout -->
+</div><!-- /un-tabs -->
+
 
 
 <?php if ($_can_edit): ?>
@@ -861,6 +1424,28 @@ $(function () {
 <?php endif; ?>
 			]
 		});
+	}
+
+	// ── Tab switching (About / Members) ──────────────────────
+	function unActivateTab(name) {
+		document.querySelectorAll('.un-tab-nav li').forEach(function(x){ x.classList.remove('un-tab-active'); });
+		document.querySelectorAll('.un-tab-panel').forEach(function(p){ p.style.display = 'none'; });
+		var tab = document.querySelector('.un-tab-nav li[data-untab="' + name + '"]');
+		var panel = document.getElementById('un-tab-' + name);
+		if (tab)   tab.classList.add('un-tab-active');
+		if (panel) panel.style.display = '';
+		// Recalc DataTables column widths if Members tab becomes visible (table init'd while hidden)
+		if (name === 'members' && $.fn.DataTable && $.fn.DataTable.isDataTable('#un-roster-table')) {
+			$('#un-roster-table').DataTable().columns.adjust();
+		}
+	}
+	document.querySelectorAll('.un-tab-nav li').forEach(function(t) {
+		t.addEventListener('click', function() { unActivateTab(t.dataset.untab); });
+	});
+	// Optional URL ?tab=members deep-link
+	var _unUrlTab = new URLSearchParams(window.location.search).get('tab');
+	if (_unUrlTab && document.querySelector('.un-tab-nav li[data-untab="' + _unUrlTab + '"]')) {
+		unActivateTab(_unUrlTab);
 	}
 });
 
@@ -1185,3 +1770,780 @@ html[data-theme="dark"] #un-roster-table_wrapper .dataTables_paginate .paginate_
   opacity: 0.4 !important;
 }
 </style>
+
+<?php if ($_can_edit): ?>
+<!-- ── Design Modal ─────────────────────────────────────── -->
+<style>
+.un-dm-overlay {
+	display: none; position: fixed; inset: 0; background: rgba(0,0,0,0.55); z-index: 1000;
+	align-items: center; justify-content: center; padding: 20px;
+}
+.un-dm-overlay.un-open { display: flex; }
+.un-dm-modal {
+	background: #fff; border-radius: 10px; width: 100%; max-width: 720px; max-height: 90vh;
+	display: flex; flex-direction: column; box-shadow: 0 20px 60px rgba(0,0,0,0.35); color: #1a202c;
+}
+html[data-theme="dark"] .un-dm-modal { background: var(--ork-card-bg); color: var(--ork-text); }
+.un-dm-header {
+	display: flex; align-items: center; justify-content: space-between;
+	padding: 14px 18px; border-bottom: 1px solid #e2e8f0; background: #f7fafc; border-radius: 10px 10px 0 0;
+}
+html[data-theme="dark"] .un-dm-header { border-color: var(--ork-border); background: var(--ork-bg-secondary); }
+.un-dm-title {
+	margin: 0; font-size: 17px; font-weight: 700; color: #2d3748;
+	display: flex; align-items: center; gap: 8px;
+	background: transparent; border: none; padding: 0; border-radius: 0; text-shadow: none;
+}
+html[data-theme="dark"] .un-dm-title { color: var(--ork-text); }
+.un-dm-close {
+	background: transparent; border: 0; cursor: pointer; font-size: 24px; color: #718096; line-height: 1;
+	padding: 4px 10px; border-radius: 6px;
+}
+.un-dm-close:hover { background: #f7fafc; color: #2d3748; }
+html[data-theme="dark"] .un-dm-close { color: var(--ork-text-muted); }
+html[data-theme="dark"] .un-dm-close:hover { background: var(--ork-bg-tertiary); color: var(--ork-text); }
+.un-dm-tabs {
+	display: flex; gap: 4px; padding: 6px 10px 0 10px; background: #f7fafc; border-bottom: 1px solid #e2e8f0;
+}
+html[data-theme="dark"] .un-dm-tabs { background: var(--ork-bg-secondary); border-color: var(--ork-border); }
+.un-dm-tab {
+	background: transparent; border: 0; padding: 9px 14px; cursor: pointer;
+	font-size: 13px; font-weight: 600; color: #718096; border-bottom: 2px solid transparent;
+	display: inline-flex; align-items: center; gap: 6px;
+}
+.un-dm-tab.un-active {
+	color: #2b6cb0; border-bottom-color: #2b6cb0;
+}
+html[data-theme="dark"] .un-dm-tab { color: var(--ork-text-secondary); }
+html[data-theme="dark"] .un-dm-tab.un-active {
+	color: var(--ork-link); border-bottom-color: var(--ork-link);
+}
+.un-dm-body {
+	padding: 18px 22px; overflow-y: auto; flex: 1;
+}
+.un-dm-panel { display: none; }
+.un-dm-panel.un-active { display: block; }
+.un-dm-error {
+	display: none; background: #fff5f5; color: #c53030; border: 1px solid #feb2b2;
+	border-radius: 6px; padding: 10px 12px; margin-bottom: 12px; font-size: 13px;
+}
+html[data-theme="dark"] .un-dm-error { background: rgba(252,129,129,0.1); color: #fc8181; }
+.un-dm-field { margin-bottom: 14px; }
+.un-dm-field label {
+	display: block; font-size: 11px; font-weight: 700; color: #4a5568;
+	text-transform: uppercase; letter-spacing: 0.5px; margin-bottom: 6px;
+}
+html[data-theme="dark"] .un-dm-field label { color: var(--ork-text-secondary); }
+.un-dm-field input[type="text"],
+.un-dm-field input[type="date"],
+.un-dm-field textarea,
+.un-dm-field select {
+	width: 100%; padding: 8px 10px; font-size: 14px;
+	border: 1px solid #cbd5e0; border-radius: 6px;
+	background: #fff; color: #2d3748; font-family: inherit;
+}
+html[data-theme="dark"] .un-dm-field input,
+html[data-theme="dark"] .un-dm-field textarea,
+html[data-theme="dark"] .un-dm-field select {
+	background: var(--ork-bg-secondary); border-color: var(--ork-border); color: var(--ork-text);
+}
+.un-dm-field textarea { min-height: 140px; resize: vertical; line-height: 1.5; }
+.un-dm-hint {
+	font-size: 12px; color: #718096;
+}
+html[data-theme="dark"] .un-dm-hint { color: var(--ork-text-muted); }
+.un-dm-footer {
+	display: flex; gap: 8px; justify-content: flex-end; padding: 12px 18px;
+	border-top: 1px solid #e2e8f0; background: #f7fafc; border-radius: 0 0 10px 10px;
+}
+html[data-theme="dark"] .un-dm-footer { background: var(--ork-bg-secondary); border-color: var(--ork-border); }
+.un-dm-btn {
+	background: #fff; border: 1px solid #cbd5e0; color: #4a5568;
+	padding: 8px 14px; font-size: 13px; font-weight: 600; border-radius: 6px; cursor: pointer;
+	display: inline-flex; align-items: center; gap: 5px;
+}
+html[data-theme="dark"] .un-dm-btn { background: var(--ork-bg-tertiary); border-color: var(--ork-border); color: var(--ork-text); }
+.un-dm-btn-primary { background: #3182ce; color: #fff; border-color: #3182ce; }
+.un-dm-btn-primary:hover { background: #2c5282; border-color: #2c5282; }
+.un-dm-btn:disabled { opacity: 0.55; cursor: not-allowed; }
+
+.un-dm-preset-grid { display: grid; grid-template-columns: repeat(8, 1fr); gap: 8px; }
+.un-dm-swatch {
+	height: 36px; border-radius: 6px; cursor: pointer;
+	border: 2px solid transparent; transition: transform 0.12s, box-shadow 0.12s;
+}
+.un-dm-swatch.un-selected { border-color: #2b6cb0; transform: scale(1.06); box-shadow: 0 0 0 2px #fff, 0 0 0 4px #2b6cb0; }
+html[data-theme="dark"] .un-dm-swatch.un-selected { box-shadow: 0 0 0 2px var(--ork-card-bg), 0 0 0 4px var(--ork-link); }
+.un-dm-color-row { display: flex; gap: 12px; flex-wrap: wrap; }
+.un-dm-color-col { flex: 1; min-width: 180px; }
+.un-dm-color-input { display: flex; align-items: center; gap: 6px; }
+.un-dm-color-input input[type="color"] {
+	width: 38px; height: 36px; border: 1px solid #cbd5e0; border-radius: 6px;
+	padding: 0; background: transparent; cursor: pointer;
+}
+.un-dm-color-input input[type="text"] { flex: 1; }
+.un-dm-overlay-btns { display: flex; gap: 6px; flex-wrap: wrap; }
+.un-dm-overlay-btn {
+	flex: 1; min-width: 80px; padding: 8px 10px; font-size: 12px; font-weight: 600;
+	border: 1px solid #cbd5e0; border-radius: 6px; background: #fff; color: #4a5568; cursor: pointer;
+}
+.un-dm-overlay-btn.un-active { background: #2b6cb0; color: #fff; border-color: #2b6cb0; }
+html[data-theme="dark"] .un-dm-overlay-btn { background: var(--ork-bg-tertiary); border-color: var(--ork-border); color: var(--ork-text-secondary); }
+html[data-theme="dark"] .un-dm-overlay-btn.un-active { background: var(--ork-link); color: var(--ork-bg-secondary); border-color: var(--ork-link); }
+
+.un-dm-font-picker { display: grid; grid-template-columns: repeat(auto-fill, minmax(140px, 1fr)); gap: 8px; }
+.un-dm-font-card {
+	border: 1px solid #cbd5e0; border-radius: 8px; padding: 10px 8px; cursor: pointer;
+	text-align: center; background: #fff;
+}
+.un-dm-font-card.un-active { border-color: #2b6cb0; background: #ebf8ff; box-shadow: 0 0 0 1px #2b6cb0; }
+html[data-theme="dark"] .un-dm-font-card { background: var(--ork-bg-tertiary); border-color: var(--ork-border); }
+html[data-theme="dark"] .un-dm-font-card.un-active { background: rgba(43,108,176,0.15); border-color: var(--ork-link); box-shadow: 0 0 0 1px var(--ork-link); }
+.un-dm-font-sample { font-size: 19px; font-weight: 600; color: #2d3748; line-height: 1.2; margin-bottom: 4px; }
+html[data-theme="dark"] .un-dm-font-sample { color: var(--ork-text); }
+.un-dm-font-label { font-size: 11px; color: #718096; }
+html[data-theme="dark"] .un-dm-font-label { color: var(--ork-text-muted); }
+
+.un-dm-md-toolbar { display: flex; justify-content: space-between; align-items: center; gap: 8px; margin-bottom: 4px; flex-wrap: wrap; }
+.un-dm-md-toggle { display: inline-flex; background: #edf2f7; border-radius: 6px; padding: 3px; gap: 3px; }
+.un-dm-md-toggle button {
+	background: transparent; border: 0; padding: 5px 10px; font-size: 12px; font-weight: 600;
+	cursor: pointer; border-radius: 4px; color: #718096;
+}
+.un-dm-md-toggle button.un-active { background: #fff; color: #2b6cb0; box-shadow: 0 1px 2px rgba(0,0,0,0.06); }
+html[data-theme="dark"] .un-dm-md-toggle { background: var(--ork-bg-tertiary); }
+html[data-theme="dark"] .un-dm-md-toggle button.un-active { background: var(--ork-card-bg); color: var(--ork-link); }
+.un-dm-md-preview {
+	border: 1px solid #cbd5e0; border-radius: 6px; padding: 12px 14px;
+	min-height: 140px; background: #fafafa; font-size: 14px; line-height: 1.55; color: #2d3748;
+}
+html[data-theme="dark"] .un-dm-md-preview { background: var(--ork-bg-secondary); border-color: var(--ork-border); color: var(--ork-text); }
+.un-dm-md-preview h1, .un-dm-md-preview h2, .un-dm-md-preview h3, .un-dm-md-preview h4 {
+	background: transparent; border: none; padding: 0; border-radius: 0; text-shadow: none;
+	margin-top: 0.9em; margin-bottom: 0.3em;
+}
+
+.un-dm-ms-toggles { display: flex; flex-wrap: wrap; gap: 8px 14px; margin-bottom: 14px; }
+.un-dm-ms-toggle { display: inline-flex; align-items: center; gap: 6px; font-size: 13px; color: #4a5568; }
+html[data-theme="dark"] .un-dm-ms-toggle { color: var(--ork-text-secondary); }
+.un-dm-ms-list { border: 1px solid #e2e8f0; border-radius: 6px; margin-bottom: 12px; max-height: 200px; overflow-y: auto; }
+html[data-theme="dark"] .un-dm-ms-list { border-color: var(--ork-border); background: var(--ork-bg-secondary); }
+.un-dm-ms-row {
+	display: flex; align-items: center; gap: 8px; padding: 8px 10px; border-bottom: 1px solid #edf2f7;
+	font-size: 13px;
+}
+html[data-theme="dark"] .un-dm-ms-row { border-color: var(--ork-border); }
+.un-dm-ms-row:last-child { border-bottom: none; }
+.un-dm-ms-row > i { color: #2b6cb0; width: 18px; text-align: center; }
+.un-dm-ms-row .un-dm-ms-desc { flex: 1; color: #2d3748; }
+html[data-theme="dark"] .un-dm-ms-row .un-dm-ms-desc { color: var(--ork-text); }
+.un-dm-ms-row .un-dm-ms-date { color: #718096; font-size: 11px; min-width: 90px; }
+html[data-theme="dark"] .un-dm-ms-row .un-dm-ms-date { color: var(--ork-text-muted); }
+html[data-theme="dark"] .un-dm-ms-row > i { color: var(--ork-link); }
+html[data-theme="dark"] .un-dm-ms-row button { color: #fc8181; }
+html[data-theme="dark"] .un-dm-ms-row button:hover { background: var(--ork-bg-tertiary); }
+.un-dm-ms-row button {
+	background: transparent; border: 0; color: #e53e3e; cursor: pointer; padding: 4px 6px;
+}
+.un-dm-ms-row button[data-tip] { position: relative; }
+.un-dm-ms-row button[data-tip]::after {
+	content: attr(data-tip); position: absolute; bottom: calc(100% + 4px); right: 0;
+	background: #2d3748; color: #fff; font-size: 11px; white-space: nowrap;
+	padding: 3px 8px; border-radius: 4px; pointer-events: none; opacity: 0;
+	transition: opacity 0.12s; z-index: 600;
+}
+.un-dm-ms-row button[data-tip]:hover::after { opacity: 1; transition-delay: 0.3s; }
+html[data-theme="dark"] .un-dm-ms-row button[data-tip]::after {
+	background: var(--ork-bg-tertiary); color: var(--ork-text); border: 1px solid var(--ork-border);
+}
+.un-dm-ms-add { display: grid; grid-template-columns: 1fr 140px 90px; gap: 8px; align-items: end; }
+@media (max-width: 600px) { .un-dm-ms-add { grid-template-columns: 1fr; } }
+.un-dm-ms-icons { display: flex; flex-wrap: wrap; gap: 6px; margin-top: 4px; }
+.un-dm-ms-icon-opt {
+	width: 28px; height: 28px; border: 1px solid #cbd5e0; border-radius: 6px;
+	display: flex; align-items: center; justify-content: center; cursor: pointer;
+	background: #fff; color: #4a5568;
+}
+.un-dm-ms-icon-opt.un-active { background: #2b6cb0; color: #fff; border-color: #2b6cb0; }
+html[data-theme="dark"] .un-dm-ms-icon-opt { background: var(--ork-bg-tertiary); border-color: var(--ork-border); color: var(--ork-text-secondary); }
+html[data-theme="dark"] .un-dm-ms-icon-opt.un-active { background: var(--ork-link); color: var(--ork-bg-secondary); border-color: var(--ork-link); }
+</style>
+
+<div class="un-dm-overlay" id="un-dm-overlay">
+	<div class="un-dm-modal">
+		<div class="un-dm-header">
+			<h3 class="un-dm-title"><i class="fas fa-palette"></i>Design <?= htmlspecialchars($_name) ?></h3>
+			<button class="un-dm-close" id="un-dm-close" aria-label="Close">&times;</button>
+		</div>
+		<div class="un-dm-tabs">
+			<button class="un-dm-tab un-active" data-untab-dm="header"><i class="fas fa-image"></i> Header</button>
+			<button class="un-dm-tab" data-untab-dm="about"><i class="fas fa-scroll"></i> About</button>
+			<button class="un-dm-tab" data-untab-dm="milestones"><i class="fas fa-stream"></i> Milestones</button>
+		</div>
+		<div class="un-dm-body">
+			<div class="un-dm-error" id="un-dm-error"></div>
+
+			<!-- Header Panel -->
+			<div class="un-dm-panel un-active" id="un-dm-panel-header">
+				<div class="un-dm-hint" style="margin-bottom:12px"><i class="fas fa-moon" style="margin-right:6px"></i><strong>Dark mode viewers</strong> see your hero with a slight darkening filter so colors stay readable.</div>
+
+				<div class="un-dm-field">
+					<label>Color Presets</label>
+					<div class="un-dm-preset-grid" id="un-dm-presets">
+						<div class="un-dm-swatch" data-primary="#2c5282" data-accent="#4299e1" style="background:#2c5282"></div>
+						<div class="un-dm-swatch" data-primary="#276749" data-accent="#48bb78" style="background:#276749"></div>
+						<div class="un-dm-swatch" data-primary="#9b2c2c" data-accent="#fc8181" style="background:#9b2c2c"></div>
+						<div class="un-dm-swatch" data-primary="#553c9a" data-accent="#9f7aea" style="background:#553c9a"></div>
+						<div class="un-dm-swatch" data-primary="#975a16" data-accent="#ecc94b" style="background:#975a16"></div>
+						<div class="un-dm-swatch" data-primary="#2d3748" data-accent="#a0aec0" style="background:#2d3748"></div>
+						<div class="un-dm-swatch" data-primary="#285e61" data-accent="#38b2ac" style="background:#285e61"></div>
+						<div class="un-dm-swatch" data-primary="#744210" data-accent="#ed8936" style="background:#744210"></div>
+					</div>
+				</div>
+
+				<div class="un-dm-field">
+					<label>Gradient Presets</label>
+					<div class="un-dm-preset-grid" id="un-dm-gradient-presets">
+						<div class="un-dm-swatch" data-primary="#1a365d" data-accent="#4299e1" data-secondary="#553c9a" style="background:linear-gradient(135deg,#1a365d,#553c9a)"></div>
+						<div class="un-dm-swatch" data-primary="#1a4731" data-accent="#48bb78" data-secondary="#2c5282" style="background:linear-gradient(135deg,#1a4731,#2c5282)"></div>
+						<div class="un-dm-swatch" data-primary="#742a2a" data-accent="#fc8181" data-secondary="#975a16" style="background:linear-gradient(135deg,#742a2a,#975a16)"></div>
+						<div class="un-dm-swatch" data-primary="#44337a" data-accent="#d6bcfa" data-secondary="#97266d" style="background:linear-gradient(135deg,#44337a,#97266d)"></div>
+						<div class="un-dm-swatch" data-primary="#234e52" data-accent="#38b2ac" data-secondary="#276749" style="background:linear-gradient(135deg,#234e52,#276749)"></div>
+						<div class="un-dm-swatch" data-primary="#2c5282" data-accent="#4299e1" data-secondary="#285e61" style="background:linear-gradient(135deg,#2c5282,#285e61)"></div>
+						<div class="un-dm-swatch" data-primary="#744210" data-accent="#ecc94b" data-secondary="#9b2c2c" style="background:linear-gradient(135deg,#744210,#9b2c2c)"></div>
+						<div class="un-dm-swatch" data-primary="#1a202c" data-accent="#a0aec0" data-secondary="#2d3748" style="background:linear-gradient(135deg,#1a202c,#2d3748)"></div>
+					</div>
+				</div>
+
+				<div class="un-dm-field">
+					<label>Custom Colors</label>
+					<div class="un-dm-color-row">
+						<div class="un-dm-color-col">
+							<div class="un-dm-hint" style="margin-bottom:4px">Primary (hero background)</div>
+							<div class="un-dm-color-input">
+								<input type="color" id="un-dm-color-primary" value="<?= htmlspecialchars($_un_color_primary ?: '#2c5282') ?>" />
+								<input type="text" id="un-dm-color-primary-hex" value="<?= htmlspecialchars($_un_color_primary ?: '#2c5282') ?>" maxlength="7" />
+							</div>
+						</div>
+						<div class="un-dm-color-col">
+							<div class="un-dm-hint" style="margin-bottom:4px">Accent (badges &amp; pencils)</div>
+							<div class="un-dm-color-input">
+								<input type="color" id="un-dm-color-accent" value="<?= htmlspecialchars($_un_color_accent ?: '#4299e1') ?>" />
+								<input type="text" id="un-dm-color-accent-hex" value="<?= htmlspecialchars($_un_color_accent ?: '#4299e1') ?>" maxlength="7" />
+							</div>
+						</div>
+					</div>
+				</div>
+
+				<div class="un-dm-field">
+					<label>Gradient (Optional)</label>
+					<div class="un-dm-color-row">
+						<div class="un-dm-color-col">
+							<div class="un-dm-hint" style="margin-bottom:4px">Secondary color</div>
+							<div class="un-dm-color-input">
+								<input type="color" id="un-dm-color-secondary" value="<?= htmlspecialchars($_un_color_secondary ?: ($_un_color_primary ?: '#2c5282')) ?>" />
+								<input type="text" id="un-dm-color-secondary-hex" value="<?= htmlspecialchars($_un_color_secondary) ?>" maxlength="7" placeholder="None" />
+							</div>
+						</div>
+						<div class="un-dm-color-col" style="display:flex;align-items:center;padding-top:18px">
+							<label style="text-transform:none;letter-spacing:0;display:flex;align-items:center;gap:6px;cursor:pointer;font-weight:500;color:#4a5568;font-size:13px;margin-bottom:0">
+								<input type="checkbox" id="un-dm-gradient-enabled" <?= $_un_color_secondary !== '' ? 'checked' : '' ?> />
+								Enable gradient
+							</label>
+						</div>
+					</div>
+				</div>
+
+				<div class="un-dm-field">
+					<label>Heraldry Overlay Strength</label>
+					<div class="un-dm-hint" style="margin-bottom:6px">Controls how much the unit heraldry shows through the hero background.</div>
+					<div class="un-dm-overlay-btns">
+						<button type="button" class="un-dm-overlay-btn<?= $_un_overlay === 'low' ? ' un-active' : '' ?>" data-overlay="low">Low</button>
+						<button type="button" class="un-dm-overlay-btn<?= $_un_overlay === 'med' ? ' un-active' : '' ?>" data-overlay="med">Medium</button>
+						<button type="button" class="un-dm-overlay-btn<?= $_un_overlay === 'high' ? ' un-active' : '' ?>" data-overlay="high">High</button>
+						<button type="button" class="un-dm-overlay-btn<?= $_un_overlay === 'vignette' ? ' un-active' : '' ?>" data-overlay="vignette">Vignette</button>
+					</div>
+					<input type="hidden" id="un-dm-hero-overlay" value="<?= htmlspecialchars($_un_overlay) ?>" />
+				</div>
+
+				<div class="un-dm-field">
+					<label>Name Font</label>
+					<div class="un-dm-hint" style="margin-bottom:6px">A decorative font for the unit name in the hero.</div>
+					<div class="un-dm-font-picker" id="un-dm-font-picker"></div>
+				</div>
+
+				<div class="un-dm-section-title">Tagline</div>
+				<div class="un-dm-field">
+					<label>Tagline</label>
+					<div class="un-dm-hint" style="margin-bottom:6px">A short phrase shown under the unit name. Max 160 characters.</div>
+					<input type="text" id="un-dm-tagline" maxlength="160" value="<?= htmlspecialchars($_unTagline) ?>" placeholder="e.g. Forging warriors since 2003." />
+					<div class="un-dm-hint" style="margin-top:4px"><span id="un-dm-tagline-count"><?= strlen($_unTagline) ?></span>/160</div>
+				</div>
+
+				<div class="un-dm-section-title">Announcement Banner</div>
+				<div class="un-dm-field">
+					<label>Announcement</label>
+					<div class="un-dm-hint" style="margin-bottom:6px">Shown as an amber banner above the hero. Plain text, max 280 characters.</div>
+					<textarea id="un-dm-announcement" maxlength="280" placeholder="e.g. New member orientation this Saturday at 10 AM." style="min-height:70px"><?= htmlspecialchars($_unAnnouncement) ?></textarea>
+					<div class="un-dm-hint" style="margin-top:4px"><span id="un-dm-announcement-count"><?= strlen($_unAnnouncement) ?></span>/280</div>
+				</div>
+				<div class="un-dm-field">
+					<label>Show until (optional)</label>
+					<div class="un-dm-hint" style="margin-bottom:6px">Banner auto-hides after this date. Leave blank to show indefinitely.</div>
+					<input type="date" id="un-dm-announcement-until" value="<?= htmlspecialchars($_unAnnouncementUntil && $_unAnnouncementUntil !== '0000-00-00' ? $_unAnnouncementUntil : '') ?>" />
+				</div>
+
+				<div class="un-dm-section-title">Recruitment Status</div>
+				<div class="un-dm-field">
+					<label>Recruitment Status</label>
+					<div class="un-dm-hint" style="margin-bottom:6px">Show recruitment status as a pill in the hero. &ldquo;Not Set&rdquo; hides the pill.</div>
+					<div class="un-dm-recruit-row" id="un-dm-recruit-row">
+						<button type="button" class="un-dm-recruit-opt<?= $_unRecruitmentStatus === 'open' ? ' un-active' : '' ?>" data-recruit="open"><i class="fas fa-door-open"></i> Recruiting</button>
+						<button type="button" class="un-dm-recruit-opt<?= $_unRecruitmentStatus === 'invite' ? ' un-active' : '' ?>" data-recruit="invite"><i class="fas fa-envelope"></i> Invite Only</button>
+						<button type="button" class="un-dm-recruit-opt<?= $_unRecruitmentStatus === 'closed' ? ' un-active' : '' ?>" data-recruit="closed"><i class="fas fa-lock"></i> Closed</button>
+						<button type="button" class="un-dm-recruit-opt<?= $_unRecruitmentStatus === '' ? ' un-active' : '' ?>" data-recruit="">Not Set</button>
+					</div>
+					<input type="hidden" id="un-dm-recruitment-status" value="<?= htmlspecialchars($_unRecruitmentStatus) ?>" />
+				</div>
+			</div>
+
+			<!-- About Panel -->
+			<div class="un-dm-panel" id="un-dm-panel-about">
+				<div class="un-dm-hint" style="margin-bottom:14px"><i class="fas fa-info-circle" style="margin-right:6px"></i>Both fields support <strong>Markdown</strong>. Use <em>About</em> for a current snapshot of the unit; use <em>Our History</em> for the founding story and notable moments.</div>
+
+				<div class="un-dm-field">
+					<div class="un-dm-md-toolbar">
+						<label style="margin-bottom:0">About <?= htmlspecialchars($_name) ?></label>
+						<div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap">
+							<div class="un-dm-md-toggle">
+								<button type="button" class="un-active" data-unmd-target="edit" data-unmd-field="about">Write</button>
+								<button type="button" data-unmd-target="preview" data-unmd-field="about">Preview</button>
+							</div>
+						</div>
+					</div>
+					<textarea id="un-dm-about-text" maxlength="10000" placeholder="Welcome to the unit... (Markdown supported)"><?= htmlspecialchars($_about_text) ?></textarea>
+					<div class="un-dm-md-preview" id="un-dm-about-preview" style="display:none"></div>
+				</div>
+
+				<div class="un-dm-field">
+					<div class="un-dm-md-toolbar">
+						<label style="margin-bottom:0">Our History</label>
+						<div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap">
+							<div class="un-dm-md-toggle">
+								<button type="button" class="un-active" data-unmd-target="edit" data-unmd-field="history">Write</button>
+								<button type="button" data-unmd-target="preview" data-unmd-field="history">Preview</button>
+							</div>
+						</div>
+					</div>
+					<textarea id="un-dm-history-text" maxlength="10000" placeholder="The unit was founded in... (Markdown supported)"><?= htmlspecialchars($_our_history) ?></textarea>
+					<div class="un-dm-md-preview" id="un-dm-history-preview" style="display:none"></div>
+				</div>
+
+				<div class="un-dm-section-title">How to Join</div>
+				<div class="un-dm-field">
+					<div class="un-dm-md-toolbar">
+						<label style="margin-bottom:0">How to Join</label>
+						<div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap">
+							<div class="un-dm-md-toggle">
+								<button type="button" class="un-active" data-unmd-target="edit" data-unmd-field="howto">Write</button>
+								<button type="button" data-unmd-target="preview" data-unmd-field="howto">Preview</button>
+							</div>
+						</div>
+					</div>
+					<textarea id="un-dm-howto-text" maxlength="5000" placeholder="Reach out to our captain on Discord, then come to a fighter practice... (Markdown supported)"><?= htmlspecialchars($_unHowToJoin) ?></textarea>
+					<div class="un-dm-md-preview" id="un-dm-howto-preview" style="display:none"></div>
+					<div class="un-dm-hint" style="margin-top:4px">Optional. Markdown supported. Visible to anyone viewing the unit profile.</div>
+				</div>
+
+				<div class="un-dm-section-title">Social Links</div>
+				<div class="un-dm-field">
+					<div class="un-dm-hint" style="margin-bottom:8px">Add full URLs (https://...). Leave blank to hide a platform.</div>
+					<div class="un-dm-social-list">
+<?php foreach ($_unSocialPlatforms as $_slug => $_meta): ?>
+						<div class="un-dm-social-row">
+							<span class="un-dm-social-label">
+								<span class="un-dm-social-icon" style="background:<?= htmlspecialchars($_meta['bg']) ?>"><i class="<?= htmlspecialchars($_meta['icon']) ?>"></i></span>
+								<?= htmlspecialchars($_meta['label']) ?>
+							</span>
+							<input type="url" data-un-social="<?= htmlspecialchars($_slug) ?>" maxlength="500" placeholder="<?= htmlspecialchars($_meta['placeholder']) ?>" value="<?= htmlspecialchars($_unSocialLinks[$_slug] ?? '') ?>" />
+						</div>
+<?php endforeach; ?>
+					</div>
+				</div>
+			</div>
+
+			<!-- Milestones Panel -->
+			<div class="un-dm-panel" id="un-dm-panel-milestones">
+				<div class="un-dm-hint" style="margin-bottom:10px">Milestones appear on the unit profile in date order. The single derived milestone (first recorded member activity) comes from attendance data; the rest are custom entries you add below.</div>
+
+				<div class="un-dm-field">
+					<label>Visible Milestone Types</label>
+					<div class="un-dm-ms-toggles" id="un-dm-ms-toggles">
+						<label class="un-dm-ms-toggle"><input type="checkbox" data-unms-type="first_member_activity" <?= $_un_ms_visible('first_member_activity') ? 'checked' : '' ?> /> <i class="fas fa-door-open"></i> First Member Activity</label>
+						<label class="un-dm-ms-toggle"><input type="checkbox" data-unms-type="custom" <?= $_un_ms_visible('custom') ? 'checked' : '' ?> /> <i class="fas fa-pen"></i> Custom Milestones</label>
+					</div>
+					<label class="un-dm-ms-toggle" style="margin-top:4px">
+						<input type="checkbox" id="un-dm-ms-newest-first" <?= $_un_ms_newest_first ? 'checked' : '' ?> />
+						Show newest first
+					</label>
+				</div>
+
+				<div class="un-dm-field">
+					<label>Custom Milestones</label>
+					<div class="un-dm-ms-list" id="un-dm-ms-list"></div>
+					<div class="un-dm-ms-add">
+						<div><input type="text" id="un-dm-ms-add-desc" placeholder="What happened?" maxlength="500" /></div>
+						<div><input type="date" id="un-dm-ms-add-date" /></div>
+						<div><button type="button" class="un-dm-btn un-dm-btn-primary" id="un-dm-ms-add-btn" style="width:100%"><i class="fas fa-plus"></i> Add</button></div>
+					</div>
+					<div class="un-dm-ms-icons" id="un-dm-ms-icons" style="margin-top:8px">
+						<?php $_unIcons = ['fa-star','fa-trophy','fa-flag','fa-chess-rook','fa-crown','fa-medal','fa-shield-alt','fa-fire','fa-bolt','fa-scroll','fa-users','fa-dragon','fa-hammer','fa-heart','fa-home','fa-anchor']; ?>
+						<?php foreach ($_unIcons as $_ic): ?>
+						<div class="un-dm-ms-icon-opt<?= $_ic === 'fa-star' ? ' un-active' : '' ?>" data-icon="<?= htmlspecialchars($_ic) ?>"><i class="fas <?= htmlspecialchars($_ic) ?>"></i></div>
+						<?php endforeach; ?>
+					</div>
+					<div class="un-dm-hint" id="un-dm-ms-add-err" style="color:#c53030;display:none;margin-top:6px"></div>
+				</div>
+			</div>
+		</div>
+		<div class="un-dm-footer">
+			<button class="un-dm-btn" id="un-dm-cancel">Cancel</button>
+			<button class="un-dm-btn un-dm-btn-primary" id="un-dm-save"><i class="fas fa-save"></i> Save Changes</button>
+		</div>
+	</div>
+</div>
+
+<script src="https://cdn.jsdelivr.net/npm/marked@12/marked.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/dompurify@3/dist/purify.min.js"></script>
+<script>
+(function() {
+	var UNIT_ID = <?= (int)$_unit_id ?>;
+	var BASE_URL = '<?= htmlspecialchars($_base_url) ?>';
+	var UN_FONTS = [
+		{ key:'', label:'Default', family:'inherit' },
+		{ key:'Cinzel', label:'Cinzel', family:'Cinzel' },
+		{ key:'Cinzel Decorative', label:'Cinzel Deco', family:"'Cinzel Decorative'" },
+		{ key:'IM Fell English', label:'IM Fell English', family:"'IM Fell English'" },
+		{ key:'UnifrakturMaguntia', label:'Unifraktur', family:'UnifrakturMaguntia' },
+		{ key:'Metamorphous', label:'Metamorphous', family:'Metamorphous' },
+		{ key:'Uncial Antiqua', label:'Uncial Antiqua', family:"'Uncial Antiqua'" },
+		{ key:'Pirata One', label:'Pirata One', family:"'Pirata One'" },
+		{ key:'Almendra', label:'Almendra', family:'Almendra' },
+		{ key:'Pinyon Script', label:'Pinyon Script', family:"'Pinyon Script'" },
+		{ key:'Great Vibes', label:'Great Vibes', family:"'Great Vibes'" }
+	];
+	var INITIAL_CUSTOM_MS = <?php
+		$customOnly = array_values(array_filter($_un_all_ms, function($m){ return empty($m['IsDerived']); }));
+		echo json_encode(array_map(function($m){
+			return [
+				'MilestoneId'   => (int)$m['MilestoneId'],
+				'Icon'          => $m['Icon'],
+				'Description'   => $m['Description'],
+				'MilestoneDate' => $m['MilestoneDate'],
+			];
+		}, $customOnly));
+	?>;
+	var unSelectedFont = <?= json_encode($_un_name_font) ?>;
+	var unSelectedIcon = 'fa-star';
+	var customMs = INITIAL_CUSTOM_MS.slice();
+
+	function gid(id) { return document.getElementById(id); }
+	function esc(s) { return String(s == null ? '' : s).replace(/[&<>"']/g, function(c) { return ({ '&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;' })[c]; }); }
+
+	window.unOpenDesignModal = function(panel) {
+		gid('un-dm-overlay').classList.add('un-open');
+		document.body.style.overflow = 'hidden';
+		if (panel) unSwitchDmPanel(panel);
+		renderCustomMsList();
+	};
+	function close() {
+		gid('un-dm-overlay').classList.remove('un-open');
+		document.body.style.overflow = '';
+	}
+	gid('un-dm-close').addEventListener('click', close);
+	gid('un-dm-cancel').addEventListener('click', close);
+	gid('un-dm-overlay').addEventListener('click', function(e) {
+		if (e.target === this) close();
+	});
+	document.addEventListener('keydown', function(e) {
+		if ((e.key === 'Escape' || e.keyCode === 27) && gid('un-dm-overlay').classList.contains('un-open')) close();
+	});
+
+	function unSwitchDmPanel(name) {
+		document.querySelectorAll('.un-dm-tab').forEach(function(t) { t.classList.remove('un-active'); });
+		document.querySelectorAll('.un-dm-panel').forEach(function(p) { p.classList.remove('un-active'); });
+		var tab = document.querySelector('.un-dm-tab[data-untab-dm="' + name + '"]');
+		var panel = gid('un-dm-panel-' + name);
+		if (tab) tab.classList.add('un-active');
+		if (panel) panel.classList.add('un-active');
+	}
+	document.querySelectorAll('.un-dm-tab').forEach(function(t) {
+		t.addEventListener('click', function() { unSwitchDmPanel(t.dataset.untabDm); });
+	});
+
+	var swatches = document.querySelectorAll('.un-dm-swatch');
+	swatches.forEach(function(sw) {
+		sw.addEventListener('click', function() {
+			swatches.forEach(function(s) { s.classList.remove('un-selected'); });
+			sw.classList.add('un-selected');
+			gid('un-dm-color-primary').value     = sw.dataset.primary;
+			gid('un-dm-color-primary-hex').value = sw.dataset.primary;
+			gid('un-dm-color-accent').value      = sw.dataset.accent;
+			gid('un-dm-color-accent-hex').value  = sw.dataset.accent;
+			if (sw.dataset.secondary) {
+				gid('un-dm-color-secondary').value     = sw.dataset.secondary;
+				gid('un-dm-color-secondary-hex').value = sw.dataset.secondary;
+				gid('un-dm-gradient-enabled').checked  = true;
+			} else {
+				gid('un-dm-color-secondary-hex').value = '';
+				gid('un-dm-gradient-enabled').checked  = false;
+			}
+		});
+	});
+	function syncHex(colorId, hexId) {
+		gid(colorId).addEventListener('input', function() { gid(hexId).value = this.value; });
+		gid(hexId).addEventListener('input', function() {
+			if (/^#[0-9a-f]{6}$/i.test(this.value)) { gid(colorId).value = this.value; }
+		});
+	}
+	syncHex('un-dm-color-primary',   'un-dm-color-primary-hex');
+	syncHex('un-dm-color-accent',    'un-dm-color-accent-hex');
+	syncHex('un-dm-color-secondary', 'un-dm-color-secondary-hex');
+
+	document.querySelectorAll('.un-dm-overlay-btn').forEach(function(btn) {
+		btn.addEventListener('click', function() {
+			document.querySelectorAll('.un-dm-overlay-btn').forEach(function(b) { b.classList.remove('un-active'); });
+			btn.classList.add('un-active');
+			gid('un-dm-hero-overlay').value = btn.dataset.overlay;
+		});
+	});
+
+	function unLoadFont(key) {
+		if (!key) return;
+		if (document.querySelector('link[data-un-font="' + key + '"]')) return;
+		var link = document.createElement('link');
+		link.rel = 'stylesheet';
+		link.href = 'https://fonts.googleapis.com/css2?family=' + key.replace(/ /g, '+') + '&display=swap';
+		link.setAttribute('data-un-font', key);
+		document.head.appendChild(link);
+	}
+	function unRenderFontPicker() {
+		var container = gid('un-dm-font-picker');
+		var sample = <?= json_encode($_name) ?>;
+		var html = '';
+		for (var i = 0; i < UN_FONTS.length; i++) {
+			var f = UN_FONTS[i];
+			var active = f.key === unSelectedFont;
+			html += '<div class="un-dm-font-card' + (active ? ' un-active' : '') + '" data-font-key="' + esc(f.key) + '">'
+				 +    '<div class="un-dm-font-sample" style="font-family:' + f.family + '">' + esc(sample) + '</div>'
+				 +    '<div class="un-dm-font-label">' + esc(f.label) + '</div>'
+				 + '</div>';
+			unLoadFont(f.key);
+		}
+		container.innerHTML = html;
+		container.addEventListener('click', function(e) {
+			var card = e.target.closest('.un-dm-font-card');
+			if (!card) return;
+			unSelectedFont = card.dataset.fontKey;
+			container.querySelectorAll('.un-dm-font-card').forEach(function(c) {
+				c.classList.toggle('un-active', c === card);
+			});
+		});
+	}
+	unRenderFontPicker();
+
+	document.querySelectorAll('[data-unmd-target]').forEach(function(btn) {
+		btn.addEventListener('click', function() {
+			var field  = btn.dataset.unmdField;
+			var target = btn.dataset.unmdTarget;
+			var taId   = field === 'about' ? 'un-dm-about-text' : (field === 'history' ? 'un-dm-history-text' : 'un-dm-howto-text');
+			var ta     = gid(taId);
+			var pv     = gid('un-dm-' + field + '-preview');
+			btn.parentElement.querySelectorAll('button').forEach(function(b) { b.classList.remove('un-active'); });
+			btn.classList.add('un-active');
+			if (target === 'preview') {
+				ta.style.display = 'none';
+				pv.style.display = '';
+				if (typeof marked !== 'undefined' && typeof DOMPurify !== 'undefined') {
+					pv.innerHTML = DOMPurify.sanitize(marked.parse(ta.value || ''));
+				} else {
+					pv.textContent = ta.value;
+				}
+			} else {
+				ta.style.display = '';
+				pv.style.display = 'none';
+			}
+		});
+	});
+
+	function renderCustomMsList() {
+		var list = gid('un-dm-ms-list');
+		if (!list) return;
+		var newestFirst = gid('un-dm-ms-newest-first').checked;
+		customMs.sort(function(a, b) {
+			var ad = a.MilestoneDate || '', bd = b.MilestoneDate || '';
+			return newestFirst ? bd.localeCompare(ad) : ad.localeCompare(bd);
+		});
+		if (customMs.length === 0) {
+			list.innerHTML = '<div style="padding:14px;font-size:12px;color:#a0aec0">No custom milestones yet.</div>';
+			return;
+		}
+		var html = '';
+		for (var i = 0; i < customMs.length; i++) {
+			var m = customMs[i];
+			var dateStr = m.MilestoneDate || '';
+			if (dateStr && dateStr !== '0000-00-00') {
+				var d = new Date(dateStr + 'T00:00:00');
+				if (!isNaN(d.getTime())) dateStr = d.toLocaleDateString('en-US', { month:'short', day:'numeric', year:'numeric' });
+			}
+			var icon = (m.Icon || 'fa-star').replace(/[^a-z0-9-]/g, '');
+			html += '<div class="un-dm-ms-row" data-ms-id="' + m.MilestoneId + '">'
+				 +    '<i class="fas ' + icon + '"></i>'
+				 +    '<span class="un-dm-ms-desc">' + esc(m.Description) + '</span>'
+				 +    '<span class="un-dm-ms-date">' + dateStr + '</span>'
+				 +    '<button type="button" data-tip="Delete" onclick="unDeleteUnitMilestone(' + m.MilestoneId + ')"><i class="fas fa-trash"></i></button>'
+				 + '</div>';
+		}
+		list.innerHTML = html;
+	}
+	gid('un-dm-ms-newest-first').addEventListener('change', renderCustomMsList);
+
+	var iconGrid = gid('un-dm-ms-icons');
+	iconGrid.addEventListener('click', function(e) {
+		var opt = e.target.closest('.un-dm-ms-icon-opt');
+		if (!opt) return;
+		iconGrid.querySelectorAll('.un-dm-ms-icon-opt').forEach(function(o) { o.classList.remove('un-active'); });
+		opt.classList.add('un-active');
+		unSelectedIcon = opt.dataset.icon;
+	});
+
+	gid('un-dm-ms-add-btn').addEventListener('click', function() {
+		var desc = gid('un-dm-ms-add-desc').value.trim();
+		var date = gid('un-dm-ms-add-date').value;
+		var err  = gid('un-dm-ms-add-err');
+		err.style.display = 'none';
+		if (!desc) { err.textContent = 'Description is required.'; err.style.display = ''; return; }
+		if (!date) { err.textContent = 'Date is required.'; err.style.display = ''; return; }
+		var btn = this; btn.disabled = true; btn.innerHTML = '<i class="fas fa-spinner fa-spin"></i>';
+		var fd = new FormData();
+		fd.append('Action', 'add_milestone');
+		fd.append('Description', desc);
+		fd.append('MilestoneDate', date);
+		fd.append('Icon', unSelectedIcon);
+		fetch(BASE_URL, { method: 'POST', body: fd })
+			.then(function(r) { return r.json(); })
+			.then(function(result) {
+				if (result && result.status === 0) {
+					customMs.push({
+						MilestoneId: result.milestoneId,
+						Icon: unSelectedIcon,
+						Description: desc,
+						MilestoneDate: date
+					});
+					renderCustomMsList();
+					gid('un-dm-ms-add-desc').value = '';
+					gid('un-dm-ms-add-date').value = '';
+					iconGrid.querySelectorAll('.un-dm-ms-icon-opt').forEach(function(o) { o.classList.remove('un-active'); });
+					iconGrid.querySelector('[data-icon="fa-star"]').classList.add('un-active');
+					unSelectedIcon = 'fa-star';
+				} else {
+					err.textContent = (result && result.error) || 'Failed to add milestone.';
+					err.style.display = '';
+				}
+			})
+			.catch(function() { err.textContent = 'Request failed.'; err.style.display = ''; })
+			.finally(function() {
+				btn.disabled = false;
+				btn.innerHTML = '<i class="fas fa-plus"></i> Add';
+			});
+	});
+
+	window.unDeleteUnitMilestone = function(id) {
+		if (!confirm('Delete this milestone?')) return;
+		var fd = new FormData();
+		fd.append('Action', 'delete_milestone');
+		fd.append('MilestoneId', id);
+		fetch(BASE_URL, { method: 'POST', body: fd })
+			.then(function(r) { return r.json(); })
+			.then(function(result) {
+				if (result && result.status === 0) {
+					customMs = customMs.filter(function(m) { return m.MilestoneId !== id; });
+					renderCustomMsList();
+				} else {
+					alert((result && result.error) || 'Failed to delete milestone.');
+				}
+			})
+			.catch(function() { alert('Request failed.'); });
+	};
+
+	(function(){
+		var taglineEl = gid('un-dm-tagline'), tCount = gid('un-dm-tagline-count');
+		if (taglineEl && tCount) taglineEl.addEventListener('input', function(){ tCount.textContent = taglineEl.value.length; });
+		var annEl = gid('un-dm-announcement'), aCount = gid('un-dm-announcement-count');
+		if (annEl && aCount) annEl.addEventListener('input', function(){ aCount.textContent = annEl.value.length; });
+		var recruitRow = gid('un-dm-recruit-row');
+		if (recruitRow) {
+			recruitRow.addEventListener('click', function(e){
+				var btn = e.target.closest('.un-dm-recruit-opt');
+				if (!btn) return;
+				recruitRow.querySelectorAll('.un-dm-recruit-opt').forEach(function(b){ b.classList.remove('un-active'); });
+				btn.classList.add('un-active');
+				gid('un-dm-recruitment-status').value = btn.dataset.recruit || '';
+			});
+		}
+	})();
+
+	gid('un-dm-save').addEventListener('click', function() {
+		var btn = this; btn.disabled = true; btn.innerHTML = '<i class="fas fa-spinner fa-spin"></i> Saving...';
+		var errEl = gid('un-dm-error'); errEl.style.display = 'none';
+		var fd = new FormData();
+		fd.append('Action', 'save_design');
+		fd.append('AboutText', gid('un-dm-about-text').value);
+		fd.append('OurHistory', gid('un-dm-history-text').value);
+		fd.append('ColorPrimary', gid('un-dm-color-primary').value);
+		fd.append('ColorAccent', gid('un-dm-color-accent').value);
+		fd.append('ColorSecondary', gid('un-dm-gradient-enabled').checked ? gid('un-dm-color-secondary').value : '');
+		fd.append('HeroOverlay', gid('un-dm-hero-overlay').value);
+		fd.append('NameFont', unSelectedFont || '');
+		var msConfig = {};
+		document.querySelectorAll('#un-dm-ms-toggles input[data-unms-type]').forEach(function(t) {
+			msConfig[t.dataset.unmsType] = t.checked ? 1 : 0;
+		});
+		msConfig['newest_first'] = gid('un-dm-ms-newest-first').checked ? 1 : 0;
+		fd.append('MilestoneConfig', JSON.stringify(msConfig));
+		fd.append('Tagline', gid('un-dm-tagline') ? gid('un-dm-tagline').value : '');
+		fd.append('Announcement', gid('un-dm-announcement') ? gid('un-dm-announcement').value : '');
+		fd.append('AnnouncementUntil', gid('un-dm-announcement-until') ? gid('un-dm-announcement-until').value : '');
+		fd.append('RecruitmentStatus', gid('un-dm-recruitment-status') ? gid('un-dm-recruitment-status').value : '');
+		fd.append('HowToJoin', gid('un-dm-howto-text') ? gid('un-dm-howto-text').value : '');
+		var social = {};
+		document.querySelectorAll('[data-un-social]').forEach(function(inp){
+			var v = inp.value.trim();
+			if (v !== '') social[inp.dataset.unSocial] = v;
+		});
+		fd.append('SocialLinks', JSON.stringify(social));
+
+		fetch(BASE_URL, { method: 'POST', body: fd })
+			.then(function(r) { return r.json(); })
+			.then(function(result) {
+				if (result && result.status === 0) {
+					window.location.reload();
+				} else {
+					errEl.textContent = (result && result.error) || 'Save failed.';
+					errEl.style.display = 'block';
+					btn.disabled = false;
+					btn.innerHTML = '<i class="fas fa-save"></i> Save Changes';
+				}
+			})
+			.catch(function(e) {
+				errEl.textContent = 'Request failed: ' + e.message;
+				errEl.style.display = 'block';
+				btn.disabled = false;
+				btn.innerHTML = '<i class="fas fa-save"></i> Save Changes';
+			});
+	});
+
+	renderCustomMsList();
+})();
+</script>
+<?php endif; ?>

--- a/orkui/template/revised-frontend/Kingdomnew_index.tpl
+++ b/orkui/template/revised-frontend/Kingdomnew_index.tpl
@@ -60,14 +60,475 @@
 			'desc'     => kn_map_markdown($p['Description'] ?? ''),
 		];
 	}
+
+	// --- Kingdom Design (header, About, Milestones customization) -------------------
+	$_kInfo         = $kingdom_info['Info']['KingdomInfo'] ?? [];
+	$aboutText      = (string)($_kInfo['AboutText']  ?? '');
+	$ourHistoryText = (string)($_kInfo['OurHistory'] ?? '');
+	$_knLegacyDesc  = (string)($_kInfo['Description'] ?? '');
+	if (trim($aboutText) === '') { $aboutText = $_knLegacyDesc; }
+
+	$knColorPrimary   = trim((string)($_kInfo['ColorPrimary']   ?? ''));
+	$knColorAccent    = trim((string)($_kInfo['ColorAccent']    ?? ''));
+	$knColorSecondary = trim((string)($_kInfo['ColorSecondary'] ?? ''));
+	$knOverlay        = strtolower(trim((string)($_kInfo['HeroOverlay'] ?? 'med')));
+	if (!in_array($knOverlay, ['low','med','high','vignette'], true)) $knOverlay = 'med';
+	$knNameFont       = trim((string)($_kInfo['NameFont'] ?? ''));
+	$knMilestoneCfg   = [];
+	if (!empty($_kInfo['MilestoneConfig'])) {
+		$_mc = json_decode($_kInfo['MilestoneConfig'], true);
+		if (is_array($_mc)) $knMilestoneCfg = $_mc;
+	}
+	$knMsVisible = function($type) use ($knMilestoneCfg) {
+		if (!array_key_exists($type, $knMilestoneCfg)) return true;
+		return !empty($knMilestoneCfg[$type]);
+	};
+	$knMsNewestFirst = !empty($knMilestoneCfg['newest_first']);
+
+	$knAllMilestones     = is_array($Milestones ?? null) ? $Milestones : [];
+	$knVisibleMilestones = [];
+	foreach ($knAllMilestones as $_knms) {
+		$_t = $_knms['Type'] ?? 'custom';
+		if ($knMsVisible($_t)) $knVisibleMilestones[] = $_knms;
+	}
+	if ($knMsNewestFirst) $knVisibleMilestones = array_reverse($knVisibleMilestones);
+	$knHasMilestones = count($knVisibleMilestones) > 0;
+
+	$knHeroFontCss    = $knNameFont !== '' ? ("'" . str_replace("'", '', $knNameFont) . "'") : '';
+	$knOverlayOpacity = ['low' => 0.06, 'med' => 0.13, 'high' => 0.28, 'vignette' => 0.45][$knOverlay] ?? 0.13;
+
+	// --- Phase 2 extras: tagline, social links, announcement, reign banner ---
+	$knTagline         = trim((string)($_kInfo['Tagline'] ?? ''));
+	$_knSocialRaw      = trim((string)($_kInfo['SocialLinks'] ?? ''));
+	$knSocialLinks     = [];
+	if ($_knSocialRaw !== '') {
+		$_dec = json_decode($_knSocialRaw, true);
+		if (is_array($_dec)) $knSocialLinks = $_dec;
+	}
+	$KN_SOCIAL_PLATFORMS = [
+		'discord'   => ['label' => 'Discord',   'icon' => 'fab fa-discord',   'bg' => '#5865f2', 'placeholder' => 'https://discord.gg/...'],
+		'facebook'  => ['label' => 'Facebook',  'icon' => 'fab fa-facebook',  'bg' => '#1877f2', 'placeholder' => 'https://facebook.com/...'],
+		'instagram' => ['label' => 'Instagram', 'icon' => 'fab fa-instagram', 'bg' => 'linear-gradient(135deg,#f09433,#e6683c,#dc2743,#cc2366,#bc1888)', 'placeholder' => 'https://instagram.com/...'],
+		'threads'   => ['label' => 'Threads',   'icon' => 'fab fa-threads',   'bg' => '#000000', 'placeholder' => 'https://threads.net/...'],
+		'bluesky'   => ['label' => 'Bluesky',   'icon' => 'fas fa-cloud',     'bg' => '#1185fe', 'placeholder' => 'https://bsky.app/...'],
+		'twitter'   => ['label' => 'X',         'icon' => 'fab fa-x-twitter', 'bg' => '#000000', 'placeholder' => 'https://x.com/...'],
+		'youtube'   => ['label' => 'YouTube',   'icon' => 'fab fa-youtube',   'bg' => '#ff0000', 'placeholder' => 'https://youtube.com/...'],
+		'amtwiki'   => ['label' => 'AmtWiki',   'icon' => 'fas fa-book',      'bg' => '#6b7280', 'placeholder' => 'https://amtwiki.net/...'],
+	];
+	$knVisibleSocials = [];
+	foreach ($KN_SOCIAL_PLATFORMS as $_slug => $_meta) {
+		$_u = trim((string)($knSocialLinks[$_slug] ?? ''));
+		if ($_u !== '') $knVisibleSocials[$_slug] = $_u;
+	}
+
+	$knAnnouncement       = trim((string)($_kInfo['Announcement'] ?? ''));
+	$knAnnouncementUntil  = trim((string)($_kInfo['AnnouncementUntil'] ?? ''));
+	$knShowAnnouncement   = false;
+	if ($knAnnouncement !== '') {
+		if ($knAnnouncementUntil === '' || $knAnnouncementUntil === '0000-00-00') {
+			$knShowAnnouncement = true;
+		} else {
+			$knShowAnnouncement = (strtotime($knAnnouncementUntil) !== false && strtotime($knAnnouncementUntil) >= strtotime(date('Y-m-d')));
+		}
+	}
+
+	$knMonarchReignStarted = trim((string)($_kInfo['MonarchReignStarted'] ?? ''));
+	$knRegentReignStarted  = trim((string)($_kInfo['RegentReignStarted']  ?? ''));
+	$knReignLore           = (string)($_kInfo['ReignLore'] ?? '');
+	$knHasReignContent     = ($monarch && !empty($monarch['MundaneId'])) || ($regent && !empty($regent['MundaneId'])) || trim($knReignLore) !== '';
+
+	if (!function_exists('kn_reign_avatar_url')) {
+		function kn_reign_avatar_url($mundaneId): string {
+			if ((int)$mundaneId <= 0) return '';
+			return HTTP_PLAYER_IMAGE . Common::resolve_image_ext(DIR_PLAYER_IMAGE, sprintf('%06d', (int)$mundaneId));
+		}
+	}
+
+	if (!function_exists('kn_markdown')) {
+		function kn_markdown(string $text): string {
+			$html = (new Parsedown())->setSafeMode(true)->setBreaksEnabled(true)->text($text);
+			return preg_replace('/<img[^>]*>/i', '', $html);
+		}
+	}
 ?>
 
 <link rel="stylesheet" href="<?= HTTP_TEMPLATE ?>revised-frontend/style/revised.css?v=<?= filemtime(DIR_TEMPLATE . 'revised-frontend/style/revised.css') ?>">
 <link rel="stylesheet" href="https://cdn.datatables.net/1.13.8/css/jquery.dataTables.min.css">
 
+<?php if ($knNameFont !== ''): ?>
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=<?= rawurlencode($knNameFont) ?>&display=swap">
+<?php endif; ?>
+
+<style>
+/* --- Kingdom Design: hero customization ------------------------------------- */
+<?php if ($knColorPrimary): ?>
+.kn-hero {
+	background-color: <?= htmlspecialchars($knColorPrimary) ?> !important;
+<?php if ($knColorSecondary && $knColorSecondary !== $knColorPrimary): ?>
+	background: linear-gradient(135deg, <?= htmlspecialchars($knColorPrimary) ?>, <?= htmlspecialchars($knColorSecondary) ?>) !important;
+<?php endif; ?>
+}
+html[data-theme="dark"] .kn-hero {
+	background-color: <?= htmlspecialchars($knColorPrimary) ?> !important;
+<?php if ($knColorSecondary && $knColorSecondary !== $knColorPrimary): ?>
+	background: linear-gradient(135deg, <?= htmlspecialchars($knColorPrimary) ?>, <?= htmlspecialchars($knColorSecondary) ?>) !important;
+<?php endif; ?>
+	filter: brightness(0.85);
+}
+<?php endif; ?>
+<?php if ($knColorAccent): ?>
+:root { --kn-accent: <?= htmlspecialchars($knColorAccent) ?>; }
+.kn-tab-nav li.kn-tab-active { color: <?= htmlspecialchars($knColorAccent) ?> !important; border-bottom-color: <?= htmlspecialchars($knColorAccent) ?> !important; }
+html[data-theme="dark"] .kn-tab-nav li.kn-tab-active { color: <?= htmlspecialchars($knColorAccent) ?> !important; border-bottom-color: <?= htmlspecialchars($knColorAccent) ?> !important; }
+.kn-stat-card { position: relative; }
+.kn-stat-card::before {
+	content: ''; position: absolute; top: 0; left: 0; right: 0; height: 3px;
+	background: <?= htmlspecialchars($knColorAccent) ?>;
+	border-top-left-radius: 8px; border-top-right-radius: 8px;
+}
+.kn-parent-kingdom-link a i { color: <?= htmlspecialchars($knColorAccent) ?>; }
+.kn-link-list .kn-link-icon i { color: <?= htmlspecialchars($knColorAccent) ?>; }
+<?php endif; ?>
+.kn-hero-bg { opacity: <?= $knOverlayOpacity ?> !important; }
+<?php if ($knOverlay === 'vignette'): ?>
+.kn-hero-bg {
+	-webkit-mask-image: radial-gradient(ellipse at center, rgba(0,0,0,0.95) 38%, rgba(0,0,0,0) 78%);
+	        mask-image: radial-gradient(ellipse at center, rgba(0,0,0,0.95) 38%, rgba(0,0,0,0) 78%);
+}
+<?php endif; ?>
+<?php if ($knNameFont !== '' && $knHeroFontCss !== ''): ?>
+.kn-kingdom-name { font-family: <?= $knHeroFontCss ?>, 'Cinzel', serif !important; letter-spacing: 0.02em; }
+<?php endif; ?>
+
+/* --- Kingdom Design: About markdown body + Our History + Milestones --------- */
+.kn-about-text { line-height: 1.6; }
+.kn-about-text h1, .kn-about-text h2, .kn-about-text h3, .kn-about-text h4 {
+	margin-top: 1.1em; margin-bottom: 0.4em;
+	background: transparent; border: none; padding: 0; border-radius: 0; text-shadow: none;
+}
+.kn-about-section-head {
+	display: flex; align-items: center; justify-content: space-between;
+	gap: 8px; margin-bottom: 6px;
+}
+.kn-about-edit-btn {
+	background: transparent; border: 1px solid transparent; color: #a0aec0;
+	padding: 4px 8px; border-radius: 6px; cursor: pointer; font-size: 12px;
+	display: inline-flex; align-items: center; gap: 4px;
+	transition: background 0.15s, color 0.15s, border-color 0.15s;
+}
+.kn-about-edit-btn:hover { background: rgba(49,130,206,0.08); color: #2b6cb0; border-color: rgba(49,130,206,0.25); }
+html[data-theme="dark"] .kn-about-edit-btn { color: var(--ork-text-muted); }
+html[data-theme="dark"] .kn-about-edit-btn:hover { background: var(--ork-bg-tertiary); color: var(--ork-link); border-color: var(--ork-border); }
+.kn-about-edit-btn[data-tip] { position: relative; }
+.kn-about-edit-btn[data-tip]::after {
+	content: attr(data-tip); position: absolute; bottom: calc(100% + 6px); right: 0;
+	background: #2d3748; color: #fff; font-size: 11px; font-style: italic; white-space: nowrap;
+	padding: 4px 10px; border-radius: 4px; pointer-events: none; opacity: 0;
+	transition: opacity 0s; z-index: 500;
+}
+.kn-about-edit-btn[data-tip]:hover::after { opacity: 1; transition-delay: 0.4s; }
+html[data-theme="dark"] .kn-about-edit-btn[data-tip]::after { background: var(--ork-bg-tertiary); color: var(--ork-text); border: 1px solid var(--ork-border); }
+
+/* Our History — visually distinct from About */
+.kn-history-card .kn-bare-heading i.kn-history-icon { color: #a0aec0; }
+.kn-history-body { line-height: 1.6; }
+.kn-history-body h1, .kn-history-body h2, .kn-history-body h3, .kn-history-body h4 {
+	margin-top: 1.1em; margin-bottom: 0.4em;
+	background: transparent; border: none; padding: 0; border-radius: 0; text-shadow: none;
+}
+
+/* Milestones timeline (mirrors player .pn-timeline-* / park .pk-timeline-*) */
+.kn-timeline-heading {
+	font-size: 13px; font-weight: 700; color: #4a5568;
+	text-transform: uppercase; letter-spacing: 0.5px;
+	margin: 0 0 14px 0;
+	background: transparent; border: none; padding: 0; border-radius: 0; text-shadow: none;
+	display: flex; align-items: center; gap: 8px;
+}
+html[data-theme="dark"] .kn-timeline-heading { color: var(--ork-text-secondary); }
+.kn-timeline { position: relative; padding-left: 32px; }
+.kn-timeline::before {
+	content: ''; position: absolute; left: 11px; top: 4px; bottom: 4px; width: 2px;
+	background: linear-gradient(to bottom, #cbd5e0, #cbd5e0 60%, transparent);
+}
+html[data-theme="dark"] .kn-timeline::before { background: linear-gradient(to bottom, var(--ork-border), var(--ork-border) 60%, transparent); }
+.kn-timeline-row {
+	position: relative; display: flex; align-items: center; gap: 12px;
+	margin-bottom: 14px; min-height: 24px;
+}
+.kn-timeline-dot {
+	position: absolute; left: -25px; top: 50%; transform: translateY(-50%);
+	width: 24px; height: 24px; border-radius: 50%;
+	background: #ebf8ff; color: #2b6cb0; display: flex; align-items: center; justify-content: center;
+	font-size: 11px; border: 2px solid #fff; box-shadow: 0 0 0 1px #cbd5e0;
+}
+.kn-timeline-row.kn-ms-derived .kn-timeline-dot { background: #faf5ff; color: #6b46c1; box-shadow: 0 0 0 1px #d6bcfa; }
+html[data-theme="dark"] .kn-timeline-dot { background: var(--ork-bg-tertiary); color: var(--ork-link); border-color: var(--ork-card-bg); box-shadow: 0 0 0 1px var(--ork-border); }
+.kn-timeline-content {
+	flex: 1; display: flex; align-items: baseline; gap: 10px; flex-wrap: wrap;
+	font-size: 13px;
+}
+.kn-timeline-date { color: #718096; font-size: 11px; font-weight: 600; min-width: 80px; }
+html[data-theme="dark"] .kn-timeline-date { color: var(--ork-text-muted); }
+.kn-timeline-desc { color: #2d3748; }
+html[data-theme="dark"] .kn-timeline-desc { color: var(--ork-text); }
+.kn-timeline-row.kn-ms-derived .kn-timeline-desc { color: #553c9a; }
+html[data-theme="dark"] .kn-timeline-row.kn-ms-derived .kn-timeline-desc { color: hsl(265, 60%, 75%); }
+.kn-timeline-empty {
+	font-size: 12px; color: #a0aec0; font-style: italic;
+	padding: 10px 0;
+}
+
+/* --- Kingdom About Tab: in-tab layout for About/History/Milestones/Meta ----- */
+.kn-about-grid { display: block; }
+.kn-about-section {
+	background: #fff; border: 1px solid #e2e8f0; border-radius: 8px;
+	padding: 16px 18px; margin-bottom: 14px;
+}
+html[data-theme="dark"] .kn-about-section {
+	background: var(--ork-card-bg, #2d3748);
+	border-color: var(--ork-border, #4a5568);
+	color: var(--ork-text, #e2e8f0);
+}
+.kn-about-label {
+	font-size: 13px; font-weight: 700; color: #4a5568;
+	text-transform: uppercase; letter-spacing: 0.5px;
+	display: flex; align-items: center;
+}
+html[data-theme="dark"] .kn-about-label { color: var(--ork-text-secondary); }
+
+/* Section variants get a soft dashed top divider when stacked */
+.kn-history-section { margin-top: 14px; }
+.kn-timeline-section { margin-top: 14px; }
+
+/* Meta row (website / parent kingdom) */
+.kn-about-meta { padding: 12px 18px; }
+.kn-about-meta-row {
+	display: flex; align-items: center; gap: 8px;
+	font-size: 13px; color: #4a5568; padding: 4px 0;
+}
+.kn-about-meta-row i { color: #a0aec0; width: 16px; text-align: center; }
+.kn-about-meta-row a { color: #2b6cb0; text-decoration: none; }
+.kn-about-meta-row a:hover { text-decoration: underline; }
+html[data-theme="dark"] .kn-about-meta-row { color: var(--ork-text); }
+html[data-theme="dark"] .kn-about-meta-row i { color: var(--ork-text-muted); }
+html[data-theme="dark"] .kn-about-meta-row a { color: var(--ork-link); }
+
+/* --- Phase 2: tagline ---------------------------------------------------- */
+.kn-tagline {
+	margin: 4px 0 6px 0;
+	font-size: 15px;
+	font-style: italic;
+	color: #e2e8f0;
+	text-shadow: 0 1px 2px rgba(0,0,0,0.4);
+	line-height: 1.35;
+	max-width: 60ch;
+}
+
+/* --- Phase 2: announcement banner --------------------------------------- */
+.kn-announce {
+	background: linear-gradient(90deg, #fef3c7, #fde68a);
+	border-bottom: 2px solid #f59e0b;
+	color: #78350f;
+	padding: 10px 18px;
+	display: flex; align-items: center; gap: 12px;
+	font-size: 14px; line-height: 1.4;
+}
+.kn-announce i.kn-announce-icon {
+	font-size: 18px; color: #b45309; flex-shrink: 0;
+}
+.kn-announce-body { flex: 1; }
+.kn-announce-body strong { color: #78350f; margin-right: 6px; }
+.kn-announce-until { font-size: 11px; color: #92400e; opacity: 0.85; white-space: nowrap; }
+html[data-theme="dark"] .kn-announce {
+	background: linear-gradient(90deg, rgba(245,158,11,0.22), rgba(245,158,11,0.32));
+	border-bottom-color: #d97706;
+	color: #fde68a;
+}
+html[data-theme="dark"] .kn-announce i.kn-announce-icon { color: #fbbf24; }
+html[data-theme="dark"] .kn-announce-body strong { color: #fef3c7; }
+html[data-theme="dark"] .kn-announce-until { color: #fbbf24; }
+
+/* --- Phase 2: Connect (sidebar) — flat accent pills --------------------- */
+.kn-connect-block { margin-top: 14px; padding-top: 12px; border-top: 1px dashed #e2e8f0; }
+html[data-theme="dark"] .kn-connect-block { border-top-color: var(--ork-border); }
+.kn-connect-subhead {
+	display: flex; align-items: center; justify-content: space-between;
+	font-size: 11px; text-transform: uppercase; letter-spacing: 0.08em;
+	color: #718096; font-weight: 600; margin-bottom: 8px;
+}
+html[data-theme="dark"] .kn-connect-subhead { color: var(--ork-text-muted); }
+.kn-connect-subhead i { margin-right: 4px; opacity: 0.6; }
+.kn-connect-edit {
+	background: transparent; border: 0; cursor: pointer; color: #a0aec0; font-size: 11px; padding: 2px 6px; border-radius: 4px;
+}
+.kn-connect-edit:hover { background: rgba(49,130,206,0.08); color: #2b6cb0; }
+html[data-theme="dark"] .kn-connect-edit:hover { background: var(--ork-bg-tertiary); color: var(--ork-link); }
+.kn-connect-pills { display: flex; flex-wrap: wrap; gap: 8px; }
+.kn-connect-pill {
+	width: 34px; height: 34px; border-radius: 50%;
+	display: inline-flex; align-items: center; justify-content: center;
+	color: #fff !important; text-decoration: none !important;
+	font-size: 14px; line-height: 1;
+	background: var(--kn-accent, #2b6cb0);
+	transition: transform 0.12s, box-shadow 0.12s;
+	position: relative;
+}
+.kn-connect-pill:hover { transform: scale(1.08); box-shadow: 0 3px 10px rgba(0,0,0,0.18); }
+.kn-connect-pill[data-tip]::after {
+	content: attr(data-tip); position: absolute; bottom: calc(100% + 6px); left: 50%; transform: translateX(-50%);
+	background: #2d3748; color: #fff; font-size: 11px; white-space: nowrap;
+	padding: 3px 8px; border-radius: 4px; pointer-events: none; opacity: 0;
+	transition: opacity 0.12s; z-index: 600;
+}
+.kn-connect-pill[data-tip]:hover::after { opacity: 1; transition-delay: 0.3s; }
+html[data-theme="dark"] .kn-connect-pill[data-tip]::after {
+	background: var(--ork-bg-tertiary); color: var(--ork-text); border: 1px solid var(--ork-border);
+}
+.kn-connect-empty {
+	display: inline-flex; font-size: 11px; color: #a0aec0; text-decoration: none;
+	padding: 4px 8px; border: 1px dashed #cbd5e0; border-radius: 999px;
+}
+.kn-connect-empty:hover { color: #2b6cb0; border-color: #2b6cb0; }
+html[data-theme="dark"] .kn-connect-empty { color: var(--ork-text-muted); border-color: var(--ork-border); }
+
+/* --- Phase 2: reign banner ---------------------------------------------- */
+.kn-reign-banner {
+	background: linear-gradient(135deg, #faf089 0%, #f6ad55 60%, #c05621 100%);
+	border: 1px solid #b7791f; border-radius: 10px;
+	padding: 14px 16px; margin-bottom: 14px;
+	color: #1a202c;
+	position: relative; overflow: hidden;
+}
+.kn-reign-banner::before {
+	content: ''; position: absolute; inset: 0;
+	background: radial-gradient(circle at top right, rgba(255,255,255,0.18), transparent 60%);
+	pointer-events: none;
+}
+.kn-reign-head {
+	display: flex; align-items: center; gap: 8px;
+	font-size: 12px; font-weight: 700;
+	text-transform: uppercase; letter-spacing: 0.6px;
+	color: #744210;
+	margin-bottom: 10px;
+	position: relative;
+}
+.kn-reign-head i { color: #b7791f; font-size: 14px; }
+.kn-reign-grid {
+	display: grid; grid-template-columns: 1fr 1fr; gap: 12px;
+	position: relative;
+}
+@media (max-width: 640px) { .kn-reign-grid { grid-template-columns: 1fr; } }
+.kn-reign-card {
+	display: flex; align-items: center; gap: 12px;
+	background: rgba(255,255,255,0.78);
+	border: 1px solid rgba(116, 66, 16, 0.25);
+	border-radius: 8px;
+	padding: 10px 12px;
+	text-decoration: none;
+	color: #2d3748;
+	transition: background 0.15s, transform 0.12s;
+}
+.kn-reign-card:hover { background: rgba(255,255,255,0.92); transform: translateY(-1px); }
+.kn-reign-avatar {
+	width: 64px; height: 64px; border-radius: 50%;
+	object-fit: cover; border: 2px solid #fff; box-shadow: 0 1px 4px rgba(0,0,0,0.15);
+	background: #cbd5e0; flex-shrink: 0;
+}
+.kn-reign-card-body { flex: 1; min-width: 0; }
+.kn-reign-role {
+	font-size: 10px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.5px;
+	color: #744210; opacity: 0.85;
+}
+.kn-reign-name {
+	font-size: 15px; font-weight: 600; color: #1a202c;
+	line-height: 1.2; margin-top: 2px;
+	white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
+.kn-reign-since {
+	font-size: 11px; color: #5c4309; opacity: 0.8; margin-top: 3px;
+}
+.kn-reign-lore {
+	margin-top: 12px; position: relative;
+	background: rgba(255,255,255,0.65);
+	border-left: 3px solid #b7791f;
+	padding: 8px 12px;
+	border-radius: 4px;
+	font-size: 13px; color: #2d3748;
+}
+.kn-reign-empty {
+	position: relative;
+	font-size: 12px; color: #5c4309; font-style: italic;
+	padding: 6px 0;
+}
+html[data-theme="dark"] .kn-reign-banner {
+	background: linear-gradient(135deg, #744210 0%, #7c2d12 60%, #4a1d0f 100%);
+	border-color: #b7791f;
+	color: #fef3c7;
+}
+html[data-theme="dark"] .kn-reign-head { color: #fbbf24; }
+html[data-theme="dark"] .kn-reign-head i { color: #fbd38d; }
+html[data-theme="dark"] .kn-reign-card {
+	background: rgba(26, 32, 44, 0.65);
+	border-color: rgba(251, 191, 36, 0.3);
+	color: var(--ork-text);
+}
+html[data-theme="dark"] .kn-reign-card:hover { background: rgba(26, 32, 44, 0.85); }
+html[data-theme="dark"] .kn-reign-role { color: #fbd38d; }
+html[data-theme="dark"] .kn-reign-name { color: var(--ork-text); }
+html[data-theme="dark"] .kn-reign-since { color: #fbbf24; opacity: 0.85; }
+html[data-theme="dark"] .kn-reign-lore {
+	background: rgba(26, 32, 44, 0.55);
+	color: var(--ork-text);
+	border-left-color: #fbbf24;
+}
+html[data-theme="dark"] .kn-reign-empty { color: #fbd38d; }
+
+/* --- Phase 2: design modal extras (social inputs etc.) ------------------ */
+.kn-dm-social-row {
+	display: grid; grid-template-columns: 110px 1fr; gap: 8px; align-items: center;
+	padding: 5px 0; border-bottom: 1px solid #edf2f7;
+}
+.kn-dm-social-row:last-child { border-bottom: none; }
+html[data-theme="dark"] .kn-dm-social-row { border-bottom-color: var(--ork-border); }
+.kn-dm-social-label {
+	display: flex; align-items: center; gap: 6px;
+	font-size: 12px; font-weight: 600; color: #4a5568;
+}
+html[data-theme="dark"] .kn-dm-social-label { color: var(--ork-text-secondary); }
+.kn-dm-social-icon-chip {
+	width: 22px; height: 22px; border-radius: 50%;
+	display: inline-flex; align-items: center; justify-content: center;
+	color: #fff; font-size: 11px;
+}
+.kn-dm-social-row input[type="url"] {
+	width: 100%; padding: 6px 8px; font-size: 12px;
+	border: 1px solid #cbd5e0; border-radius: 4px;
+	background: #fff; color: #2d3748;
+}
+html[data-theme="dark"] .kn-dm-social-row input[type="url"] {
+	background: var(--ork-bg-tertiary); border-color: var(--ork-border); color: var(--ork-text);
+}
+
+.kn-dm-counter {
+	font-size: 11px; color: #718096; text-align: right; margin-top: 4px;
+}
+html[data-theme="dark"] .kn-dm-counter { color: var(--ork-text-muted); }
+.kn-dm-counter.kn-over { color: #c53030; font-weight: 600; }
+</style>
+
 <!-- =============================================
      ZONE 1: Hero Header
      ============================================= -->
+<?php if ($knShowAnnouncement): ?>
+<div class="kn-announce" role="status">
+	<i class="fas fa-bullhorn kn-announce-icon"></i>
+	<div class="kn-announce-body"><strong>Announcement:</strong><?= htmlspecialchars($knAnnouncement) ?></div>
+	<?php if ($knAnnouncementUntil !== '' && $knAnnouncementUntil !== '0000-00-00'): ?>
+	<div class="kn-announce-until">Until <?= date('M j, Y', strtotime($knAnnouncementUntil)) ?></div>
+	<?php endif; ?>
+</div>
+<?php endif; ?>
 <div class="kn-hero">
 	<div class="kn-hero-bg" style="background-image: url('<?= htmlspecialchars($heraldryUrl) ?>')"></div>
 	<div class="kn-hero-content">
@@ -95,6 +556,9 @@
 			</div>
 			<?php endif; ?>
 			<h1 class="kn-kingdom-name"><?= htmlspecialchars($kingdom_name) ?></h1>
+			<?php if ($knTagline !== ''): ?>
+			<div class="kn-tagline"><?= htmlspecialchars($knTagline) ?></div>
+			<?php endif; ?>
 			<div class="kn-badges">
 				<span class="kn-badge kn-badge-green">
 					<i class="fas fa-shield-alt"></i> <?= $entityLabel ?>
@@ -123,6 +587,9 @@
 				<i class="fas fa-map"></i> Map
 			</a>
 			<?php if ($CanManageKingdom ?? false): ?>
+			<button class="kn-btn kn-btn-outline" onclick="knOpenDesignModal()">
+				<i class="fas fa-palette"></i> Design
+			</button>
 			<button class="kn-btn kn-btn-outline" onclick="knOpenAdminModal()">
 				<i class="fas fa-cog"></i> Admin
 			</button>
@@ -197,19 +664,6 @@
 		</div>
 		<?php endif; ?>
 
-		<?php
-			$_knDescription = $kingdom_info['Info']['KingdomInfo']['Description'] ?? '';
-		?>
-		<?php if (!empty($_knDescription)): ?>
-		<div class="kn-card kn-description-card">
-			<h4 class="kn-bare-heading"><i class="fas fa-info-circle"></i> About</h4>
-			<div class="kn-description-body"><?= preg_replace('/<img[^>]*>/i', '', (new Parsedown())->setSafeMode(true)->setBreaksEnabled(true)->text($_knDescription)) ?></div>
-			<?php if (!empty($kingdom_info['Info']['KingdomInfo']['Url'] ?? '')): ?>
-			<a class="kn-description-url" href="<?= htmlspecialchars($kingdom_info['Info']['KingdomInfo']['Url']) ?>" target="_blank" rel="noopener"><i class="fas fa-external-link-alt" style="margin-right:4px;font-size:11px"></i><?= htmlspecialchars($kingdom_info['Info']['KingdomInfo']['Url']) ?></a>
-			<?php endif; ?>
-		</div>
-		<?php endif; ?>
-
 		<!-- Quick Links -->
 		<div class="kn-card">
 			<h4 class="kn-bare-heading"><i class="fas fa-link"></i> Quick Links</h4>
@@ -237,6 +691,29 @@
 					<a href="<?= UIR ?>Search/event&KingdomId=<?= $kingdom_id ?>">Find Events</a>
 				</li>
 			</ul>
+			<?php if (!empty($knVisibleSocials) || ($CanManageKingdom ?? false)): ?>
+			<div class="kn-connect-block">
+				<div class="kn-connect-subhead">
+					<span><i class="fas fa-share-alt"></i> Connect</span>
+					<?php if ($CanManageKingdom ?? false): ?>
+					<button class="kn-connect-edit" type="button" onclick="knOpenDesignModal('about')" data-tip="Edit social links"><i class="fas fa-pencil-alt"></i></button>
+					<?php endif; ?>
+				</div>
+				<?php if (!empty($knVisibleSocials)): ?>
+				<div class="kn-connect-pills">
+					<?php foreach ($knVisibleSocials as $_slug => $_url):
+						$_meta = $KN_SOCIAL_PLATFORMS[$_slug];
+					?>
+					<a class="kn-connect-pill" href="<?= htmlspecialchars($_url) ?>" target="_blank" rel="noopener noreferrer" data-tip="<?= htmlspecialchars($_meta['label']) ?>">
+						<i class="<?= $_meta['icon'] ?>"></i>
+					</a>
+					<?php endforeach; ?>
+				</div>
+				<?php elseif ($CanManageKingdom ?? false): ?>
+				<a href="#" class="kn-connect-empty" onclick="event.preventDefault();knOpenDesignModal('about')">+ Add</a>
+				<?php endif; ?>
+			</div>
+			<?php endif; ?>
 		</div>
 
 	</div>
@@ -245,7 +722,10 @@
 	<div class="kn-main">
 		<div class="kn-tabs">
 			<ul class="kn-tab-nav">
-				<li class="kn-tab-active" data-kntab="parks">
+				<li class="kn-tab-active" data-kntab="about">
+					<i class="fas fa-info-circle"></i><span class="kn-tab-label"> About</span>
+				</li>
+				<li data-kntab="parks">
 					<i class="fas fa-map-marker-alt"></i><span class="kn-tab-label"> Parks</span>
 					<span class="kn-tab-count">(<?= count($parkList) ?>)</span>
 				</li>
@@ -283,10 +763,169 @@
 				</li>
 				<?php endif; ?>
 			</ul>
-			<div class="kn-active-tab-label" id="kn-active-tab-label">Parks</div>
+			<div class="kn-active-tab-label" id="kn-active-tab-label">About</div>
+
+			<!-- About Tab -->
+			<div class="kn-tab-panel" id="kn-tab-about">
+				<?php if ($knHasReignContent || ($CanManageKingdom ?? false)): ?>
+				<?php if ($knHasReignContent): ?>
+				<div class="kn-reign-banner">
+					<div class="kn-reign-head">
+						<i class="fas fa-crown"></i>
+						<span>Current Reign</span>
+						<?php if ($CanManageKingdom ?? false): ?>
+						<button class="kn-about-edit-btn" type="button" onclick="knOpenDesignModal('header')" data-tip="Edit Reign" style="margin-left:auto;background:transparent;border:0;color:#744210;cursor:pointer;font-size:11px">
+							<i class="fas fa-pencil-alt"></i> Edit
+						</button>
+						<?php endif; ?>
+					</div>
+					<?php $_hasReignCard = ($monarch && !empty($monarch['MundaneId'])) || ($regent && !empty($regent['MundaneId'])); ?>
+					<?php if ($_hasReignCard): ?>
+					<div class="kn-reign-grid">
+						<?php if ($monarch && !empty($monarch['MundaneId']) && $monarch['MundaneId'] > 0):
+							$_mImg = kn_reign_avatar_url($monarch['MundaneId']);
+							$_mInitial = htmlspecialchars(strtoupper(mb_substr($monarch['Persona'] ?? '?', 0, 1)));
+						?>
+						<a href="<?= UIR ?>Player/profile/<?= (int)$monarch['MundaneId'] ?>" class="kn-reign-card">
+							<img src="<?= htmlspecialchars($_mImg) ?>" alt="" class="kn-reign-avatar" onerror="this.onerror=null;this.src='<?= HTTP_PLAYER_HERALDRY ?>000000.jpg'">
+							<div class="kn-reign-card-body">
+								<div class="kn-reign-role">Monarch</div>
+								<div class="kn-reign-name"><?= htmlspecialchars($monarch['Persona']) ?></div>
+								<?php if ($knMonarchReignStarted !== '' && $knMonarchReignStarted !== '0000-00-00' && strtotime($knMonarchReignStarted)): ?>
+								<div class="kn-reign-since">Since <?= date('M Y', strtotime($knMonarchReignStarted)) ?></div>
+								<?php endif; ?>
+							</div>
+						</a>
+						<?php endif; ?>
+						<?php if ($regent && !empty($regent['MundaneId']) && $regent['MundaneId'] > 0):
+							$_rImg = kn_reign_avatar_url($regent['MundaneId']);
+						?>
+						<a href="<?= UIR ?>Player/profile/<?= (int)$regent['MundaneId'] ?>" class="kn-reign-card">
+							<img src="<?= htmlspecialchars($_rImg) ?>" alt="" class="kn-reign-avatar" onerror="this.onerror=null;this.src='<?= HTTP_PLAYER_HERALDRY ?>000000.jpg'">
+							<div class="kn-reign-card-body">
+								<div class="kn-reign-role">Regent</div>
+								<div class="kn-reign-name"><?= htmlspecialchars($regent['Persona']) ?></div>
+								<?php if ($knRegentReignStarted !== '' && $knRegentReignStarted !== '0000-00-00' && strtotime($knRegentReignStarted)): ?>
+								<div class="kn-reign-since">Since <?= date('M Y', strtotime($knRegentReignStarted)) ?></div>
+								<?php endif; ?>
+							</div>
+						</a>
+						<?php endif; ?>
+					</div>
+					<?php endif; ?>
+					<?php if (trim($knReignLore) !== ''): ?>
+					<div class="kn-reign-lore kn-description-body"><?= kn_markdown($knReignLore) ?></div>
+					<?php endif; ?>
+				</div>
+				<?php elseif ($CanManageKingdom ?? false): ?>
+				<div class="kn-reign-banner">
+					<div class="kn-reign-head"><i class="fas fa-crown"></i><span>Current Reign</span></div>
+					<div class="kn-reign-empty">
+						Showcase the current Monarch &amp; Regent. <a href="#" onclick="event.preventDefault();knOpenDesignModal('header')" style="color:#744210;text-decoration:underline">Set reign-start dates</a> or add lore.
+					</div>
+				</div>
+				<?php endif; ?>
+				<?php endif; ?>
+
+				<div class="kn-about-grid">
+					<?php if (!empty($aboutText) || ($CanManageKingdom ?? false)): ?>
+					<div class="kn-about-section">
+						<div class="kn-about-section-head">
+							<div class="kn-about-label">About</div>
+							<?php if ($CanManageKingdom ?? false): ?>
+							<button class="kn-about-edit-btn" type="button" onclick="knOpenDesignModal('about')" data-tip="Edit About">
+								<i class="fas fa-pencil-alt"></i> Edit
+							</button>
+							<?php endif; ?>
+						</div>
+						<?php if (!empty($aboutText)): ?>
+						<div class="kn-about-text kn-description-body"><?= kn_markdown($aboutText) ?></div>
+						<?php elseif ($CanManageKingdom ?? false): ?>
+						<div class="kn-empty" style="text-align:left;font-size:13px;color:#a0aec0">
+							No About content yet. <a href="#" onclick="event.preventDefault();knOpenDesignModal('about')">Add some</a> to introduce <?= htmlspecialchars($kingdom_name) ?> to visitors.
+						</div>
+						<?php endif; ?>
+					</div>
+					<?php endif; ?>
+				</div>
+
+				<?php if (!empty($ourHistoryText) || ($CanManageKingdom ?? false)): ?>
+				<div class="kn-about-section kn-history-section">
+					<div class="kn-about-section-head">
+						<div class="kn-about-label"><i class="fas fa-scroll" style="margin-right:6px;color:#a0aec0"></i>Our History</div>
+						<?php if ($CanManageKingdom ?? false): ?>
+						<button class="kn-about-edit-btn" type="button" onclick="knOpenDesignModal('about')" data-tip="Edit Our History">
+							<i class="fas fa-pencil-alt"></i> Edit
+						</button>
+						<?php endif; ?>
+					</div>
+					<?php if (!empty($ourHistoryText)): ?>
+					<div class="kn-about-text kn-description-body"><?= kn_markdown($ourHistoryText) ?></div>
+					<?php elseif ($CanManageKingdom ?? false): ?>
+					<div class="kn-empty" style="text-align:left;font-size:13px;color:#a0aec0">
+						Share the founding story, past officers, or notable moments. <a href="#" onclick="event.preventDefault();knOpenDesignModal('about')">Add Our History</a>.
+					</div>
+					<?php endif; ?>
+				</div>
+				<?php endif; ?>
+
+				<?php
+					$_knWebsiteUrl = trim((string)($_kInfo['Url'] ?? ''));
+					$_knParentId   = (int)($_kInfo['ParentKingdomId'] ?? ($ParentKingdomId ?? 0));
+					$_knParentName = trim((string)($ParentKingdomName ?? ''));
+				?>
+				<?php if ($_knWebsiteUrl !== '' || $_knParentId > 0): ?>
+				<div class="kn-about-section kn-about-meta">
+					<?php if ($_knWebsiteUrl !== ''): ?>
+					<div class="kn-about-meta-row">
+						<i class="fas fa-globe"></i>
+						<a href="<?= htmlspecialchars($_knWebsiteUrl) ?>" target="_blank" rel="noopener"><?= htmlspecialchars($_knWebsiteUrl) ?></a>
+					</div>
+					<?php endif; ?>
+					<?php if ($_knParentId > 0): ?>
+					<div class="kn-about-meta-row">
+						<i class="fas fa-chess-rook"></i>
+						<a href="<?= UIR ?>Kingdom/profile/<?= $_knParentId ?>"><?= htmlspecialchars($_knParentName !== '' ? $_knParentName : 'Parent kingdom') ?></a>
+					</div>
+					<?php endif; ?>
+				</div>
+				<?php endif; ?>
+
+				<?php if ($knHasMilestones || ($CanManageKingdom ?? false)): ?>
+				<div class="kn-about-section kn-timeline-section">
+					<div class="kn-about-section-head">
+						<h3 class="kn-timeline-heading"><i class="fas fa-stream"></i> Milestones</h3>
+						<?php if ($CanManageKingdom ?? false): ?>
+						<button class="kn-about-edit-btn" type="button" onclick="knOpenDesignModal('milestones')" data-tip="Manage milestones">
+							<i class="fas fa-pencil-alt"></i> Manage
+						</button>
+						<?php endif; ?>
+					</div>
+					<?php if ($knHasMilestones): ?>
+					<div class="kn-timeline">
+						<?php foreach ($knVisibleMilestones as $_knms): ?>
+						<div class="kn-timeline-row<?= !empty($_knms['IsDerived']) ? ' kn-ms-derived' : '' ?>">
+							<div class="kn-timeline-dot">
+								<i class="fas <?= htmlspecialchars(preg_replace('/[^a-z0-9-]/','', (string)($_knms['Icon'] ?? 'fa-star')) ?: 'fa-star') ?>"></i>
+							</div>
+							<div class="kn-timeline-content">
+								<span class="kn-timeline-date"><?= !empty($_knms['MilestoneDate']) && $_knms['MilestoneDate'] !== '0000-00-00' ? date('M j, Y', strtotime($_knms['MilestoneDate'])) : '' ?></span>
+								<span class="kn-timeline-desc"><?= htmlspecialchars((string)($_knms['Description'] ?? '')) ?></span>
+							</div>
+						</div>
+						<?php endforeach; ?>
+					</div>
+					<?php elseif ($CanManageKingdom ?? false): ?>
+					<div class="kn-timeline-empty">
+						No milestones yet. <a href="#" onclick="event.preventDefault();knOpenDesignModal('milestones')">Add the first one</a> — founding date, charter dates, notable events.
+					</div>
+					<?php endif; ?>
+				</div>
+				<?php endif; ?>
+			</div><!-- /kn-tab-about -->
 
 			<!-- Parks Tab -->
-			<div class="kn-tab-panel" id="kn-tab-parks">
+			<div class="kn-tab-panel" id="kn-tab-parks" style="display:none">
 				<?php
 					// Pre-sort alphabetically so tiles match default list order
 					usort($parkList, function($a, $b) { return strcmp($a['ParkName'], $b['ParkName']); });
@@ -2431,4 +3070,858 @@ window.OrkRsCfg = {
 };
 </script>
 <?php include __DIR__ . '/_recommendation_seconds_assets.tpl'; ?>
+<?php endif; ?>
+
+<?php if ($CanManageKingdom ?? false): ?>
+<!-- =============================================
+     Kingdom Design Modal
+     ============================================= -->
+<style>
+/* --- Kingdom Design Modal: scoped styles (kn-dm-*) ----------------------------- */
+.kn-dm-overlay {
+	position: fixed; inset: 0; background: rgba(0,0,0,0.55); z-index: 10000;
+	display: none; align-items: center; justify-content: center; padding: 20px;
+}
+.kn-dm-overlay.kn-open { display: flex; }
+.kn-dm-modal {
+	background: #fff; border-radius: 10px; width: 720px; max-width: calc(100vw - 40px);
+	max-height: 88vh; display: flex; flex-direction: column; overflow: hidden;
+	box-shadow: 0 18px 50px rgba(0,0,0,0.35);
+}
+html[data-theme="dark"] .kn-dm-modal { background: var(--ork-card-bg); color: var(--ork-text); }
+.kn-dm-header {
+	display: flex; align-items: center; justify-content: space-between;
+	padding: 14px 18px; border-bottom: 1px solid #e2e8f0;
+}
+html[data-theme="dark"] .kn-dm-header { border-color: var(--ork-border); background: var(--ork-bg-secondary); }
+.kn-dm-title {
+	margin: 0; font-size: 16px; font-weight: 700; color: #2d3748;
+	background: transparent; border: none; padding: 0; border-radius: 0; text-shadow: none;
+	display: inline-flex; align-items: center; gap: 8px;
+}
+html[data-theme="dark"] .kn-dm-title { color: var(--ork-text); }
+.kn-dm-close {
+	background: transparent; border: 0; font-size: 22px; cursor: pointer; color: #718096;
+	width: 32px; height: 32px; border-radius: 6px;
+}
+.kn-dm-close:hover { background: #f7fafc; color: #2d3748; }
+html[data-theme="dark"] .kn-dm-close { color: var(--ork-text-muted); }
+html[data-theme="dark"] .kn-dm-close:hover { background: var(--ork-bg-tertiary); color: var(--ork-text); }
+.kn-dm-tabs {
+	display: flex; gap: 4px; padding: 8px 18px 0 18px; border-bottom: 1px solid #e2e8f0;
+	background: #f7fafc;
+}
+html[data-theme="dark"] .kn-dm-tabs { background: var(--ork-bg-secondary); border-color: var(--ork-border); }
+.kn-dm-tab {
+	background: transparent; border: 1px solid transparent; border-bottom: none;
+	padding: 8px 14px; font-size: 13px; font-weight: 600; color: #718096; cursor: pointer;
+	border-radius: 6px 6px 0 0; display: inline-flex; align-items: center; gap: 6px;
+}
+.kn-dm-tab.kn-active {
+	background: #fff; color: #2b6cb0; border-color: #e2e8f0; border-bottom: 1px solid #fff;
+	margin-bottom: -1px;
+}
+html[data-theme="dark"] .kn-dm-tab { color: var(--ork-text-secondary); }
+html[data-theme="dark"] .kn-dm-tab.kn-active {
+	background: var(--ork-card-bg); color: var(--ork-link); border-color: var(--ork-border);
+	border-bottom-color: var(--ork-card-bg);
+}
+.kn-dm-body { padding: 18px; overflow-y: auto; flex: 1; }
+.kn-dm-panel { display: none; }
+.kn-dm-panel.kn-active { display: block; }
+.kn-dm-error {
+	display: none; background: #fff5f5; border: 1px solid #fc8181; color: #9b2c2c;
+	border-radius: 6px; padding: 10px 12px; font-size: 13px; margin-bottom: 12px;
+}
+html[data-theme="dark"] .kn-dm-error { background: rgba(252,129,129,0.1); color: #fc8181; }
+.kn-dm-field { margin-bottom: 14px; }
+.kn-dm-field label {
+	display: block; font-size: 12px; font-weight: 700; color: #4a5568;
+	text-transform: uppercase; letter-spacing: 0.4px; margin-bottom: 4px;
+}
+html[data-theme="dark"] .kn-dm-field label { color: var(--ork-text-secondary); }
+.kn-dm-field input[type="text"],
+.kn-dm-field input[type="date"],
+.kn-dm-field textarea,
+.kn-dm-field select {
+	width: 100%; padding: 8px 10px; border: 1px solid #cbd5e0; border-radius: 6px;
+	font-size: 14px; color: #2d3748; box-sizing: border-box; background: #fff;
+	font-family: inherit;
+}
+html[data-theme="dark"] .kn-dm-field input,
+html[data-theme="dark"] .kn-dm-field textarea,
+html[data-theme="dark"] .kn-dm-field select {
+	background: var(--ork-input-bg); border-color: var(--ork-input-border); color: var(--ork-text);
+}
+.kn-dm-field textarea { min-height: 140px; resize: vertical; line-height: 1.5; }
+.kn-dm-hint { font-size: 12px; color: #718096; margin-top: 4px; }
+html[data-theme="dark"] .kn-dm-hint { color: var(--ork-text-muted); }
+.kn-dm-footer {
+	border-top: 1px solid #e2e8f0; padding: 12px 18px;
+	display: flex; justify-content: flex-end; gap: 8px; background: #f7fafc;
+}
+html[data-theme="dark"] .kn-dm-footer { background: var(--ork-bg-secondary); border-color: var(--ork-border); }
+.kn-dm-btn {
+	padding: 8px 16px; font-size: 13px; font-weight: 600; border-radius: 6px;
+	border: 1px solid #cbd5e0; background: #fff; color: #2d3748; cursor: pointer;
+	display: inline-flex; align-items: center; gap: 6px;
+}
+html[data-theme="dark"] .kn-dm-btn { background: var(--ork-bg-tertiary); border-color: var(--ork-border); color: var(--ork-text); }
+.kn-dm-btn-primary { background: #3182ce; color: #fff; border-color: #3182ce; }
+.kn-dm-btn-primary:hover { background: #2c5282; border-color: #2c5282; }
+.kn-dm-btn:disabled { opacity: 0.55; cursor: not-allowed; }
+
+.kn-dm-preset-grid { display: grid; grid-template-columns: repeat(8, 1fr); gap: 8px; }
+.kn-dm-swatch {
+	height: 40px; border-radius: 6px; cursor: pointer; border: 2px solid transparent;
+	box-shadow: 0 1px 2px rgba(0,0,0,0.1) inset;
+}
+.kn-dm-swatch.kn-selected { border-color: #2b6cb0; transform: scale(1.06); box-shadow: 0 0 0 2px #fff, 0 0 0 4px #2b6cb0; }
+html[data-theme="dark"] .kn-dm-swatch.kn-selected { box-shadow: 0 0 0 2px var(--ork-card-bg), 0 0 0 4px var(--ork-link); }
+.kn-dm-color-row { display: flex; gap: 12px; flex-wrap: wrap; }
+.kn-dm-color-col { flex: 1; min-width: 180px; }
+.kn-dm-color-input { display: flex; align-items: center; gap: 6px; }
+.kn-dm-color-input input[type="color"] {
+	width: 38px; height: 36px; border: 1px solid #cbd5e0; border-radius: 6px;
+	padding: 0; background: transparent; cursor: pointer;
+}
+.kn-dm-color-input input[type="text"] { flex: 1; }
+.kn-dm-overlay-btns { display: flex; gap: 6px; flex-wrap: wrap; }
+.kn-dm-overlay-btn {
+	flex: 1; min-width: 80px; padding: 8px 10px; font-size: 12px; font-weight: 600;
+	border: 1px solid #cbd5e0; border-radius: 6px; background: #fff; color: #4a5568; cursor: pointer;
+}
+.kn-dm-overlay-btn.kn-active { background: #2b6cb0; color: #fff; border-color: #2b6cb0; }
+html[data-theme="dark"] .kn-dm-overlay-btn { background: var(--ork-bg-tertiary); border-color: var(--ork-border); color: var(--ork-text-secondary); }
+html[data-theme="dark"] .kn-dm-overlay-btn.kn-active { background: var(--ork-link); color: var(--ork-bg-secondary); border-color: var(--ork-link); }
+
+.kn-dm-font-picker { display: grid; grid-template-columns: repeat(auto-fill, minmax(140px, 1fr)); gap: 8px; }
+.kn-dm-font-card {
+	border: 1px solid #cbd5e0; border-radius: 8px; padding: 10px 8px; cursor: pointer;
+	text-align: center; background: #fff;
+}
+.kn-dm-font-card.kn-active { border-color: #2b6cb0; background: #ebf8ff; box-shadow: 0 0 0 1px #2b6cb0; }
+html[data-theme="dark"] .kn-dm-font-card { background: var(--ork-bg-tertiary); border-color: var(--ork-border); }
+html[data-theme="dark"] .kn-dm-font-card.kn-active { background: rgba(43,108,176,0.15); border-color: var(--ork-link); box-shadow: 0 0 0 1px var(--ork-link); }
+.kn-dm-font-sample { font-size: 19px; font-weight: 600; color: #2d3748; line-height: 1.2; margin-bottom: 4px; }
+html[data-theme="dark"] .kn-dm-font-sample { color: var(--ork-text); }
+.kn-dm-font-label { font-size: 11px; color: #718096; }
+html[data-theme="dark"] .kn-dm-font-label { color: var(--ork-text-muted); }
+
+.kn-dm-md-toolbar { display: flex; justify-content: space-between; align-items: center; gap: 8px; margin-bottom: 4px; flex-wrap: wrap; }
+.kn-dm-md-toggle { display: inline-flex; background: #edf2f7; border-radius: 6px; padding: 3px; gap: 3px; }
+.kn-dm-md-toggle button {
+	background: transparent; border: 0; padding: 5px 10px; font-size: 12px; font-weight: 600;
+	cursor: pointer; border-radius: 4px; color: #718096;
+}
+.kn-dm-md-toggle button.kn-active { background: #fff; color: #2b6cb0; box-shadow: 0 1px 2px rgba(0,0,0,0.06); }
+html[data-theme="dark"] .kn-dm-md-toggle { background: var(--ork-bg-tertiary); }
+html[data-theme="dark"] .kn-dm-md-toggle button.kn-active { background: var(--ork-card-bg); color: var(--ork-link); }
+.kn-dm-md-quick { display: flex; flex-wrap: wrap; gap: 6px; }
+.kn-dm-md-quick-btn {
+	background: #fff; border: 1px solid #cbd5e0; color: #4a5568;
+	padding: 5px 10px; border-radius: 14px; font-size: 11px; font-weight: 600;
+	cursor: pointer; display: inline-flex; align-items: center; gap: 4px;
+}
+.kn-dm-md-quick-btn:hover { background: #ebf8ff; color: #2b6cb0; border-color: #90cdf4; }
+html[data-theme="dark"] .kn-dm-md-quick-btn { background: var(--ork-bg-tertiary); border-color: var(--ork-border); color: var(--ork-text-secondary); }
+html[data-theme="dark"] .kn-dm-md-quick-btn:hover { background: var(--ork-bg-secondary); color: var(--ork-link); border-color: var(--ork-link); }
+.kn-dm-md-preview {
+	border: 1px solid #cbd5e0; border-radius: 6px; padding: 12px 14px;
+	min-height: 140px; background: #fafafa; font-size: 14px; line-height: 1.55; color: #2d3748;
+}
+html[data-theme="dark"] .kn-dm-md-preview { background: var(--ork-bg-secondary); border-color: var(--ork-border); color: var(--ork-text); }
+.kn-dm-md-preview h1, .kn-dm-md-preview h2, .kn-dm-md-preview h3, .kn-dm-md-preview h4 {
+	background: transparent; border: none; padding: 0; border-radius: 0; text-shadow: none;
+	margin-top: 0.9em; margin-bottom: 0.3em;
+}
+
+.kn-dm-ms-toggles { display: flex; flex-wrap: wrap; gap: 8px 14px; margin-bottom: 14px; }
+.kn-dm-ms-toggle { display: inline-flex; align-items: center; gap: 6px; font-size: 13px; color: #4a5568; }
+html[data-theme="dark"] .kn-dm-ms-toggle { color: var(--ork-text-secondary); }
+.kn-dm-ms-list { border: 1px solid #e2e8f0; border-radius: 6px; margin-bottom: 12px; max-height: 200px; overflow-y: auto; }
+html[data-theme="dark"] .kn-dm-ms-list { border-color: var(--ork-border); background: var(--ork-bg-secondary); }
+.kn-dm-ms-row {
+	display: flex; align-items: center; gap: 8px; padding: 8px 10px; border-bottom: 1px solid #edf2f7;
+	font-size: 13px;
+}
+html[data-theme="dark"] .kn-dm-ms-row { border-color: var(--ork-border); }
+.kn-dm-ms-row:last-child { border-bottom: none; }
+.kn-dm-ms-row > i { color: #2b6cb0; width: 18px; text-align: center; }
+.kn-dm-ms-row .kn-dm-ms-desc { flex: 1; color: #2d3748; }
+html[data-theme="dark"] .kn-dm-ms-row .kn-dm-ms-desc { color: var(--ork-text); }
+.kn-dm-ms-row .kn-dm-ms-date { color: #718096; font-size: 11px; min-width: 90px; }
+html[data-theme="dark"] .kn-dm-ms-row .kn-dm-ms-date { color: var(--ork-text-muted); }
+html[data-theme="dark"] .kn-dm-ms-row > i { color: var(--ork-link); }
+html[data-theme="dark"] .kn-dm-ms-row button { color: #fc8181; }
+html[data-theme="dark"] .kn-dm-ms-row button:hover { background: var(--ork-bg-tertiary); }
+.kn-dm-ms-row button {
+	background: transparent; border: 0; color: #e53e3e; cursor: pointer; padding: 4px 6px;
+}
+.kn-dm-ms-row button[data-tip] { position: relative; }
+.kn-dm-ms-row button[data-tip]::after {
+	content: attr(data-tip); position: absolute; bottom: calc(100% + 4px); right: 0;
+	background: #2d3748; color: #fff; font-size: 11px; white-space: nowrap;
+	padding: 3px 8px; border-radius: 4px; pointer-events: none; opacity: 0;
+	transition: opacity 0.12s; z-index: 600;
+}
+.kn-dm-ms-row button[data-tip]:hover::after { opacity: 1; transition-delay: 0.3s; }
+html[data-theme="dark"] .kn-dm-ms-row button[data-tip]::after {
+	background: var(--ork-bg-tertiary); color: var(--ork-text); border: 1px solid var(--ork-border);
+}
+.kn-dm-ms-add { display: grid; grid-template-columns: 1fr 140px 90px; gap: 8px; align-items: end; }
+@media (max-width: 600px) { .kn-dm-ms-add { grid-template-columns: 1fr; } }
+.kn-dm-ms-icons { display: flex; flex-wrap: wrap; gap: 6px; margin-top: 4px; }
+.kn-dm-ms-icon-opt {
+	width: 28px; height: 28px; border: 1px solid #cbd5e0; border-radius: 6px;
+	display: flex; align-items: center; justify-content: center; cursor: pointer;
+	background: #fff; color: #4a5568;
+}
+.kn-dm-ms-icon-opt.kn-active { background: #2b6cb0; color: #fff; border-color: #2b6cb0; }
+html[data-theme="dark"] .kn-dm-ms-icon-opt { background: var(--ork-bg-tertiary); border-color: var(--ork-border); color: var(--ork-text-secondary); }
+html[data-theme="dark"] .kn-dm-ms-icon-opt.kn-active { background: var(--ork-link); color: var(--ork-bg-secondary); border-color: var(--ork-link); }
+</style>
+
+<div class="kn-dm-overlay" id="kn-dm-overlay">
+	<div class="kn-dm-modal">
+		<div class="kn-dm-header">
+			<h3 class="kn-dm-title"><i class="fas fa-palette"></i>Design <?= htmlspecialchars($kingdom_name) ?></h3>
+			<button class="kn-dm-close" id="kn-dm-close" aria-label="Close">&times;</button>
+		</div>
+		<div class="kn-dm-tabs">
+			<button class="kn-dm-tab kn-active" data-kntab-dm="header"><i class="fas fa-image"></i> Header</button>
+			<button class="kn-dm-tab" data-kntab-dm="about"><i class="fas fa-scroll"></i> About</button>
+			<button class="kn-dm-tab" data-kntab-dm="milestones"><i class="fas fa-stream"></i> Milestones</button>
+		</div>
+		<div class="kn-dm-body">
+			<div class="kn-dm-error" id="kn-dm-error"></div>
+
+			<div class="kn-dm-panel kn-active" id="kn-dm-panel-header">
+				<div class="kn-dm-hint" style="margin-bottom:12px"><i class="fas fa-moon" style="margin-right:6px"></i><strong>Dark mode viewers</strong> see your hero with a slight darkening filter so colors stay readable. Preview both themes with the moon icon in the site header before saving.</div>
+
+				<div class="kn-dm-field">
+					<label>Color Presets</label>
+					<div class="kn-dm-preset-grid" id="kn-dm-presets">
+						<div class="kn-dm-swatch" data-primary="#2c5282" data-accent="#4299e1" style="background:#2c5282"></div>
+						<div class="kn-dm-swatch" data-primary="#276749" data-accent="#48bb78" style="background:#276749"></div>
+						<div class="kn-dm-swatch" data-primary="#9b2c2c" data-accent="#fc8181" style="background:#9b2c2c"></div>
+						<div class="kn-dm-swatch" data-primary="#553c9a" data-accent="#9f7aea" style="background:#553c9a"></div>
+						<div class="kn-dm-swatch" data-primary="#975a16" data-accent="#ecc94b" style="background:#975a16"></div>
+						<div class="kn-dm-swatch" data-primary="#2d3748" data-accent="#a0aec0" style="background:#2d3748"></div>
+						<div class="kn-dm-swatch" data-primary="#285e61" data-accent="#38b2ac" style="background:#285e61"></div>
+						<div class="kn-dm-swatch" data-primary="#744210" data-accent="#ed8936" style="background:#744210"></div>
+					</div>
+				</div>
+
+				<div class="kn-dm-field">
+					<label>Gradient Presets</label>
+					<div class="kn-dm-preset-grid" id="kn-dm-gradient-presets">
+						<div class="kn-dm-swatch" data-primary="#1a365d" data-accent="#4299e1" data-secondary="#553c9a" style="background:linear-gradient(135deg,#1a365d,#553c9a)"></div>
+						<div class="kn-dm-swatch" data-primary="#1a4731" data-accent="#48bb78" data-secondary="#2c5282" style="background:linear-gradient(135deg,#1a4731,#2c5282)"></div>
+						<div class="kn-dm-swatch" data-primary="#742a2a" data-accent="#fc8181" data-secondary="#975a16" style="background:linear-gradient(135deg,#742a2a,#975a16)"></div>
+						<div class="kn-dm-swatch" data-primary="#44337a" data-accent="#d6bcfa" data-secondary="#97266d" style="background:linear-gradient(135deg,#44337a,#97266d)"></div>
+						<div class="kn-dm-swatch" data-primary="#234e52" data-accent="#38b2ac" data-secondary="#276749" style="background:linear-gradient(135deg,#234e52,#276749)"></div>
+						<div class="kn-dm-swatch" data-primary="#2c5282" data-accent="#4299e1" data-secondary="#285e61" style="background:linear-gradient(135deg,#2c5282,#285e61)"></div>
+						<div class="kn-dm-swatch" data-primary="#744210" data-accent="#ecc94b" data-secondary="#9b2c2c" style="background:linear-gradient(135deg,#744210,#9b2c2c)"></div>
+						<div class="kn-dm-swatch" data-primary="#1a202c" data-accent="#a0aec0" data-secondary="#2d3748" style="background:linear-gradient(135deg,#1a202c,#2d3748)"></div>
+					</div>
+				</div>
+
+				<div class="kn-dm-field">
+					<label>Custom Colors</label>
+					<div class="kn-dm-color-row">
+						<div class="kn-dm-color-col">
+							<div class="kn-dm-hint" style="margin-bottom:4px">Primary (hero background)</div>
+							<div class="kn-dm-color-input">
+								<input type="color" id="kn-dm-color-primary" value="<?= htmlspecialchars($knColorPrimary ?: '#2c5282') ?>" />
+								<input type="text" id="kn-dm-color-primary-hex" value="<?= htmlspecialchars($knColorPrimary ?: '#2c5282') ?>" maxlength="7" />
+							</div>
+						</div>
+						<div class="kn-dm-color-col">
+							<div class="kn-dm-hint" style="margin-bottom:4px">Accent (links &amp; tabs)</div>
+							<div class="kn-dm-color-input">
+								<input type="color" id="kn-dm-color-accent" value="<?= htmlspecialchars($knColorAccent ?: '#4299e1') ?>" />
+								<input type="text" id="kn-dm-color-accent-hex" value="<?= htmlspecialchars($knColorAccent ?: '#4299e1') ?>" maxlength="7" />
+							</div>
+						</div>
+					</div>
+				</div>
+
+				<div class="kn-dm-field">
+					<label>Gradient (Optional)</label>
+					<div class="kn-dm-color-row">
+						<div class="kn-dm-color-col">
+							<div class="kn-dm-hint" style="margin-bottom:4px">Secondary color</div>
+							<div class="kn-dm-color-input">
+								<input type="color" id="kn-dm-color-secondary" value="<?= htmlspecialchars($knColorSecondary ?: ($knColorPrimary ?: '#2c5282')) ?>" />
+								<input type="text" id="kn-dm-color-secondary-hex" value="<?= htmlspecialchars($knColorSecondary) ?>" maxlength="7" placeholder="None" />
+							</div>
+						</div>
+						<div class="kn-dm-color-col" style="display:flex;align-items:center;padding-top:18px">
+							<label style="text-transform:none;letter-spacing:0;display:flex;align-items:center;gap:6px;cursor:pointer;font-weight:500;color:#4a5568;font-size:13px;margin-bottom:0">
+								<input type="checkbox" id="kn-dm-gradient-enabled" <?= $knColorSecondary !== '' ? 'checked' : '' ?> />
+								Enable gradient
+							</label>
+						</div>
+					</div>
+				</div>
+
+				<div class="kn-dm-field">
+					<label>Heraldry Overlay Strength</label>
+					<div class="kn-dm-hint" style="margin-bottom:6px">Controls how much the kingdom heraldry shows through the hero background.</div>
+					<div class="kn-dm-overlay-btns">
+						<button type="button" class="kn-dm-overlay-btn<?= $knOverlay === 'low' ? ' kn-active' : '' ?>" data-overlay="low">Low</button>
+						<button type="button" class="kn-dm-overlay-btn<?= $knOverlay === 'med' ? ' kn-active' : '' ?>" data-overlay="med">Medium</button>
+						<button type="button" class="kn-dm-overlay-btn<?= $knOverlay === 'high' ? ' kn-active' : '' ?>" data-overlay="high">High</button>
+						<button type="button" class="kn-dm-overlay-btn<?= $knOverlay === 'vignette' ? ' kn-active' : '' ?>" data-overlay="vignette">Vignette</button>
+					</div>
+					<input type="hidden" id="kn-dm-hero-overlay" value="<?= htmlspecialchars($knOverlay) ?>" />
+				</div>
+
+				<div class="kn-dm-field">
+					<label>Name Font</label>
+					<div class="kn-dm-hint" style="margin-bottom:6px">A decorative font for the kingdom name in the hero. Viewers with accessibility fonts enabled will see their preferred font instead.</div>
+					<div class="kn-dm-font-picker" id="kn-dm-font-picker"></div>
+				</div>
+
+				<div class="kn-dm-field">
+					<label>Tagline</label>
+					<div class="kn-dm-hint" style="margin-bottom:6px">A short one-liner that appears under the kingdom name in the hero. 160 characters max.</div>
+					<input type="text" id="kn-dm-tagline" maxlength="160" value="<?= htmlspecialchars($knTagline) ?>" placeholder="e.g. Honor, Glory, and the Sound of Sword on Shield." style="width:100%;padding:8px 10px;font-size:13px;border:1px solid #cbd5e0;border-radius:5px" />
+					<div class="kn-dm-counter" id="kn-dm-tagline-counter">0 / 160</div>
+				</div>
+
+				<div class="kn-dm-field">
+					<label>Announcement Banner</label>
+					<div class="kn-dm-hint" style="margin-bottom:6px">A short amber banner that appears above the hero. Use for upcoming events, weather cancellations, or kingdom news. 280 characters max.</div>
+					<textarea id="kn-dm-announcement" maxlength="280" placeholder="e.g. Crown List sign-ups close Friday at midnight. RSVP on the events page!" style="width:100%;padding:8px 10px;font-size:13px;border:1px solid #cbd5e0;border-radius:5px;min-height:60px;resize:vertical"><?= htmlspecialchars($knAnnouncement) ?></textarea>
+					<div class="kn-dm-counter" id="kn-dm-announcement-counter">0 / 280</div>
+					<div style="display:flex;gap:8px;align-items:center;margin-top:8px;flex-wrap:wrap">
+						<label style="font-size:12px;color:#4a5568;text-transform:none;letter-spacing:0;margin-bottom:0">Show until (optional):</label>
+						<input type="date" id="kn-dm-announcement-until" value="<?= htmlspecialchars(($knAnnouncementUntil !== '' && $knAnnouncementUntil !== '0000-00-00') ? $knAnnouncementUntil : '') ?>" style="padding:5px 8px;font-size:12px;border:1px solid #cbd5e0;border-radius:4px" />
+						<button type="button" id="kn-dm-announcement-clear" style="background:transparent;border:0;color:#718096;font-size:11px;cursor:pointer;text-decoration:underline">Clear date</button>
+					</div>
+				</div>
+
+				<div class="kn-dm-field">
+					<label>Reign Banner</label>
+					<div class="kn-dm-hint" style="margin-bottom:8px">Personae are derived from current Monarch &amp; Regent on the Officers list. Set reign-start dates and add optional lore (Markdown supported, 2,000 char max).</div>
+					<div style="display:grid;grid-template-columns:1fr 1fr;gap:10px;margin-bottom:10px">
+						<div>
+							<label style="font-size:11px;color:#4a5568;text-transform:none;letter-spacing:0">Monarch reign started</label>
+							<input type="date" id="kn-dm-monarch-reign" value="<?= htmlspecialchars(($knMonarchReignStarted !== '' && $knMonarchReignStarted !== '0000-00-00') ? $knMonarchReignStarted : '') ?>" style="width:100%;padding:6px 8px;font-size:12px;border:1px solid #cbd5e0;border-radius:4px" />
+						</div>
+						<div>
+							<label style="font-size:11px;color:#4a5568;text-transform:none;letter-spacing:0">Regent reign started</label>
+							<input type="date" id="kn-dm-regent-reign" value="<?= htmlspecialchars(($knRegentReignStarted !== '' && $knRegentReignStarted !== '0000-00-00') ? $knRegentReignStarted : '') ?>" style="width:100%;padding:6px 8px;font-size:12px;border:1px solid #cbd5e0;border-radius:4px" />
+						</div>
+					</div>
+					<div class="kn-dm-md-toolbar">
+						<label style="margin-bottom:0;font-size:11px;text-transform:none;letter-spacing:0;color:#4a5568">Reign Lore (optional, Markdown)</label>
+						<div class="kn-dm-md-toggle">
+							<button type="button" class="kn-active" data-knmd-target="edit" data-knmd-field="reign">Write</button>
+							<button type="button" data-knmd-target="preview" data-knmd-field="reign">Preview</button>
+						</div>
+					</div>
+					<textarea id="kn-dm-reign-text" maxlength="2000" placeholder="e.g. Their Royal Majesties were crowned at Spring Coronation after a hard-fought Crown List..." style="width:100%;min-height:120px"><?= htmlspecialchars($knReignLore) ?></textarea>
+					<div class="kn-dm-md-preview" id="kn-dm-reign-preview" style="display:none"></div>
+					<div class="kn-dm-counter" id="kn-dm-reign-counter">0 / 2,000</div>
+				</div>
+			</div>
+
+			<div class="kn-dm-panel" id="kn-dm-panel-about">
+				<div class="kn-dm-field">
+					<label>Social Links</label>
+					<div class="kn-dm-hint" style="margin-bottom:8px">Add any platforms your kingdom uses. Empty fields aren't shown. We'll add <code>https://</code> automatically if you omit it.</div>
+					<div class="kn-dm-social-row">
+						<div class="kn-dm-social-label"><span class="kn-dm-social-icon-chip" style="background:#5865f2"><i class="fab fa-discord"></i></span>Discord</div>
+						<input type="url" data-knsoc="discord" placeholder="https://discord.gg/..." value="<?= htmlspecialchars((string)($knSocialLinks['discord'] ?? '')) ?>" maxlength="500" />
+					</div>
+					<div class="kn-dm-social-row">
+						<div class="kn-dm-social-label"><span class="kn-dm-social-icon-chip" style="background:#1877f2"><i class="fab fa-facebook"></i></span>Facebook</div>
+						<input type="url" data-knsoc="facebook" placeholder="https://facebook.com/..." value="<?= htmlspecialchars((string)($knSocialLinks['facebook'] ?? '')) ?>" maxlength="500" />
+					</div>
+					<div class="kn-dm-social-row">
+						<div class="kn-dm-social-label"><span class="kn-dm-social-icon-chip" style="background:linear-gradient(135deg,#f09433,#dc2743,#bc1888)"><i class="fab fa-instagram"></i></span>Instagram</div>
+						<input type="url" data-knsoc="instagram" placeholder="https://instagram.com/..." value="<?= htmlspecialchars((string)($knSocialLinks['instagram'] ?? '')) ?>" maxlength="500" />
+					</div>
+					<div class="kn-dm-social-row">
+						<div class="kn-dm-social-label"><span class="kn-dm-social-icon-chip" style="background:#000"><i class="fab fa-threads"></i></span>Threads</div>
+						<input type="url" data-knsoc="threads" placeholder="https://threads.net/..." value="<?= htmlspecialchars((string)($knSocialLinks['threads'] ?? '')) ?>" maxlength="500" />
+					</div>
+					<div class="kn-dm-social-row">
+						<div class="kn-dm-social-label"><span class="kn-dm-social-icon-chip" style="background:#1185fe"><i class="fas fa-cloud"></i></span>Bluesky</div>
+						<input type="url" data-knsoc="bluesky" placeholder="https://bsky.app/..." value="<?= htmlspecialchars((string)($knSocialLinks['bluesky'] ?? '')) ?>" maxlength="500" />
+					</div>
+					<div class="kn-dm-social-row">
+						<div class="kn-dm-social-label"><span class="kn-dm-social-icon-chip" style="background:#000"><i class="fab fa-x-twitter"></i></span>X</div>
+						<input type="url" data-knsoc="twitter" placeholder="https://x.com/..." value="<?= htmlspecialchars((string)($knSocialLinks['twitter'] ?? '')) ?>" maxlength="500" />
+					</div>
+					<div class="kn-dm-social-row">
+						<div class="kn-dm-social-label"><span class="kn-dm-social-icon-chip" style="background:#ff0000"><i class="fab fa-youtube"></i></span>YouTube</div>
+						<input type="url" data-knsoc="youtube" placeholder="https://youtube.com/..." value="<?= htmlspecialchars((string)($knSocialLinks['youtube'] ?? '')) ?>" maxlength="500" />
+					</div>
+					<div class="kn-dm-social-row">
+						<div class="kn-dm-social-label"><span class="kn-dm-social-icon-chip" style="background:#6b7280"><i class="fas fa-book"></i></span>AmtWiki</div>
+						<input type="url" data-knsoc="amtwiki" placeholder="https://amtwiki.net/..." value="<?= htmlspecialchars((string)($knSocialLinks['amtwiki'] ?? '')) ?>" maxlength="500" />
+					</div>
+				</div>
+
+				<div class="kn-dm-hint" style="margin-bottom:14px"><i class="fas fa-info-circle" style="margin-right:6px"></i>Both fields below support <strong>Markdown</strong>. Use <em>About</em> for a current snapshot of the kingdom; use <em>Our History</em> for the founding story, past reigns, and notable moments.</div>
+
+				<div class="kn-dm-field">
+					<div class="kn-dm-md-toolbar">
+						<label style="margin-bottom:0">About <?= htmlspecialchars($kingdom_name) ?></label>
+						<div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap">
+							<div class="kn-dm-md-toggle">
+								<button type="button" class="kn-active" data-knmd-target="edit" data-knmd-field="about">Write</button>
+								<button type="button" data-knmd-target="preview" data-knmd-field="about">Preview</button>
+							</div>
+							<div class="kn-dm-md-quick">
+								<button type="button" class="kn-dm-md-quick-btn" data-knquick="newbies" data-knfield="about"><i class="fas fa-hand-sparkles"></i> New Player Welcome</button>
+								<button type="button" class="kn-dm-md-quick-btn" data-knquick="vibe" data-knfield="about"><i class="fas fa-fire"></i> Kingdom Vibe</button>
+								<button type="button" class="kn-dm-md-quick-btn" data-knquick="findus" data-knfield="about"><i class="fas fa-map-marker-alt"></i> Where We Play</button>
+							</div>
+						</div>
+					</div>
+					<textarea id="kn-dm-about-text" maxlength="10000" placeholder="Welcome to the kingdom... (Markdown supported)"><?= htmlspecialchars($aboutText) ?></textarea>
+					<div class="kn-dm-md-preview" id="kn-dm-about-preview" style="display:none"></div>
+				</div>
+
+				<div class="kn-dm-field">
+					<div class="kn-dm-md-toolbar">
+						<label style="margin-bottom:0">Our History</label>
+						<div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap">
+							<div class="kn-dm-md-toggle">
+								<button type="button" class="kn-active" data-knmd-target="edit" data-knmd-field="history">Write</button>
+								<button type="button" data-knmd-target="preview" data-knmd-field="history">Preview</button>
+							</div>
+							<div class="kn-dm-md-quick">
+								<button type="button" class="kn-dm-md-quick-btn" data-knquick="founding" data-knfield="history"><i class="fas fa-flag"></i> Founding</button>
+								<button type="button" class="kn-dm-md-quick-btn" data-knquick="charter" data-knfield="history"><i class="fas fa-chess-rook"></i> Charter</button>
+								<button type="button" class="kn-dm-md-quick-btn" data-knquick="pastmonarchs" data-knfield="history"><i class="fas fa-crown"></i> Past Monarchs</button>
+							</div>
+						</div>
+					</div>
+					<textarea id="kn-dm-history-text" maxlength="10000" placeholder="The kingdom was founded in... (Markdown supported)"><?= htmlspecialchars($ourHistoryText) ?></textarea>
+					<div class="kn-dm-md-preview" id="kn-dm-history-preview" style="display:none"></div>
+				</div>
+			</div>
+
+			<div class="kn-dm-panel" id="kn-dm-panel-milestones">
+				<div class="kn-dm-hint" style="margin-bottom:10px">Milestones appear in the sidebar in date order. Some are derived from attendance data (first sign-in, count thresholds); the rest are custom entries you add below.</div>
+
+				<div class="kn-dm-field">
+					<label>Visible Milestone Types</label>
+					<div class="kn-dm-ms-toggles" id="kn-dm-ms-toggles">
+						<label class="kn-dm-ms-toggle"><input type="checkbox" data-knms-type="first_attendance" <?= $knMsVisible('first_attendance') ? 'checked' : '' ?> /> <i class="fas fa-door-open"></i> First Attendance</label>
+						<label class="kn-dm-ms-toggle"><input type="checkbox" data-knms-type="attendance_count" <?= $knMsVisible('attendance_count') ? 'checked' : '' ?> /> <i class="fas fa-clipboard-list"></i> Attendance Crossings</label>
+						<label class="kn-dm-ms-toggle"><input type="checkbox" data-knms-type="distinct_members" <?= $knMsVisible('distinct_members') ? 'checked' : '' ?> /> <i class="fas fa-users"></i> Member Crossings</label>
+						<label class="kn-dm-ms-toggle"><input type="checkbox" data-knms-type="custom" <?= $knMsVisible('custom') ? 'checked' : '' ?> /> <i class="fas fa-pen"></i> Custom Milestones</label>
+					</div>
+					<label class="kn-dm-ms-toggle" style="margin-top:4px">
+						<input type="checkbox" id="kn-dm-ms-newest-first" <?= $knMsNewestFirst ? 'checked' : '' ?> />
+						Show newest first
+					</label>
+				</div>
+
+				<div class="kn-dm-field">
+					<label>Custom Milestones</label>
+					<div class="kn-dm-ms-list" id="kn-dm-ms-list"></div>
+					<div class="kn-dm-ms-add">
+						<div>
+							<input type="text" id="kn-dm-ms-add-desc" placeholder="What happened?" maxlength="500" />
+						</div>
+						<div>
+							<input type="date" id="kn-dm-ms-add-date" />
+						</div>
+						<div>
+							<button type="button" class="kn-dm-btn kn-dm-btn-primary" id="kn-dm-ms-add-btn" style="width:100%"><i class="fas fa-plus"></i> Add</button>
+						</div>
+					</div>
+					<div class="kn-dm-ms-icons" id="kn-dm-ms-icons" style="margin-top:8px">
+						<?php $_knIcons = ['fa-star','fa-trophy','fa-flag','fa-chess-rook','fa-crown','fa-medal','fa-shield-alt','fa-fire','fa-bolt','fa-scroll','fa-campground','fa-map-marker-alt','fa-users','fa-dragon','fa-hammer','fa-heart']; ?>
+						<?php foreach ($_knIcons as $_ic): ?>
+						<div class="kn-dm-ms-icon-opt<?= $_ic === 'fa-star' ? ' kn-active' : '' ?>" data-icon="<?= htmlspecialchars($_ic) ?>"><i class="fas <?= htmlspecialchars($_ic) ?>"></i></div>
+						<?php endforeach; ?>
+					</div>
+					<div class="kn-dm-hint" id="kn-dm-ms-add-err" style="color:#c53030;display:none;margin-top:6px"></div>
+				</div>
+			</div>
+		</div>
+		<div class="kn-dm-footer">
+			<button class="kn-dm-btn" id="kn-dm-cancel">Cancel</button>
+			<button class="kn-dm-btn kn-dm-btn-primary" id="kn-dm-save"><i class="fas fa-save"></i> Save Changes</button>
+		</div>
+	</div>
+</div>
+
+<script src="https://cdn.jsdelivr.net/npm/marked@12/marked.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/dompurify@3/dist/purify.min.js"></script>
+<script>
+(function() {
+	var KINGDOM_ID = <?= (int)$kingdom_id ?>;
+	var BASE_UIR = '<?= UIR ?>';
+	var KN_FONTS = [
+		{ key:'', label:'Default', family:'inherit' },
+		{ key:'Cinzel', label:'Cinzel', family:'Cinzel' },
+		{ key:'Cinzel Decorative', label:'Cinzel Deco', family:"'Cinzel Decorative'" },
+		{ key:'IM Fell English', label:'IM Fell English', family:"'IM Fell English'" },
+		{ key:'UnifrakturMaguntia', label:'Unifraktur', family:'UnifrakturMaguntia' },
+		{ key:'Metamorphous', label:'Metamorphous', family:'Metamorphous' },
+		{ key:'Uncial Antiqua', label:'Uncial Antiqua', family:"'Uncial Antiqua'" },
+		{ key:'Pirata One', label:'Pirata One', family:"'Pirata One'" },
+		{ key:'Almendra', label:'Almendra', family:'Almendra' },
+		{ key:'Pinyon Script', label:'Pinyon Script', family:"'Pinyon Script'" },
+		{ key:'Great Vibes', label:'Great Vibes', family:"'Great Vibes'" }
+	];
+	var KN_QUICKS = {
+		newbies: 'New players welcome! Every park in the kingdom keeps loaner gear on hand and our experienced fighters love teaching the ropes. Find a park near you on the Map tab.',
+		vibe:    "## The Vibe\n\nFamily-friendly, hard-hitting, and warm. Whether you swing a sword, paint a banner, or sing a song around the fire, there's a place for you here.",
+		findus:  "## Where We Play\n\nWe have parks across the kingdom — check the **Map** tab to find your nearest one. Visit a park day, an event, or both.",
+		founding:"## Founding\n\nThe kingdom was founded in **YYYY** by a group of players meeting at _location_. It was first chartered under _circumstances_.",
+		charter: "## Charter History\n\n- **YYYY** — Chartered as a Shire under Kingdom of _parent_\n- **YYYY** — Elevated to a Principality\n- **YYYY** — Elevated to a full Kingdom\n_(Edit dates and lines as appropriate)_",
+		pastmonarchs:"## Past Monarchs & Regents\n\n- **YYYY–YYYY** — _Persona_ (Monarch), _Persona_ (Regent)\n- **YYYY–YYYY** — _Persona_ (Monarch), _Persona_ (Regent)"
+	};
+	var INITIAL_CUSTOM_MS = <?php
+		$customOnly = array_values(array_filter($knAllMilestones, function($m){ return empty($m['IsDerived']); }));
+		echo json_encode(array_map(function($m){
+			return [
+				'MilestoneId'   => (int)$m['MilestoneId'],
+				'Icon'          => $m['Icon'],
+				'Description'   => $m['Description'],
+				'MilestoneDate' => $m['MilestoneDate'],
+			];
+		}, $customOnly));
+	?>;
+	var knSelectedFont = <?= json_encode($knNameFont) ?>;
+	var knSelectedIcon = 'fa-star';
+	var customMs = INITIAL_CUSTOM_MS.slice();
+
+	function gid(id) { return document.getElementById(id); }
+	function esc(s) { return String(s == null ? '' : s).replace(/[&<>"']/g, function(c) { return ({ '&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;' })[c]; }); }
+
+	window.knOpenDesignModal = function(panel) {
+		gid('kn-dm-overlay').classList.add('kn-open');
+		document.body.style.overflow = 'hidden';
+		if (panel) knSwitchDmPanel(panel);
+		renderCustomMsList();
+	};
+	function close() {
+		gid('kn-dm-overlay').classList.remove('kn-open');
+		document.body.style.overflow = '';
+	}
+	gid('kn-dm-close').addEventListener('click', close);
+	gid('kn-dm-cancel').addEventListener('click', close);
+	gid('kn-dm-overlay').addEventListener('click', function(e) {
+		if (e.target === this) close();
+	});
+	document.addEventListener('keydown', function(e) {
+		if ((e.key === 'Escape' || e.keyCode === 27) && gid('kn-dm-overlay').classList.contains('kn-open')) close();
+	});
+
+	function knSwitchDmPanel(name) {
+		document.querySelectorAll('.kn-dm-tab').forEach(function(t) { t.classList.remove('kn-active'); });
+		document.querySelectorAll('.kn-dm-panel').forEach(function(p) { p.classList.remove('kn-active'); });
+		var tab = document.querySelector('.kn-dm-tab[data-kntab-dm="' + name + '"]');
+		var panel = gid('kn-dm-panel-' + name);
+		if (tab) tab.classList.add('kn-active');
+		if (panel) panel.classList.add('kn-active');
+	}
+	document.querySelectorAll('.kn-dm-tab').forEach(function(t) {
+		t.addEventListener('click', function() { knSwitchDmPanel(t.dataset.kntabDm); });
+	});
+
+	var swatches = document.querySelectorAll('.kn-dm-swatch');
+	swatches.forEach(function(sw) {
+		sw.addEventListener('click', function() {
+			swatches.forEach(function(s) { s.classList.remove('kn-selected'); });
+			sw.classList.add('kn-selected');
+			gid('kn-dm-color-primary').value     = sw.dataset.primary;
+			gid('kn-dm-color-primary-hex').value = sw.dataset.primary;
+			gid('kn-dm-color-accent').value      = sw.dataset.accent;
+			gid('kn-dm-color-accent-hex').value  = sw.dataset.accent;
+			if (sw.dataset.secondary) {
+				gid('kn-dm-color-secondary').value     = sw.dataset.secondary;
+				gid('kn-dm-color-secondary-hex').value = sw.dataset.secondary;
+				gid('kn-dm-gradient-enabled').checked  = true;
+			} else {
+				gid('kn-dm-color-secondary-hex').value = '';
+				gid('kn-dm-gradient-enabled').checked  = false;
+			}
+		});
+	});
+	function syncHex(colorId, hexId) {
+		gid(colorId).addEventListener('input', function() { gid(hexId).value = this.value; });
+		gid(hexId).addEventListener('input', function() {
+			if (/^#[0-9a-f]{6}$/i.test(this.value)) { gid(colorId).value = this.value; }
+		});
+	}
+	syncHex('kn-dm-color-primary',   'kn-dm-color-primary-hex');
+	syncHex('kn-dm-color-accent',    'kn-dm-color-accent-hex');
+	syncHex('kn-dm-color-secondary', 'kn-dm-color-secondary-hex');
+
+	document.querySelectorAll('.kn-dm-overlay-btn').forEach(function(btn) {
+		btn.addEventListener('click', function() {
+			document.querySelectorAll('.kn-dm-overlay-btn').forEach(function(b) { b.classList.remove('kn-active'); });
+			btn.classList.add('kn-active');
+			gid('kn-dm-hero-overlay').value = btn.dataset.overlay;
+		});
+	});
+
+	function knLoadFont(key) {
+		if (!key) return;
+		if (document.querySelector('link[data-kn-font="' + key + '"]')) return;
+		var link = document.createElement('link');
+		link.rel = 'stylesheet';
+		link.href = 'https://fonts.googleapis.com/css2?family=' + key.replace(/ /g, '+') + '&display=swap';
+		link.setAttribute('data-kn-font', key);
+		document.head.appendChild(link);
+	}
+	function knRenderFontPicker() {
+		var container = gid('kn-dm-font-picker');
+		var sample = <?= json_encode($kingdom_name) ?>;
+		var html = '';
+		for (var i = 0; i < KN_FONTS.length; i++) {
+			var f = KN_FONTS[i];
+			var active = f.key === knSelectedFont;
+			html += '<div class="kn-dm-font-card' + (active ? ' kn-active' : '') + '" data-font-key="' + esc(f.key) + '">'
+				 +    '<div class="kn-dm-font-sample" style="font-family:' + f.family + '">' + esc(sample) + '</div>'
+				 +    '<div class="kn-dm-font-label">' + esc(f.label) + '</div>'
+				 + '</div>';
+			knLoadFont(f.key);
+		}
+		container.innerHTML = html;
+		container.addEventListener('click', function(e) {
+			var card = e.target.closest('.kn-dm-font-card');
+			if (!card) return;
+			knSelectedFont = card.dataset.fontKey;
+			container.querySelectorAll('.kn-dm-font-card').forEach(function(c) {
+				c.classList.toggle('kn-active', c === card);
+			});
+		});
+	}
+	knRenderFontPicker();
+
+	function knBindCounter(taId, counterId, limit, formatted) {
+		var ta = gid(taId); var c = gid(counterId);
+		if (!ta || !c) return;
+		function upd() {
+			var n = (ta.value || '').length;
+			c.textContent = n + ' / ' + (formatted || limit);
+			c.classList.toggle('kn-over', n > limit);
+		}
+		ta.addEventListener('input', upd);
+		upd();
+	}
+	knBindCounter('kn-dm-tagline',       'kn-dm-tagline-counter',       160);
+	knBindCounter('kn-dm-announcement',  'kn-dm-announcement-counter',  280);
+	knBindCounter('kn-dm-reign-text',    'kn-dm-reign-counter',         2000, '2,000');
+	var _knAnClear = gid('kn-dm-announcement-clear');
+	if (_knAnClear) _knAnClear.addEventListener('click', function() { gid('kn-dm-announcement-until').value = ''; });
+
+	function knTaIdForField(field) {
+		if (field === 'about')   return 'kn-dm-about-text';
+		if (field === 'history') return 'kn-dm-history-text';
+		if (field === 'reign')   return 'kn-dm-reign-text';
+		return 'kn-dm-' + field + '-text';
+	}
+
+	document.querySelectorAll('[data-knmd-target]').forEach(function(btn) {
+		btn.addEventListener('click', function() {
+			var field  = btn.dataset.knmdField;
+			var target = btn.dataset.knmdTarget;
+			var ta     = gid(knTaIdForField(field));
+			var pv     = gid('kn-dm-' + field + '-preview');
+			btn.parentElement.querySelectorAll('button').forEach(function(b) { b.classList.remove('kn-active'); });
+			btn.classList.add('kn-active');
+			if (target === 'preview') {
+				ta.style.display = 'none';
+				pv.style.display = '';
+				if (typeof marked !== 'undefined' && typeof DOMPurify !== 'undefined') {
+					pv.innerHTML = DOMPurify.sanitize(marked.parse(ta.value || ''));
+				} else {
+					pv.textContent = ta.value;
+				}
+			} else {
+				ta.style.display = '';
+				pv.style.display = 'none';
+			}
+		});
+	});
+
+	document.querySelectorAll('[data-knquick]').forEach(function(btn) {
+		btn.addEventListener('click', function() {
+			var key   = btn.dataset.knquick;
+			var field = btn.dataset.knfield;
+			var ta    = gid('kn-dm-' + (field === 'about' ? 'about-text' : 'history-text'));
+			if (!ta) return;
+			var writeBtn = document.querySelector('[data-knmd-field="' + field + '"][data-knmd-target="edit"]');
+			if (writeBtn && !writeBtn.classList.contains('kn-active')) writeBtn.click();
+			var snippet = KN_QUICKS[key] || '';
+			if (!snippet) return;
+			var existing = ta.value;
+			var sep = existing.length === 0 ? '' : (existing.endsWith('\n\n') ? '' : (existing.endsWith('\n') ? '\n' : '\n\n'));
+			ta.value = existing + sep + snippet;
+			ta.focus();
+			ta.setSelectionRange(ta.value.length, ta.value.length);
+		});
+	});
+
+	function renderCustomMsList() {
+		var list = gid('kn-dm-ms-list');
+		if (!list) return;
+		var newestFirst = gid('kn-dm-ms-newest-first').checked;
+		customMs.sort(function(a, b) {
+			var ad = a.MilestoneDate || '', bd = b.MilestoneDate || '';
+			return newestFirst ? bd.localeCompare(ad) : ad.localeCompare(bd);
+		});
+		if (customMs.length === 0) {
+			list.innerHTML = '<div style="padding:14px;font-size:12px;color:#a0aec0">No custom milestones yet.</div>';
+			return;
+		}
+		var html = '';
+		for (var i = 0; i < customMs.length; i++) {
+			var m = customMs[i];
+			var dateStr = m.MilestoneDate || '';
+			if (dateStr && dateStr !== '0000-00-00') {
+				var d = new Date(dateStr + 'T00:00:00');
+				if (!isNaN(d.getTime())) dateStr = d.toLocaleDateString('en-US', { month:'short', day:'numeric', year:'numeric' });
+			}
+			var icon = (m.Icon || 'fa-star').replace(/[^a-z0-9-]/g, '');
+			html += '<div class="kn-dm-ms-row" data-ms-id="' + m.MilestoneId + '">'
+				 +    '<i class="fas ' + icon + '"></i>'
+				 +    '<span class="kn-dm-ms-desc">' + esc(m.Description) + '</span>'
+				 +    '<span class="kn-dm-ms-date">' + dateStr + '</span>'
+				 +    '<button type="button" data-tip="Delete" onclick="knDeleteKingdomMilestone(' + m.MilestoneId + ')"><i class="fas fa-trash"></i></button>'
+				 + '</div>';
+		}
+		list.innerHTML = html;
+	}
+	gid('kn-dm-ms-newest-first').addEventListener('change', renderCustomMsList);
+
+	var iconGrid = gid('kn-dm-ms-icons');
+	iconGrid.addEventListener('click', function(e) {
+		var opt = e.target.closest('.kn-dm-ms-icon-opt');
+		if (!opt) return;
+		iconGrid.querySelectorAll('.kn-dm-ms-icon-opt').forEach(function(o) { o.classList.remove('kn-active'); });
+		opt.classList.add('kn-active');
+		knSelectedIcon = opt.dataset.icon;
+	});
+
+	gid('kn-dm-ms-add-btn').addEventListener('click', function() {
+		var desc = gid('kn-dm-ms-add-desc').value.trim();
+		var date = gid('kn-dm-ms-add-date').value;
+		var err  = gid('kn-dm-ms-add-err');
+		err.style.display = 'none';
+		if (!desc) { err.textContent = 'Description is required.'; err.style.display = ''; return; }
+		if (!date) { err.textContent = 'Date is required.'; err.style.display = ''; return; }
+		var btn = this; btn.disabled = true; btn.innerHTML = '<i class="fas fa-spinner fa-spin"></i>';
+		var fd = new FormData();
+		fd.append('Description', desc);
+		fd.append('MilestoneDate', date);
+		fd.append('Icon', knSelectedIcon);
+		fetch(BASE_UIR + 'KingdomAjax/kingdom/' + KINGDOM_ID + '/addmilestone', { method: 'POST', body: fd })
+			.then(function(r) { return r.json(); })
+			.then(function(result) {
+				if (result && result.status === 0) {
+					customMs.push({
+						MilestoneId: result.milestoneId,
+						Icon: knSelectedIcon,
+						Description: desc,
+						MilestoneDate: date
+					});
+					renderCustomMsList();
+					gid('kn-dm-ms-add-desc').value = '';
+					gid('kn-dm-ms-add-date').value = '';
+					iconGrid.querySelectorAll('.kn-dm-ms-icon-opt').forEach(function(o) { o.classList.remove('kn-active'); });
+					iconGrid.querySelector('[data-icon="fa-star"]').classList.add('kn-active');
+					knSelectedIcon = 'fa-star';
+				} else {
+					err.textContent = (result && result.error) || 'Failed to add milestone.';
+					err.style.display = '';
+				}
+			})
+			.catch(function() {
+				err.textContent = 'Request failed.';
+				err.style.display = '';
+			})
+			.finally(function() {
+				btn.disabled = false;
+				btn.innerHTML = '<i class="fas fa-plus"></i> Add';
+			});
+	});
+
+	window.knDeleteKingdomMilestone = function(id) {
+		if (!confirm('Delete this milestone?')) return;
+		var fd = new FormData();
+		fd.append('MilestoneId', id);
+		fetch(BASE_UIR + 'KingdomAjax/kingdom/' + KINGDOM_ID + '/deletemilestone', { method: 'POST', body: fd })
+			.then(function(r) { return r.json(); })
+			.then(function(result) {
+				if (result && result.status === 0) {
+					customMs = customMs.filter(function(m) { return m.MilestoneId !== id; });
+					renderCustomMsList();
+				} else {
+					alert((result && result.error) || 'Failed to delete milestone.');
+				}
+			})
+			.catch(function() { alert('Request failed.'); });
+	};
+
+	gid('kn-dm-save').addEventListener('click', function() {
+		var btn = this; btn.disabled = true; btn.innerHTML = '<i class="fas fa-spinner fa-spin"></i> Saving...';
+		var errEl = gid('kn-dm-error'); errEl.style.display = 'none';
+		var fd = new FormData();
+		fd.append('AboutText', gid('kn-dm-about-text').value);
+		fd.append('OurHistory', gid('kn-dm-history-text').value);
+		fd.append('ColorPrimary', gid('kn-dm-color-primary').value);
+		fd.append('ColorAccent', gid('kn-dm-color-accent').value);
+		fd.append('ColorSecondary', gid('kn-dm-gradient-enabled').checked ? gid('kn-dm-color-secondary').value : '');
+		fd.append('HeroOverlay', gid('kn-dm-hero-overlay').value);
+		fd.append('NameFont', knSelectedFont || '');
+		var msConfig = {};
+		document.querySelectorAll('#kn-dm-ms-toggles input[data-knms-type]').forEach(function(t) {
+			msConfig[t.dataset.knmsType] = t.checked ? 1 : 0;
+		});
+		msConfig['newest_first'] = gid('kn-dm-ms-newest-first').checked ? 1 : 0;
+		fd.append('MilestoneConfig', JSON.stringify(msConfig));
+
+		fd.append('Tagline', gid('kn-dm-tagline').value);
+		fd.append('Announcement', gid('kn-dm-announcement').value);
+		fd.append('AnnouncementUntil', gid('kn-dm-announcement-until').value);
+		fd.append('MonarchReignStarted', gid('kn-dm-monarch-reign').value);
+		fd.append('RegentReignStarted', gid('kn-dm-regent-reign').value);
+		fd.append('ReignLore', gid('kn-dm-reign-text').value);
+
+		var socialPayload = {};
+		document.querySelectorAll('[data-knsoc]').forEach(function(inp) {
+			var v = (inp.value || '').trim();
+			if (v) socialPayload[inp.dataset.knsoc] = v;
+		});
+		fd.append('SocialLinks', JSON.stringify(socialPayload));
+
+		fetch(BASE_UIR + 'KingdomAjax/kingdom/' + KINGDOM_ID + '/savedesign', { method: 'POST', body: fd })
+			.then(function(r) { return r.json(); })
+			.then(function(result) {
+				if (result && result.status === 0) {
+					window.location.reload();
+				} else {
+					errEl.textContent = (result && result.error) || 'Save failed.';
+					errEl.style.display = 'block';
+					btn.disabled = false;
+					btn.innerHTML = '<i class="fas fa-save"></i> Save Changes';
+				}
+			})
+			.catch(function(e) {
+				errEl.textContent = 'Request failed: ' + e.message;
+				errEl.style.display = 'block';
+				btn.disabled = false;
+				btn.innerHTML = '<i class="fas fa-save"></i> Save Changes';
+			});
+	});
+
+	renderCustomMsList();
+})();
+</script>
 <?php endif; ?>

--- a/orkui/template/revised-frontend/Parknew_index.tpl
+++ b/orkui/template/revised-frontend/Parknew_index.tpl
@@ -78,6 +78,81 @@
 		}
 	}
 
+	// --- Park Design (header, About, Milestones customization) -----------------------
+	$aboutText      = (string)($parkInfo['AboutText']   ?? '');
+	$ourHistoryText = (string)($parkInfo['OurHistory']  ?? '');
+	// Fallback: if no customized about_text yet, keep showing the legacy description.
+	if (trim($aboutText) === '') { $aboutText = $description; }
+
+	$pkColorPrimary   = trim((string)($parkInfo['ColorPrimary']   ?? ''));
+	$pkColorAccent    = trim((string)($parkInfo['ColorAccent']    ?? ''));
+	$pkColorSecondary = trim((string)($parkInfo['ColorSecondary'] ?? ''));
+	$pkOverlay        = strtolower(trim((string)($parkInfo['HeroOverlay'] ?? 'med')));
+	if (!in_array($pkOverlay, ['low','med','high','vignette'], true)) $pkOverlay = 'med';
+	$pkNameFont       = trim((string)($parkInfo['NameFont'] ?? ''));
+	$pkMilestoneCfg   = [];
+	if (!empty($parkInfo['MilestoneConfig'])) {
+		$_mc = json_decode($parkInfo['MilestoneConfig'], true);
+		if (is_array($_mc)) $pkMilestoneCfg = $_mc;
+	}
+	// Visibility default: ON for every known type unless config says 0.
+	$pkMsVisible = function($type) use ($pkMilestoneCfg) {
+		if (!array_key_exists($type, $pkMilestoneCfg)) return true;
+		return !empty($pkMilestoneCfg[$type]);
+	};
+	$pkMsNewestFirst = !empty($pkMilestoneCfg['newest_first']);
+
+	$pkAllMilestones  = is_array($Milestones ?? null) ? $Milestones : [];
+	$pkVisibleMilestones = [];
+	foreach ($pkAllMilestones as $_pkms) {
+		$_t = $_pkms['Type'] ?? 'custom';
+		if ($pkMsVisible($_t)) $pkVisibleMilestones[] = $_pkms;
+	}
+	if ($pkMsNewestFirst) $pkVisibleMilestones = array_reverse($pkVisibleMilestones);
+	$pkHasMilestones = count($pkVisibleMilestones) > 0;
+
+	// Hero font CSS — wrap font name in single quotes for CSS safety; bypass for viewer accessibility fonts is left to a future enhancement.
+	$pkHeroFontCss = $pkNameFont !== '' ? ("'" . str_replace("'", '', $pkNameFont) . "'") : '';
+
+	// Overlay opacity map for the heraldry background image on the hero.
+	$pkOverlayOpacity = ['low' => 0.06, 'med' => 0.13, 'high' => 0.28, 'vignette' => 0.45][$pkOverlay] ?? 0.13;
+
+	// --- Phase 2 customizations: tagline, social links, announcement ---
+	$pkTagline           = trim((string)($parkInfo['Tagline'] ?? ''));
+	$pkAnnouncement      = trim((string)($parkInfo['Announcement'] ?? ''));
+	$pkAnnouncementUntil = trim((string)($parkInfo['AnnouncementUntil'] ?? ''));
+	$pkShowAnnouncement  = ($pkAnnouncement !== '');
+	if ($pkShowAnnouncement && $pkAnnouncementUntil !== '' && $pkAnnouncementUntil !== '0000-00-00') {
+		$pkShowAnnouncement = (strtotime($pkAnnouncementUntil) >= strtotime(date('Y-m-d')));
+	}
+	$pkSocialRaw   = (string)($parkInfo['SocialLinks'] ?? '');
+	$pkSocialLinks = [];
+	if ($pkSocialRaw !== '') {
+		$_sl = json_decode($pkSocialRaw, true);
+		if (is_array($_sl)) {
+			foreach ($_sl as $_k => $_v) {
+				$_v = trim((string)$_v);
+				if ($_v !== '' && preg_match('#^https?://#i', $_v)) {
+					$pkSocialLinks[(string)$_k] = $_v;
+				}
+			}
+		}
+	}
+	$pkSocialPlatforms = [
+		'discord'   => ['label'=>'Discord',   'icon'=>'fab fa-discord',         'bg'=>'#5865f2', 'placeholder'=>'https://discord.gg/...'],
+		'facebook'  => ['label'=>'Facebook',  'icon'=>'fab fa-facebook',        'bg'=>'#1877f2', 'placeholder'=>'https://facebook.com/...'],
+		'instagram' => ['label'=>'Instagram', 'icon'=>'fab fa-instagram',       'bg'=>'#e4405f', 'placeholder'=>'https://instagram.com/...'],
+		'threads'   => ['label'=>'Threads',   'icon'=>'fab fa-square-threads',  'bg'=>'#000000', 'placeholder'=>'https://threads.net/@...'],
+		'bluesky'   => ['label'=>'Bluesky',   'icon'=>'fas fa-cloud',           'bg'=>'#1185fe', 'placeholder'=>'https://bsky.app/profile/...'],
+		'twitter'   => ['label'=>'Twitter',   'icon'=>'fab fa-twitter',         'bg'=>'#1da1f2', 'placeholder'=>'https://twitter.com/...'],
+		'youtube'   => ['label'=>'YouTube',   'icon'=>'fab fa-youtube',         'bg'=>'#ff0000', 'placeholder'=>'https://youtube.com/@...'],
+		'amtwiki'   => ['label'=>'Amtwiki',   'icon'=>'fas fa-book',            'bg'=>'#4a5568', 'placeholder'=>'https://amtwiki.net/...'],
+	];
+	$pkHasSocial = false;
+	foreach ($pkSocialPlatforms as $_slug => $_meta) {
+		if (!empty($pkSocialLinks[$_slug])) { $pkHasSocial = true; break; }
+	}
+
 
 	// Pre-compute FullCalendar event data
 	$pkCalEvents = [];
@@ -176,9 +251,206 @@
 <link rel="stylesheet" href="<?= HTTP_TEMPLATE ?>revised-frontend/style/revised.css?v=<?= filemtime(DIR_TEMPLATE . 'revised-frontend/style/revised.css') ?>">
 <link rel="stylesheet" href="https://cdn.datatables.net/1.13.8/css/jquery.dataTables.min.css">
 
+<?php if ($pkNameFont !== ''): ?>
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=<?= rawurlencode($pkNameFont) ?>&display=swap">
+<?php endif; ?>
+
+<style>
+/* --- Park Design: hero customization ----------------------------------------- */
+<?php if ($pkColorPrimary): ?>
+.pk-hero {
+	background-color: <?= htmlspecialchars($pkColorPrimary) ?> !important;
+<?php if ($pkColorSecondary && $pkColorSecondary !== $pkColorPrimary): ?>
+	background: linear-gradient(135deg, <?= htmlspecialchars($pkColorPrimary) ?>, <?= htmlspecialchars($pkColorSecondary) ?>) !important;
+<?php endif; ?>
+}
+html[data-theme="dark"] .pk-hero {
+	background-color: <?= htmlspecialchars($pkColorPrimary) ?> !important;
+<?php if ($pkColorSecondary && $pkColorSecondary !== $pkColorPrimary): ?>
+	background: linear-gradient(135deg, <?= htmlspecialchars($pkColorPrimary) ?>, <?= htmlspecialchars($pkColorSecondary) ?>) !important;
+<?php endif; ?>
+	filter: brightness(0.85);
+}
+<?php endif; ?>
+<?php if ($pkColorAccent): ?>
+:root { --pk-accent: <?= htmlspecialchars($pkColorAccent) ?>; }
+.pk-tab-nav li.pk-tab-active { color: <?= htmlspecialchars($pkColorAccent) ?> !important; border-bottom-color: <?= htmlspecialchars($pkColorAccent) ?> !important; }
+html[data-theme="dark"] .pk-tab-nav li.pk-tab-active { color: <?= htmlspecialchars($pkColorAccent) ?> !important; border-bottom-color: <?= htmlspecialchars($pkColorAccent) ?> !important; }
+.pk-stat-card { position: relative; }
+.pk-stat-card::before {
+	content: ''; position: absolute; top: 0; left: 0; right: 0; height: 3px;
+	background: <?= htmlspecialchars($pkColorAccent) ?>;
+	border-top-left-radius: 8px; border-top-right-radius: 8px;
+}
+.pk-kingdom-link a i { color: <?= htmlspecialchars($pkColorAccent) ?>; }
+<?php endif; ?>
+.pk-hero-bg { opacity: <?= $pkOverlayOpacity ?> !important; }
+<?php if ($pkOverlay === 'vignette'): ?>
+.pk-hero-bg {
+	-webkit-mask-image: radial-gradient(ellipse at center, rgba(0,0,0,0.95) 38%, rgba(0,0,0,0) 78%);
+	        mask-image: radial-gradient(ellipse at center, rgba(0,0,0,0.95) 38%, rgba(0,0,0,0) 78%);
+}
+<?php endif; ?>
+<?php if ($pkNameFont !== '' && $pkHeroFontCss !== ''): ?>
+.pk-park-name { font-family: <?= $pkHeroFontCss ?>, 'Cinzel', serif !important; letter-spacing: 0.02em; }
+<?php endif; ?>
+
+/* --- Phase 2: Tagline --- */
+.pk-tagline {
+	font-style: italic; font-size: 13px; color: rgba(255,255,255,0.78);
+	margin: 2px 0 4px; max-width: 640px;
+	white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
+html[data-theme="dark"] .pk-tagline { color: rgba(255,255,255,0.7); }
+
+/* --- Phase 2: Announcement Banner --- */
+.pk-announcement {
+	display: flex; align-items: center; gap: 10px;
+	background: #fffbeb; color: #92400e; border: 1px solid #fcd34d;
+	border-radius: 8px; padding: 8px 14px; margin-bottom: 10px;
+	font-size: 13px; line-height: 1.4;
+}
+.pk-announcement i.fa-bullhorn { color: #d97706; flex-shrink: 0; }
+.pk-announcement-text { flex: 1; }
+.pk-announcement-until { font-size: 11px; opacity: 0.8; font-style: italic; white-space: nowrap; }
+html[data-theme="dark"] .pk-announcement {
+	background: rgba(251,191,36,0.15); color: #fbbf24; border-color: rgba(251,191,36,0.35);
+}
+html[data-theme="dark"] .pk-announcement i.fa-bullhorn { color: #fbbf24; }
+
+/* --- Phase 2: Connect (sidebar) --- */
+.pk-connect-block { margin-top: 14px; padding-top: 12px; border-top: 1px dashed #e2e8f0; }
+html[data-theme="dark"] .pk-connect-block { border-top-color: var(--ork-border); }
+.pk-connect-subhead {
+	display: flex; align-items: center; justify-content: space-between;
+	font-size: 11px; text-transform: uppercase; letter-spacing: 0.08em;
+	color: #718096; font-weight: 600; margin-bottom: 8px;
+}
+html[data-theme="dark"] .pk-connect-subhead { color: var(--ork-text-muted); }
+.pk-connect-subhead i { margin-right: 4px; opacity: 0.6; }
+.pk-connect-edit {
+	background: transparent; border: 0; cursor: pointer; color: #a0aec0; font-size: 11px; padding: 2px 6px; border-radius: 4px;
+}
+.pk-connect-edit:hover { background: rgba(49,130,206,0.08); color: #2b6cb0; }
+html[data-theme="dark"] .pk-connect-edit:hover { background: var(--ork-bg-tertiary); color: var(--ork-link); }
+.pk-connect-pills { display: flex; flex-wrap: wrap; gap: 8px; }
+.pk-connect-pill {
+	width: 34px; height: 34px; border-radius: 50%;
+	display: inline-flex; align-items: center; justify-content: center;
+	color: #fff !important; text-decoration: none !important;
+	font-size: 14px; line-height: 1;
+	background: var(--pk-accent, #2b6cb0);
+	transition: transform 0.12s, box-shadow 0.12s;
+	position: relative;
+}
+.pk-connect-pill:hover { transform: scale(1.08); box-shadow: 0 3px 10px rgba(0,0,0,0.18); }
+.pk-connect-pill[data-tip]::after {
+	content: attr(data-tip); position: absolute; bottom: calc(100% + 6px); left: 50%; transform: translateX(-50%);
+	background: #2d3748; color: #fff; font-size: 11px; white-space: nowrap;
+	padding: 3px 8px; border-radius: 4px; pointer-events: none; opacity: 0;
+	transition: opacity 0.12s; z-index: 600;
+}
+.pk-connect-pill[data-tip]:hover::after { opacity: 1; transition-delay: 0.3s; }
+html[data-theme="dark"] .pk-connect-pill[data-tip]::after {
+	background: var(--ork-bg-tertiary); color: var(--ork-text); border: 1px solid var(--ork-border);
+}
+.pk-connect-empty {
+	display: inline-flex; font-size: 11px; color: #a0aec0; text-decoration: none;
+	padding: 4px 8px; border: 1px dashed #cbd5e0; border-radius: 999px;
+}
+.pk-connect-empty:hover { color: #2b6cb0; border-color: #2b6cb0; }
+html[data-theme="dark"] .pk-connect-empty { color: var(--ork-text-muted); border-color: var(--ork-border); }
+
+/* --- Park Design: About markdown body + Our History + Milestones ------------- */
+.pk-about-text { line-height: 1.6; }
+.pk-about-text h1, .pk-about-text h2, .pk-about-text h3, .pk-about-text h4 {
+	margin-top: 1.1em; margin-bottom: 0.4em;
+	background: transparent; border: none; padding: 0; border-radius: 0; text-shadow: none;
+}
+.pk-about-section-head {
+	display:flex; align-items:center; justify-content:space-between;
+	gap:8px; margin-bottom:6px;
+}
+.pk-about-edit-btn {
+	background: transparent; border: 1px solid transparent; color: #a0aec0;
+	padding: 4px 8px; border-radius: 6px; cursor: pointer; font-size: 12px;
+	display:inline-flex; align-items:center; gap:4px;
+	transition: background 0.15s, color 0.15s, border-color 0.15s;
+}
+.pk-about-edit-btn:hover { background: rgba(49,130,206,0.08); color: #2b6cb0; border-color: rgba(49,130,206,0.25); }
+html[data-theme="dark"] .pk-about-edit-btn { color: var(--ork-text-muted); }
+html[data-theme="dark"] .pk-about-edit-btn:hover { background: var(--ork-bg-tertiary); color: var(--ork-link); border-color: var(--ork-border); }
+.pk-about-edit-btn[data-tip] { position: relative; }
+.pk-about-edit-btn[data-tip]::after {
+	content: attr(data-tip); position: absolute; bottom: calc(100% + 6px); right: 0;
+	background: #2d3748; color: #fff; font-size: 11px; font-style: italic; white-space: nowrap;
+	padding: 4px 10px; border-radius: 4px; pointer-events: none; opacity: 0;
+	transition: opacity 0s; z-index: 500;
+}
+.pk-about-edit-btn[data-tip]:hover::after { opacity: 1; transition-delay: 0.4s; }
+html[data-theme="dark"] .pk-about-edit-btn[data-tip]::after { background: var(--ork-bg-tertiary); color: var(--ork-text); border: 1px solid var(--ork-border); }
+
+/* Our History — visually distinct from About */
+.pk-history-section { margin-top: 18px; padding-top: 18px; border-top: 1px dashed #e2e8f0; }
+html[data-theme="dark"] .pk-history-section { border-top-color: var(--ork-border); }
+
+/* Milestones timeline (mirrors player .pn-timeline-* with park prefix) */
+.pk-timeline-section { margin-top: 22px; padding-top: 18px; border-top: 1px dashed #e2e8f0; }
+html[data-theme="dark"] .pk-timeline-section { border-top-color: var(--ork-border); }
+.pk-timeline-heading {
+	font-size: 13px; font-weight: 700; color: #4a5568;
+	text-transform: uppercase; letter-spacing: 0.5px;
+	margin: 0 0 14px 0;
+	background: transparent; border: none; padding: 0; border-radius: 0; text-shadow: none;
+	display: flex; align-items: center; gap: 8px;
+}
+html[data-theme="dark"] .pk-timeline-heading { color: var(--ork-text-secondary); }
+.pk-timeline { position: relative; padding-left: 32px; }
+.pk-timeline::before {
+	content: ''; position: absolute; left: 11px; top: 4px; bottom: 4px; width: 2px;
+	background: linear-gradient(to bottom, #cbd5e0, #cbd5e0 60%, transparent);
+}
+html[data-theme="dark"] .pk-timeline::before { background: linear-gradient(to bottom, var(--ork-border), var(--ork-border) 60%, transparent); }
+.pk-timeline-row {
+	position: relative; display: flex; align-items: center; gap: 12px;
+	margin-bottom: 14px; min-height: 24px;
+}
+.pk-timeline-dot {
+	position: absolute; left: -25px; top: 50%; transform: translateY(-50%);
+	width: 24px; height: 24px; border-radius: 50%;
+	background: #ebf8ff; color: #2b6cb0; display: flex; align-items: center; justify-content: center;
+	font-size: 11px; border: 2px solid #fff; box-shadow: 0 0 0 1px #cbd5e0;
+}
+.pk-timeline-row.pk-ms-derived .pk-timeline-dot { background: #faf5ff; color: #6b46c1; box-shadow: 0 0 0 1px #d6bcfa; }
+html[data-theme="dark"] .pk-timeline-dot { background: var(--ork-bg-tertiary); color: var(--ork-link); border-color: var(--ork-card-bg); box-shadow: 0 0 0 1px var(--ork-border); }
+.pk-timeline-content {
+	flex: 1; display: flex; align-items: baseline; gap: 10px; flex-wrap: wrap;
+	font-size: 13px;
+}
+.pk-timeline-date { color: #718096; font-size: 11px; font-weight: 600; min-width: 80px; }
+html[data-theme="dark"] .pk-timeline-date { color: var(--ork-text-muted); }
+.pk-timeline-desc { color: #2d3748; }
+html[data-theme="dark"] .pk-timeline-desc { color: var(--ork-text); }
+.pk-timeline-row.pk-ms-derived .pk-timeline-desc { color: #553c9a; }
+html[data-theme="dark"] .pk-timeline-row.pk-ms-derived .pk-timeline-desc { color: hsl(265, 60%, 75%); }
+.pk-timeline-empty {
+	font-size: 12px; color: #a0aec0; font-style: italic;
+	padding: 10px 0;
+}
+</style>
+
 <!-- =============================================
      ZONE 1: Hero Header
      ============================================= -->
+<?php if ($pkShowAnnouncement): ?>
+<div class="pk-announcement">
+	<i class="fas fa-bullhorn"></i>
+	<span class="pk-announcement-text"><?= htmlspecialchars($pkAnnouncement) ?></span>
+	<?php if ($pkAnnouncementUntil !== '' && $pkAnnouncementUntil !== '0000-00-00'): ?>
+	<span class="pk-announcement-until">through <?= date('M j', strtotime($pkAnnouncementUntil)) ?></span>
+	<?php endif; ?>
+</div>
+<?php endif; ?>
 <div class="pk-hero<?= $parkIsInactive ? ' pk-hero--inactive' : '' ?>">
 	<div class="pk-hero-bg" style="background-image: url('<?= htmlspecialchars($heraldryUrl) ?>')"></div>
 	<div class="pk-hero-content">
@@ -208,6 +480,9 @@
 				</a>
 			</div>
 			<h1 class="pk-park-name"><?= htmlspecialchars($park_name) ?></h1>
+			<?php if ($pkTagline !== ''): ?>
+			<div class="pk-tagline"><?= htmlspecialchars($pkTagline) ?></div>
+			<?php endif; ?>
 			<div class="pk-hero-badges">
 				<?php if (!empty($parkTitle)): ?>
 					<span class="pk-park-title-badge"><?= htmlspecialchars($parkTitle) ?></span>
@@ -248,6 +523,9 @@
 				<?php if (!empty($CanAdminPark)): ?>
 					<button class="pk-btn pk-btn-outline" onclick="pkOpenAwardModal()">
 						<i class="fas fa-medal"></i> Enter Awards
+					</button>
+					<button class="pk-btn pk-btn-outline" onclick="pkOpenDesignModal()">
+						<i class="fas fa-palette"></i> Design
 					</button>
 					<button class="pk-btn pk-btn-outline" onclick="pkOpenAdminModal()">
 						<i class="fas fa-cog"></i> Admin
@@ -387,6 +665,31 @@
 				</li>
 				<?php endif; ?>
 			</ul>
+			<?php if ($pkHasSocial || !empty($CanAdminPark)): ?>
+			<div class="pk-connect-block">
+				<div class="pk-connect-subhead">
+					<span><i class="fas fa-share-alt"></i> Connect</span>
+					<?php if (!empty($CanAdminPark)): ?>
+					<button class="pk-connect-edit" type="button" onclick="pkOpenDesignModal('about')" data-tip="Edit social links"><i class="fas fa-pencil-alt"></i></button>
+					<?php endif; ?>
+				</div>
+				<?php if ($pkHasSocial): ?>
+				<div class="pk-connect-pills">
+					<?php foreach ($pkSocialPlatforms as $_slug => $_meta): ?>
+						<?php if (!empty($pkSocialLinks[$_slug])): ?>
+						<a href="<?= htmlspecialchars($pkSocialLinks[$_slug]) ?>" target="_blank" rel="noopener"
+						   class="pk-connect-pill"
+						   data-tip="<?= htmlspecialchars($_meta['label']) ?>">
+							<i class="<?= htmlspecialchars($_meta['icon']) ?>"></i>
+						</a>
+						<?php endif; ?>
+					<?php endforeach; ?>
+				</div>
+				<?php elseif (!empty($CanAdminPark)): ?>
+				<a href="#" class="pk-connect-empty" onclick="event.preventDefault();pkOpenDesignModal('about')">+ Add</a>
+				<?php endif; ?>
+			</div>
+			<?php endif; ?>
 		</div>
 
 	</aside>
@@ -442,10 +745,23 @@
 					$_addrFull  = implode(', ', array_filter([$_addrLine1, $_addrLine2]));
 				?>
 				<div class="pk-about-grid">
-					<?php if (!empty($description)): ?>
+					<?php if (!empty($aboutText) || !empty($CanAdminPark)): ?>
 					<div class="pk-about-section">
-						<div class="pk-about-label">About</div>
-						<div class="pk-about-text kn-description-body"><?= pk_markdown($description) ?></div>
+						<div class="pk-about-section-head">
+							<div class="pk-about-label">About</div>
+							<?php if (!empty($CanAdminPark)): ?>
+							<button class="pk-about-edit-btn" type="button" onclick="pkOpenDesignModal('about')" data-tip="Edit About">
+								<i class="fas fa-pencil-alt"></i> Edit
+							</button>
+							<?php endif; ?>
+						</div>
+						<?php if (!empty($aboutText)): ?>
+						<div class="pk-about-text kn-description-body"><?= pk_markdown($aboutText) ?></div>
+						<?php elseif (!empty($CanAdminPark)): ?>
+						<div class="pk-empty" style="text-align:left;font-size:13px;color:#a0aec0">
+							No About content yet. <a href="#" onclick="event.preventDefault();pkOpenDesignModal('about')">Add some</a> to introduce <?= htmlspecialchars($park_name) ?> to visitors.
+						</div>
+						<?php endif; ?>
 					</div>
 					<?php endif; ?>
 
@@ -465,6 +781,26 @@
 					<?php endif; ?>
 				</div>
 
+				<?php if (!empty($ourHistoryText) || !empty($CanAdminPark)): ?>
+				<div class="pk-about-section pk-history-section">
+					<div class="pk-about-section-head">
+						<div class="pk-about-label"><i class="fas fa-scroll" style="margin-right:6px;color:#a0aec0"></i>Our History</div>
+						<?php if (!empty($CanAdminPark)): ?>
+						<button class="pk-about-edit-btn" type="button" onclick="pkOpenDesignModal('about')" data-tip="Edit Our History">
+							<i class="fas fa-pencil-alt"></i> Edit
+						</button>
+						<?php endif; ?>
+					</div>
+					<?php if (!empty($ourHistoryText)): ?>
+					<div class="pk-about-text kn-description-body"><?= pk_markdown($ourHistoryText) ?></div>
+					<?php elseif (!empty($CanAdminPark)): ?>
+					<div class="pk-empty" style="text-align:left;font-size:13px;color:#a0aec0">
+						Share the founding story, past officers, or notable moments. <a href="#" onclick="event.preventDefault();pkOpenDesignModal('about')">Add Our History</a>.
+					</div>
+					<?php endif; ?>
+				</div>
+				<?php endif; ?>
+
 				<?php if (!empty($websiteUrl) || !empty($parkInfo['MapUrl'])): ?>
 				<div class="pk-about-section pk-about-meta" style="margin-top:12px">
 					<?php if (!empty($websiteUrl)): ?>
@@ -477,6 +813,39 @@
 					<div class="pk-about-meta-row">
 						<i class="fas fa-map"></i>
 						<a href="<?= htmlspecialchars($parkInfo['MapUrl']) ?>" target="_blank" rel="noopener">View on Map</a>
+					</div>
+					<?php endif; ?>
+				</div>
+				<?php endif; ?>
+
+				<!-- Milestones timeline (derived + custom) -->
+				<?php if ($pkHasMilestones || !empty($CanAdminPark)): ?>
+				<div class="pk-about-section pk-timeline-section">
+					<div class="pk-about-section-head">
+						<h3 class="pk-timeline-heading"><i class="fas fa-stream"></i> Milestones</h3>
+						<?php if (!empty($CanAdminPark)): ?>
+						<button class="pk-about-edit-btn" type="button" onclick="pkOpenDesignModal('milestones')" data-tip="Manage milestones">
+							<i class="fas fa-pencil-alt"></i> Manage
+						</button>
+						<?php endif; ?>
+					</div>
+					<?php if ($pkHasMilestones): ?>
+					<div class="pk-timeline">
+						<?php foreach ($pkVisibleMilestones as $_pkms): ?>
+						<div class="pk-timeline-row<?= !empty($_pkms['IsDerived']) ? ' pk-ms-derived' : '' ?>">
+							<div class="pk-timeline-dot">
+								<i class="fas <?= htmlspecialchars(preg_replace('/[^a-z0-9-]/','', (string)($_pkms['Icon'] ?? 'fa-star')) ?: 'fa-star') ?>"></i>
+							</div>
+							<div class="pk-timeline-content">
+								<span class="pk-timeline-date"><?= !empty($_pkms['MilestoneDate']) && $_pkms['MilestoneDate'] !== '0000-00-00' ? date('M j, Y', strtotime($_pkms['MilestoneDate'])) : '' ?></span>
+								<span class="pk-timeline-desc"><?= htmlspecialchars((string)($_pkms['Description'] ?? '')) ?></span>
+							</div>
+						</div>
+						<?php endforeach; ?>
+					</div>
+					<?php elseif (!empty($CanAdminPark)): ?>
+					<div class="pk-timeline-empty">
+						No milestones yet. <a href="#" onclick="event.preventDefault();pkOpenDesignModal('milestones')">Add the first one</a> — founding date, elevation history, notable events.
 					</div>
 					<?php endif; ?>
 				</div>
@@ -2151,4 +2520,864 @@ window.OrkRsCfg = {
 };
 </script>
 <?php include __DIR__ . '/_recommendation_seconds_assets.tpl'; ?>
+<?php endif; ?>
+
+<?php if (!empty($CanAdminPark)): ?>
+<!-- =============================================
+     Park Design Modal
+     ============================================= -->
+<style>
+/* --- Park Design Modal: scoped styles (pk-dm-*) ----------------------------- */
+.pk-dm-overlay {
+	position: fixed; inset: 0; background: rgba(0,0,0,0.55); z-index: 10000;
+	display: none; align-items: center; justify-content: center; padding: 20px;
+}
+.pk-dm-overlay.pk-open { display: flex; }
+.pk-dm-modal {
+	background: #fff; border-radius: 10px; width: 720px; max-width: calc(100vw - 40px);
+	max-height: 88vh; display: flex; flex-direction: column; overflow: hidden;
+	box-shadow: 0 18px 50px rgba(0,0,0,0.35);
+}
+html[data-theme="dark"] .pk-dm-modal { background: var(--ork-card-bg); color: var(--ork-text); }
+.pk-dm-header {
+	display: flex; align-items: center; justify-content: space-between;
+	padding: 14px 18px; border-bottom: 1px solid #e2e8f0;
+}
+html[data-theme="dark"] .pk-dm-header { border-color: var(--ork-border); background: var(--ork-bg-secondary); }
+.pk-dm-title {
+	margin: 0; font-size: 16px; font-weight: 700; color: #2d3748;
+	background: transparent; border: none; padding: 0; border-radius: 0; text-shadow: none;
+	display: inline-flex; align-items: center; gap: 8px;
+}
+html[data-theme="dark"] .pk-dm-title { color: var(--ork-text); }
+.pk-dm-close {
+	background: transparent; border: 0; font-size: 22px; cursor: pointer; color: #718096;
+	width: 32px; height: 32px; border-radius: 6px;
+}
+.pk-dm-close:hover { background: #f7fafc; color: #2d3748; }
+html[data-theme="dark"] .pk-dm-close { color: var(--ork-text-muted); }
+html[data-theme="dark"] .pk-dm-close:hover { background: var(--ork-bg-tertiary); color: var(--ork-text); }
+.pk-dm-tabs {
+	display: flex; gap: 4px; padding: 8px 18px 0 18px; border-bottom: 1px solid #e2e8f0;
+	background: #f7fafc;
+}
+html[data-theme="dark"] .pk-dm-tabs { background: var(--ork-bg-secondary); border-color: var(--ork-border); }
+.pk-dm-tab {
+	background: transparent; border: 1px solid transparent; border-bottom: none;
+	padding: 8px 14px; font-size: 13px; font-weight: 600; color: #718096; cursor: pointer;
+	border-radius: 6px 6px 0 0; display: inline-flex; align-items: center; gap: 6px;
+}
+.pk-dm-tab.pk-active {
+	background: #fff; color: #2b6cb0; border-color: #e2e8f0; border-bottom: 1px solid #fff;
+	margin-bottom: -1px;
+}
+html[data-theme="dark"] .pk-dm-tab { color: var(--ork-text-secondary); }
+html[data-theme="dark"] .pk-dm-tab.pk-active {
+	background: var(--ork-card-bg); color: var(--ork-link); border-color: var(--ork-border);
+	border-bottom-color: var(--ork-card-bg);
+}
+.pk-dm-body {
+	padding: 18px; overflow-y: auto; flex: 1;
+}
+.pk-dm-panel { display: none; }
+.pk-dm-panel.pk-active { display: block; }
+.pk-dm-error {
+	display: none; background: #fff5f5; border: 1px solid #fc8181; color: #9b2c2c;
+	border-radius: 6px; padding: 10px 12px; font-size: 13px; margin-bottom: 12px;
+}
+html[data-theme="dark"] .pk-dm-error { background: rgba(252,129,129,0.1); color: #fc8181; }
+.pk-dm-field { margin-bottom: 14px; }
+.pk-dm-field label {
+	display: block; font-size: 12px; font-weight: 700; color: #4a5568;
+	text-transform: uppercase; letter-spacing: 0.4px; margin-bottom: 4px;
+}
+html[data-theme="dark"] .pk-dm-field label { color: var(--ork-text-secondary); }
+.pk-dm-field input[type="text"],
+.pk-dm-field input[type="date"],
+.pk-dm-field textarea,
+.pk-dm-field select {
+	width: 100%; padding: 8px 10px; border: 1px solid #cbd5e0; border-radius: 6px;
+	font-size: 14px; color: #2d3748; box-sizing: border-box; background: #fff;
+	font-family: inherit;
+}
+html[data-theme="dark"] .pk-dm-field input,
+html[data-theme="dark"] .pk-dm-field textarea,
+html[data-theme="dark"] .pk-dm-field select {
+	background: var(--ork-input-bg); border-color: var(--ork-input-border); color: var(--ork-text);
+}
+.pk-dm-field textarea { min-height: 140px; resize: vertical; line-height: 1.5; }
+.pk-dm-hint {
+	font-size: 12px; color: #718096; margin-top: 4px;
+}
+html[data-theme="dark"] .pk-dm-hint { color: var(--ork-text-muted); }
+.pk-dm-footer {
+	border-top: 1px solid #e2e8f0; padding: 12px 18px;
+	display: flex; justify-content: flex-end; gap: 8px; background: #f7fafc;
+}
+html[data-theme="dark"] .pk-dm-footer { background: var(--ork-bg-secondary); border-color: var(--ork-border); }
+.pk-dm-btn {
+	padding: 8px 16px; font-size: 13px; font-weight: 600; border-radius: 6px;
+	border: 1px solid #cbd5e0; background: #fff; color: #2d3748; cursor: pointer;
+	display: inline-flex; align-items: center; gap: 6px;
+}
+html[data-theme="dark"] .pk-dm-btn { background: var(--ork-bg-tertiary); border-color: var(--ork-border); color: var(--ork-text); }
+.pk-dm-btn-primary { background: #3182ce; color: #fff; border-color: #3182ce; }
+.pk-dm-btn-primary:hover { background: #2c5282; border-color: #2c5282; }
+.pk-dm-btn:disabled { opacity: 0.55; cursor: not-allowed; }
+
+/* --- Colors panel --- */
+.pk-dm-preset-grid { display: grid; grid-template-columns: repeat(8, 1fr); gap: 8px; }
+.pk-dm-swatch {
+	height: 40px; border-radius: 6px; cursor: pointer; border: 2px solid transparent;
+	box-shadow: 0 1px 2px rgba(0,0,0,0.1) inset;
+}
+.pk-dm-swatch.pk-selected { border-color: #2b6cb0; transform: scale(1.06); box-shadow: 0 0 0 2px #fff, 0 0 0 4px #2b6cb0; }
+html[data-theme="dark"] .pk-dm-swatch.pk-selected { box-shadow: 0 0 0 2px var(--ork-card-bg), 0 0 0 4px var(--ork-link); }
+.pk-dm-color-row { display: flex; gap: 12px; flex-wrap: wrap; }
+.pk-dm-color-col { flex: 1; min-width: 180px; }
+.pk-dm-color-input { display: flex; align-items: center; gap: 6px; }
+.pk-dm-color-input input[type="color"] {
+	width: 38px; height: 36px; border: 1px solid #cbd5e0; border-radius: 6px;
+	padding: 0; background: transparent; cursor: pointer;
+}
+.pk-dm-color-input input[type="text"] { flex: 1; }
+.pk-dm-overlay-btns { display: flex; gap: 6px; flex-wrap: wrap; }
+.pk-dm-overlay-btn {
+	flex: 1; min-width: 80px; padding: 8px 10px; font-size: 12px; font-weight: 600;
+	border: 1px solid #cbd5e0; border-radius: 6px; background: #fff; color: #4a5568; cursor: pointer;
+}
+.pk-dm-overlay-btn.pk-active { background: #2b6cb0; color: #fff; border-color: #2b6cb0; }
+html[data-theme="dark"] .pk-dm-overlay-btn { background: var(--ork-bg-tertiary); border-color: var(--ork-border); color: var(--ork-text-secondary); }
+html[data-theme="dark"] .pk-dm-overlay-btn.pk-active { background: var(--ork-link); color: var(--ork-bg-secondary); border-color: var(--ork-link); }
+
+/* --- Font picker --- */
+.pk-dm-font-picker { display: grid; grid-template-columns: repeat(auto-fill, minmax(140px, 1fr)); gap: 8px; }
+.pk-dm-font-card {
+	border: 1px solid #cbd5e0; border-radius: 8px; padding: 10px 8px; cursor: pointer;
+	text-align: center; background: #fff;
+}
+.pk-dm-font-card.pk-active { border-color: #2b6cb0; background: #ebf8ff; box-shadow: 0 0 0 1px #2b6cb0; }
+html[data-theme="dark"] .pk-dm-font-card { background: var(--ork-bg-tertiary); border-color: var(--ork-border); }
+html[data-theme="dark"] .pk-dm-font-card.pk-active { background: rgba(43,108,176,0.15); border-color: var(--ork-link); box-shadow: 0 0 0 1px var(--ork-link); }
+.pk-dm-font-sample { font-size: 19px; font-weight: 600; color: #2d3748; line-height: 1.2; margin-bottom: 4px; }
+html[data-theme="dark"] .pk-dm-font-sample { color: var(--ork-text); }
+.pk-dm-font-label { font-size: 11px; color: #718096; }
+html[data-theme="dark"] .pk-dm-font-label { color: var(--ork-text-muted); }
+
+/* --- About / Markdown editor --- */
+.pk-dm-md-toolbar { display: flex; justify-content: space-between; align-items: center; gap: 8px; margin-bottom: 4px; flex-wrap: wrap; }
+.pk-dm-md-toggle { display: inline-flex; background: #edf2f7; border-radius: 6px; padding: 3px; gap: 3px; }
+.pk-dm-md-toggle button {
+	background: transparent; border: 0; padding: 5px 10px; font-size: 12px; font-weight: 600;
+	cursor: pointer; border-radius: 4px; color: #718096;
+}
+.pk-dm-md-toggle button.pk-active { background: #fff; color: #2b6cb0; box-shadow: 0 1px 2px rgba(0,0,0,0.06); }
+html[data-theme="dark"] .pk-dm-md-toggle { background: var(--ork-bg-tertiary); }
+html[data-theme="dark"] .pk-dm-md-toggle button.pk-active { background: var(--ork-card-bg); color: var(--ork-link); }
+.pk-dm-md-quick { display: flex; flex-wrap: wrap; gap: 6px; }
+.pk-dm-md-quick-btn {
+	background: #fff; border: 1px solid #cbd5e0; color: #4a5568;
+	padding: 5px 10px; border-radius: 14px; font-size: 11px; font-weight: 600;
+	cursor: pointer; display: inline-flex; align-items: center; gap: 4px;
+}
+.pk-dm-md-quick-btn:hover { background: #ebf8ff; color: #2b6cb0; border-color: #90cdf4; }
+html[data-theme="dark"] .pk-dm-md-quick-btn { background: var(--ork-bg-tertiary); border-color: var(--ork-border); color: var(--ork-text-secondary); }
+html[data-theme="dark"] .pk-dm-md-quick-btn:hover { background: var(--ork-bg-secondary); color: var(--ork-link); border-color: var(--ork-link); }
+.pk-dm-md-preview {
+	border: 1px solid #cbd5e0; border-radius: 6px; padding: 12px 14px;
+	min-height: 140px; background: #fafafa; font-size: 14px; line-height: 1.55; color: #2d3748;
+}
+html[data-theme="dark"] .pk-dm-md-preview { background: var(--ork-bg-secondary); border-color: var(--ork-border); color: var(--ork-text); }
+.pk-dm-md-preview h1, .pk-dm-md-preview h2, .pk-dm-md-preview h3, .pk-dm-md-preview h4 {
+	background: transparent; border: none; padding: 0; border-radius: 0; text-shadow: none;
+	margin-top: 0.9em; margin-bottom: 0.3em;
+}
+
+/* --- Milestones panel --- */
+.pk-dm-ms-toggles { display: flex; flex-wrap: wrap; gap: 8px 14px; margin-bottom: 14px; }
+.pk-dm-ms-toggle { display: inline-flex; align-items: center; gap: 6px; font-size: 13px; color: #4a5568; }
+html[data-theme="dark"] .pk-dm-ms-toggle { color: var(--ork-text-secondary); }
+.pk-dm-ms-list { border: 1px solid #e2e8f0; border-radius: 6px; margin-bottom: 12px; max-height: 200px; overflow-y: auto; }
+html[data-theme="dark"] .pk-dm-ms-list { border-color: var(--ork-border); background: var(--ork-bg-secondary); }
+.pk-dm-ms-row {
+	display: flex; align-items: center; gap: 8px; padding: 8px 10px; border-bottom: 1px solid #edf2f7;
+	font-size: 13px;
+}
+html[data-theme="dark"] .pk-dm-ms-row { border-color: var(--ork-border); }
+.pk-dm-ms-row:last-child { border-bottom: none; }
+.pk-dm-ms-row > i { color: #2b6cb0; width: 18px; text-align: center; }
+.pk-dm-ms-row .pk-dm-ms-desc { flex: 1; color: #2d3748; }
+html[data-theme="dark"] .pk-dm-ms-row .pk-dm-ms-desc { color: var(--ork-text); }
+.pk-dm-ms-row .pk-dm-ms-date { color: #718096; font-size: 11px; min-width: 90px; }
+html[data-theme="dark"] .pk-dm-ms-row .pk-dm-ms-date { color: var(--ork-text-muted); }
+html[data-theme="dark"] .pk-dm-ms-row > i { color: var(--ork-link); }
+html[data-theme="dark"] .pk-dm-ms-row button { color: #fc8181; }
+html[data-theme="dark"] .pk-dm-ms-row button:hover { background: var(--ork-bg-tertiary); }
+.pk-dm-ms-row button {
+	background: transparent; border: 0; color: #e53e3e; cursor: pointer; padding: 4px 6px;
+}
+.pk-dm-ms-row button[data-tip] { position: relative; }
+.pk-dm-ms-row button[data-tip]::after {
+	content: attr(data-tip); position: absolute; bottom: calc(100% + 4px); right: 0;
+	background: #2d3748; color: #fff; font-size: 11px; white-space: nowrap;
+	padding: 3px 8px; border-radius: 4px; pointer-events: none; opacity: 0;
+	transition: opacity 0.12s; z-index: 600;
+}
+.pk-dm-ms-row button[data-tip]:hover::after { opacity: 1; transition-delay: 0.3s; }
+html[data-theme="dark"] .pk-dm-ms-row button[data-tip]::after {
+	background: var(--ork-bg-tertiary); color: var(--ork-text); border: 1px solid var(--ork-border);
+}
+.pk-dm-ms-add { display: grid; grid-template-columns: 1fr 140px 90px; gap: 8px; align-items: end; }
+@media (max-width: 600px) { .pk-dm-ms-add { grid-template-columns: 1fr; } }
+.pk-dm-ms-icons {
+	display: flex; flex-wrap: wrap; gap: 6px; margin-top: 4px;
+}
+.pk-dm-ms-icon-opt {
+	width: 28px; height: 28px; border: 1px solid #cbd5e0; border-radius: 6px;
+	display: flex; align-items: center; justify-content: center; cursor: pointer;
+	background: #fff; color: #4a5568;
+}
+.pk-dm-ms-icon-opt.pk-active { background: #2b6cb0; color: #fff; border-color: #2b6cb0; }
+html[data-theme="dark"] .pk-dm-ms-icon-opt { background: var(--ork-bg-tertiary); border-color: var(--ork-border); color: var(--ork-text-secondary); }
+html[data-theme="dark"] .pk-dm-ms-icon-opt.pk-active { background: var(--ork-link); color: var(--ork-bg-secondary); border-color: var(--ork-link); }
+
+/* Social links editor */
+.pk-dm-social-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 8px 14px; }
+@media (max-width: 640px) { .pk-dm-social-grid { grid-template-columns: 1fr; } }
+.pk-dm-social-row { display: flex; align-items: center; gap: 6px; }
+.pk-dm-social-icon {
+	width: 28px; height: 28px; border-radius: 6px; color: #fff;
+	display: inline-flex; align-items: center; justify-content: center;
+	flex-shrink: 0; font-size: 13px;
+}
+.pk-dm-social-input { flex: 1; min-width: 0; }
+.pk-dm-social-clear {
+	width: 26px; height: 26px; border: 1px solid #e2e8f0; background: #fff;
+	color: #718096; border-radius: 4px; cursor: pointer; flex-shrink: 0;
+	display: inline-flex; align-items: center; justify-content: center; font-size: 11px;
+	position: relative;
+}
+.pk-dm-social-clear:hover { color: #c53030; border-color: #fc8181; }
+html[data-theme="dark"] .pk-dm-social-clear { background: var(--ork-bg-tertiary); border-color: var(--ork-border); color: var(--ork-text-muted); }
+html[data-theme="dark"] .pk-dm-social-clear:hover { color: #fc8181; border-color: #fc8181; }
+.pk-dm-social-clear[data-tip]::after {
+	content: attr(data-tip); position: absolute; bottom: calc(100% + 4px); right: 0;
+	background: #2d3748; color: #fff; font-size: 11px; white-space: nowrap;
+	padding: 3px 8px; border-radius: 4px; pointer-events: none; opacity: 0;
+	transition: opacity 0.12s; z-index: 600;
+}
+.pk-dm-social-clear[data-tip]:hover::after { opacity: 1; transition-delay: 0.3s; }
+html[data-theme="dark"] .pk-dm-social-clear[data-tip]::after { background: var(--ork-bg-tertiary); color: var(--ork-text); border: 1px solid var(--ork-border); }
+</style>
+
+<div class="pk-dm-overlay" id="pk-dm-overlay">
+	<div class="pk-dm-modal">
+		<div class="pk-dm-header">
+			<h3 class="pk-dm-title"><i class="fas fa-palette"></i>Design <?= htmlspecialchars($park_name) ?></h3>
+			<button class="pk-dm-close" id="pk-dm-close" aria-label="Close">&times;</button>
+		</div>
+		<div class="pk-dm-tabs">
+			<button class="pk-dm-tab pk-active" data-pktab-dm="header"><i class="fas fa-image"></i> Header</button>
+			<button class="pk-dm-tab" data-pktab-dm="about"><i class="fas fa-scroll"></i> About</button>
+			<button class="pk-dm-tab" data-pktab-dm="milestones"><i class="fas fa-stream"></i> Milestones</button>
+		</div>
+		<div class="pk-dm-body">
+			<div class="pk-dm-error" id="pk-dm-error"></div>
+
+			<!-- Header Panel -->
+			<div class="pk-dm-panel pk-active" id="pk-dm-panel-header">
+				<div class="pk-dm-hint" style="margin-bottom:12px"><i class="fas fa-moon" style="margin-right:6px"></i><strong>Dark mode viewers</strong> see your hero with a slight darkening filter so colors stay readable. Preview both themes with the moon icon in the site header before saving.</div>
+
+				<div class="pk-dm-field">
+					<label>Color Presets</label>
+					<div class="pk-dm-preset-grid" id="pk-dm-presets">
+						<div class="pk-dm-swatch" data-primary="#2c5282" data-accent="#4299e1" style="background:#2c5282"></div>
+						<div class="pk-dm-swatch" data-primary="#276749" data-accent="#48bb78" style="background:#276749"></div>
+						<div class="pk-dm-swatch" data-primary="#9b2c2c" data-accent="#fc8181" style="background:#9b2c2c"></div>
+						<div class="pk-dm-swatch" data-primary="#553c9a" data-accent="#9f7aea" style="background:#553c9a"></div>
+						<div class="pk-dm-swatch" data-primary="#975a16" data-accent="#ecc94b" style="background:#975a16"></div>
+						<div class="pk-dm-swatch" data-primary="#2d3748" data-accent="#a0aec0" style="background:#2d3748"></div>
+						<div class="pk-dm-swatch" data-primary="#285e61" data-accent="#38b2ac" style="background:#285e61"></div>
+						<div class="pk-dm-swatch" data-primary="#744210" data-accent="#ed8936" style="background:#744210"></div>
+					</div>
+				</div>
+
+				<div class="pk-dm-field">
+					<label>Gradient Presets</label>
+					<div class="pk-dm-preset-grid" id="pk-dm-gradient-presets">
+						<div class="pk-dm-swatch" data-primary="#1a365d" data-accent="#4299e1" data-secondary="#553c9a" style="background:linear-gradient(135deg,#1a365d,#553c9a)"></div>
+						<div class="pk-dm-swatch" data-primary="#1a4731" data-accent="#48bb78" data-secondary="#2c5282" style="background:linear-gradient(135deg,#1a4731,#2c5282)"></div>
+						<div class="pk-dm-swatch" data-primary="#742a2a" data-accent="#fc8181" data-secondary="#975a16" style="background:linear-gradient(135deg,#742a2a,#975a16)"></div>
+						<div class="pk-dm-swatch" data-primary="#44337a" data-accent="#d6bcfa" data-secondary="#97266d" style="background:linear-gradient(135deg,#44337a,#97266d)"></div>
+						<div class="pk-dm-swatch" data-primary="#234e52" data-accent="#38b2ac" data-secondary="#276749" style="background:linear-gradient(135deg,#234e52,#276749)"></div>
+						<div class="pk-dm-swatch" data-primary="#2c5282" data-accent="#4299e1" data-secondary="#285e61" style="background:linear-gradient(135deg,#2c5282,#285e61)"></div>
+						<div class="pk-dm-swatch" data-primary="#744210" data-accent="#ecc94b" data-secondary="#9b2c2c" style="background:linear-gradient(135deg,#744210,#9b2c2c)"></div>
+						<div class="pk-dm-swatch" data-primary="#1a202c" data-accent="#a0aec0" data-secondary="#2d3748" style="background:linear-gradient(135deg,#1a202c,#2d3748)"></div>
+					</div>
+				</div>
+
+				<div class="pk-dm-field">
+					<label>Custom Colors</label>
+					<div class="pk-dm-color-row">
+						<div class="pk-dm-color-col">
+							<div class="pk-dm-hint" style="margin-bottom:4px">Primary (hero background)</div>
+							<div class="pk-dm-color-input">
+								<input type="color" id="pk-dm-color-primary" value="<?= htmlspecialchars($pkColorPrimary ?: '#2c5282') ?>" />
+								<input type="text" id="pk-dm-color-primary-hex" value="<?= htmlspecialchars($pkColorPrimary ?: '#2c5282') ?>" maxlength="7" />
+							</div>
+						</div>
+						<div class="pk-dm-color-col">
+							<div class="pk-dm-hint" style="margin-bottom:4px">Accent (links &amp; tabs)</div>
+							<div class="pk-dm-color-input">
+								<input type="color" id="pk-dm-color-accent" value="<?= htmlspecialchars($pkColorAccent ?: '#4299e1') ?>" />
+								<input type="text" id="pk-dm-color-accent-hex" value="<?= htmlspecialchars($pkColorAccent ?: '#4299e1') ?>" maxlength="7" />
+							</div>
+						</div>
+					</div>
+				</div>
+
+				<div class="pk-dm-field">
+					<label>Gradient (Optional)</label>
+					<div class="pk-dm-color-row">
+						<div class="pk-dm-color-col">
+							<div class="pk-dm-hint" style="margin-bottom:4px">Secondary color</div>
+							<div class="pk-dm-color-input">
+								<input type="color" id="pk-dm-color-secondary" value="<?= htmlspecialchars($pkColorSecondary ?: ($pkColorPrimary ?: '#2c5282')) ?>" />
+								<input type="text" id="pk-dm-color-secondary-hex" value="<?= htmlspecialchars($pkColorSecondary) ?>" maxlength="7" placeholder="None" />
+							</div>
+						</div>
+						<div class="pk-dm-color-col" style="display:flex;align-items:center;padding-top:18px">
+							<label style="text-transform:none;letter-spacing:0;display:flex;align-items:center;gap:6px;cursor:pointer;font-weight:500;color:#4a5568;font-size:13px;margin-bottom:0">
+								<input type="checkbox" id="pk-dm-gradient-enabled" <?= $pkColorSecondary !== '' ? 'checked' : '' ?> />
+								Enable gradient
+							</label>
+						</div>
+					</div>
+				</div>
+
+				<div class="pk-dm-field">
+					<label>Heraldry Overlay Strength</label>
+					<div class="pk-dm-hint" style="margin-bottom:6px">Controls how much the park heraldry shows through the hero background.</div>
+					<div class="pk-dm-overlay-btns">
+						<button type="button" class="pk-dm-overlay-btn<?= $pkOverlay === 'low' ? ' pk-active' : '' ?>" data-overlay="low">Low</button>
+						<button type="button" class="pk-dm-overlay-btn<?= $pkOverlay === 'med' ? ' pk-active' : '' ?>" data-overlay="med">Medium</button>
+						<button type="button" class="pk-dm-overlay-btn<?= $pkOverlay === 'high' ? ' pk-active' : '' ?>" data-overlay="high">High</button>
+						<button type="button" class="pk-dm-overlay-btn<?= $pkOverlay === 'vignette' ? ' pk-active' : '' ?>" data-overlay="vignette">Vignette</button>
+					</div>
+					<input type="hidden" id="pk-dm-hero-overlay" value="<?= htmlspecialchars($pkOverlay) ?>" />
+				</div>
+
+				<div class="pk-dm-field">
+					<label>Name Font</label>
+					<div class="pk-dm-hint" style="margin-bottom:6px">A decorative font for the park name in the hero. Viewers with accessibility fonts enabled will see their preferred font instead.</div>
+					<div class="pk-dm-font-picker" id="pk-dm-font-picker"></div>
+				</div>
+
+				<div class="pk-dm-field">
+					<label>Tagline (optional)</label>
+					<div class="pk-dm-hint" style="margin-bottom:6px">A short motto or descriptor shown under the park name.</div>
+					<input type="text" id="pk-dm-tagline" maxlength="160" value="<?= htmlspecialchars($pkTagline) ?>" placeholder="e.g. Where steel meets song." />
+				</div>
+
+				<div class="pk-dm-field">
+					<label>Announcement</label>
+					<div class="pk-dm-hint" style="margin-bottom:6px">Pinned message shown above the hero. Leave "Show until" blank for indefinite. Plain text only.</div>
+					<textarea id="pk-dm-announcement" maxlength="280" rows="3" placeholder="e.g. Practice cancelled Saturday — see you at the campout!"><?= htmlspecialchars($pkAnnouncement) ?></textarea>
+					<div class="pk-dm-hint" id="pk-dm-announcement-count" style="text-align:right;margin-top:2px;display:none"></div>
+					<div style="margin-top:8px;display:flex;align-items:center;gap:10px;flex-wrap:wrap">
+						<label for="pk-dm-announcement-until" style="text-transform:none;letter-spacing:0;font-weight:500;color:#4a5568;font-size:13px;margin-bottom:0">Show until (optional):</label>
+						<input type="date" id="pk-dm-announcement-until" value="<?= htmlspecialchars($pkAnnouncementUntil && $pkAnnouncementUntil !== '0000-00-00' ? $pkAnnouncementUntil : '') ?>" style="max-width:200px" />
+					</div>
+				</div>
+			</div>
+
+			<!-- About Panel -->
+			<div class="pk-dm-panel" id="pk-dm-panel-about">
+				<div class="pk-dm-hint" style="margin-bottom:14px"><i class="fas fa-info-circle" style="margin-right:6px"></i>Both fields support <strong>Markdown</strong>. Use <em>About</em> for a current snapshot of the park; use <em>Our History</em> for the founding story, past elevations, and notable moments.</div>
+
+				<div class="pk-dm-field">
+					<div class="pk-dm-md-toolbar">
+						<label style="margin-bottom:0">About <?= htmlspecialchars($park_name) ?></label>
+						<div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap">
+							<div class="pk-dm-md-toggle">
+								<button type="button" class="pk-active" data-pkmd-target="edit" data-pkmd-field="about">Write</button>
+								<button type="button" data-pkmd-target="preview" data-pkmd-field="about">Preview</button>
+							</div>
+							<div class="pk-dm-md-quick">
+								<button type="button" class="pk-dm-md-quick-btn" data-pkquick="newbies" data-pkfield="about"><i class="fas fa-hand-sparkles"></i> New Player Welcome</button>
+								<button type="button" class="pk-dm-md-quick-btn" data-pkquick="vibe" data-pkfield="about"><i class="fas fa-fire"></i> Park Vibe</button>
+								<button type="button" class="pk-dm-md-quick-btn" data-pkquick="findus" data-pkfield="about"><i class="fas fa-map-marker-alt"></i> Find Us</button>
+							</div>
+						</div>
+					</div>
+					<textarea id="pk-dm-about-text" maxlength="10000" placeholder="Welcome to the park... (Markdown supported)"><?= htmlspecialchars($aboutText) ?></textarea>
+					<div class="pk-dm-md-preview" id="pk-dm-about-preview" style="display:none"></div>
+				</div>
+
+				<div class="pk-dm-field">
+					<div class="pk-dm-md-toolbar">
+						<label style="margin-bottom:0">Our History</label>
+						<div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap">
+							<div class="pk-dm-md-toggle">
+								<button type="button" class="pk-active" data-pkmd-target="edit" data-pkmd-field="history">Write</button>
+								<button type="button" data-pkmd-target="preview" data-pkmd-field="history">Preview</button>
+							</div>
+							<div class="pk-dm-md-quick">
+								<button type="button" class="pk-dm-md-quick-btn" data-pkquick="founding" data-pkfield="history"><i class="fas fa-flag"></i> Founding</button>
+								<button type="button" class="pk-dm-md-quick-btn" data-pkquick="elevation" data-pkfield="history"><i class="fas fa-chess-rook"></i> Elevations</button>
+								<button type="button" class="pk-dm-md-quick-btn" data-pkquick="pastofficers" data-pkfield="history"><i class="fas fa-crown"></i> Past Officers</button>
+							</div>
+						</div>
+					</div>
+					<textarea id="pk-dm-history-text" maxlength="10000" placeholder="The park was founded in... (Markdown supported)"><?= htmlspecialchars($ourHistoryText) ?></textarea>
+					<div class="pk-dm-md-preview" id="pk-dm-history-preview" style="display:none"></div>
+				</div>
+
+				<div class="pk-dm-field">
+					<label>Social Links</label>
+					<div class="pk-dm-hint" style="margin-bottom:8px">Add the URL for each platform your park uses. Leave blank to omit.</div>
+					<div class="pk-dm-social-grid">
+						<?php foreach ($pkSocialPlatforms as $_slug => $_meta): ?>
+						<div class="pk-dm-social-row">
+							<span class="pk-dm-social-icon" style="background: <?= htmlspecialchars($_meta['bg']) ?>;"><i class="<?= htmlspecialchars($_meta['icon']) ?>"></i></span>
+							<input type="url" class="pk-dm-social-input" data-pksocial="<?= htmlspecialchars($_slug) ?>"
+							       placeholder="<?= htmlspecialchars($_meta['placeholder']) ?>"
+							       maxlength="500"
+							       value="<?= htmlspecialchars($pkSocialLinks[$_slug] ?? '') ?>" />
+							<button type="button" class="pk-dm-social-clear" data-pksocial-clear="<?= htmlspecialchars($_slug) ?>" data-tip="Clear" aria-label="Clear"><i class="fas fa-times"></i></button>
+						</div>
+						<?php endforeach; ?>
+					</div>
+				</div>
+			</div>
+
+			<!-- Milestones Panel -->
+			<div class="pk-dm-panel" id="pk-dm-panel-milestones">
+				<div class="pk-dm-hint" style="margin-bottom:10px">Milestones appear on the About tab in date order. Some are derived from attendance data (first sign-in, count thresholds); the rest are custom entries you add below.</div>
+
+				<div class="pk-dm-field">
+					<label>Visible Milestone Types</label>
+					<div class="pk-dm-ms-toggles" id="pk-dm-ms-toggles">
+						<label class="pk-dm-ms-toggle"><input type="checkbox" data-pkms-type="first_attendance" <?= $pkMsVisible('first_attendance') ? 'checked' : '' ?> /> <i class="fas fa-door-open"></i> First Attendance</label>
+						<label class="pk-dm-ms-toggle"><input type="checkbox" data-pkms-type="attendance_count" <?= $pkMsVisible('attendance_count') ? 'checked' : '' ?> /> <i class="fas fa-clipboard-list"></i> Attendance Crossings</label>
+						<label class="pk-dm-ms-toggle"><input type="checkbox" data-pkms-type="distinct_members" <?= $pkMsVisible('distinct_members') ? 'checked' : '' ?> /> <i class="fas fa-users"></i> Member Crossings</label>
+						<label class="pk-dm-ms-toggle"><input type="checkbox" data-pkms-type="custom" <?= $pkMsVisible('custom') ? 'checked' : '' ?> /> <i class="fas fa-pen"></i> Custom Milestones</label>
+					</div>
+					<label class="pk-dm-ms-toggle" style="margin-top:4px">
+						<input type="checkbox" id="pk-dm-ms-newest-first" <?= $pkMsNewestFirst ? 'checked' : '' ?> />
+						Show newest first
+					</label>
+				</div>
+
+				<div class="pk-dm-field">
+					<label>Custom Milestones</label>
+					<div class="pk-dm-ms-list" id="pk-dm-ms-list"></div>
+					<div class="pk-dm-ms-add">
+						<div>
+							<input type="text" id="pk-dm-ms-add-desc" placeholder="What happened?" maxlength="500" />
+						</div>
+						<div>
+							<input type="date" id="pk-dm-ms-add-date" />
+						</div>
+						<div>
+							<button type="button" class="pk-dm-btn pk-dm-btn-primary" id="pk-dm-ms-add-btn" style="width:100%"><i class="fas fa-plus"></i> Add</button>
+						</div>
+					</div>
+					<div class="pk-dm-ms-icons" id="pk-dm-ms-icons" style="margin-top:8px">
+						<?php $_pkIcons = ['fa-star','fa-trophy','fa-flag','fa-chess-rook','fa-crown','fa-medal','fa-shield-alt','fa-fire','fa-bolt','fa-scroll','fa-campground','fa-map-marker-alt','fa-users','fa-dragon','fa-hammer','fa-heart']; ?>
+						<?php foreach ($_pkIcons as $_ic): ?>
+						<div class="pk-dm-ms-icon-opt<?= $_ic === 'fa-star' ? ' pk-active' : '' ?>" data-icon="<?= htmlspecialchars($_ic) ?>"><i class="fas <?= htmlspecialchars($_ic) ?>"></i></div>
+						<?php endforeach; ?>
+					</div>
+					<div class="pk-dm-hint" id="pk-dm-ms-add-err" style="color:#c53030;display:none;margin-top:6px"></div>
+				</div>
+			</div>
+		</div>
+		<div class="pk-dm-footer">
+			<button class="pk-dm-btn" id="pk-dm-cancel">Cancel</button>
+			<button class="pk-dm-btn pk-dm-btn-primary" id="pk-dm-save"><i class="fas fa-save"></i> Save Changes</button>
+		</div>
+	</div>
+</div>
+
+<!-- Markdown libs (only loaded for editors — small CDN bundles) -->
+<script src="https://cdn.jsdelivr.net/npm/marked@12/marked.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/dompurify@3/dist/purify.min.js"></script>
+<script>
+(function() {
+	var PARK_ID = <?= (int)$park_id ?>;
+	var BASE_UIR = '<?= UIR ?>';
+	var PK_FONTS = [
+		{ key:'', label:'Default', family:'inherit' },
+		{ key:'Cinzel', label:'Cinzel', family:'Cinzel' },
+		{ key:'Cinzel Decorative', label:'Cinzel Deco', family:"'Cinzel Decorative'" },
+		{ key:'IM Fell English', label:'IM Fell English', family:"'IM Fell English'" },
+		{ key:'UnifrakturMaguntia', label:'Unifraktur', family:'UnifrakturMaguntia' },
+		{ key:'Metamorphous', label:'Metamorphous', family:'Metamorphous' },
+		{ key:'Uncial Antiqua', label:'Uncial Antiqua', family:"'Uncial Antiqua'" },
+		{ key:'Pirata One', label:'Pirata One', family:"'Pirata One'" },
+		{ key:'Almendra', label:'Almendra', family:'Almendra' },
+		{ key:'Pinyon Script', label:'Pinyon Script', family:"'Pinyon Script'" },
+		{ key:'Great Vibes', label:'Great Vibes', family:"'Great Vibes'" }
+	];
+	var PK_QUICKS = {
+		newbies: 'New players welcome! Loaner gear is always on hand and our experienced fighters love teaching the ropes. Just show up — no experience needed.',
+		vibe:    "## The Vibe\n\nFamily-friendly, hard-hitting, and warm. Whether you swing a sword, paint a banner, or sing a song around the fire, there's a place for you here.",
+		findus:  "## Find Us\n\n- **Address:** _add the address_\n- **Parking:** _quick parking notes here_\n- **Look for:** _identifying landmark / banner_",
+		founding:"## Founding\n\nThe park was founded in **YYYY** by a small group meeting at _location_. It was first chartered as an **Outpost** under the Kingdom of _kingdom name_.",
+		elevation:"## Elevation History\n\n- **YYYY** — Chartered as an Outpost\n- **YYYY** — Elevated to a Shire\n- **YYYY** — Elevated to a Barony\n_(Edit dates and lines as appropriate)_",
+		pastofficers:"## Past Monarchs & Regents\n\n- **YYYY–YYYY** — _Persona_ (Monarch), _Persona_ (Regent)\n- **YYYY–YYYY** — _Persona_ (Monarch), _Persona_ (Regent)"
+	};
+	var INITIAL_CUSTOM_MS = <?php
+		$customOnly = array_values(array_filter($pkAllMilestones, function($m){ return empty($m['IsDerived']); }));
+		echo json_encode(array_map(function($m){
+			return [
+				'MilestoneId'   => (int)$m['MilestoneId'],
+				'Icon'          => $m['Icon'],
+				'Description'   => $m['Description'],
+				'MilestoneDate' => $m['MilestoneDate'],
+			];
+		}, $customOnly));
+	?>;
+	var pkSelectedFont = <?= json_encode($pkNameFont) ?>;
+	var pkSelectedIcon = 'fa-star';
+	var customMs = INITIAL_CUSTOM_MS.slice();
+
+	function gid(id) { return document.getElementById(id); }
+	function esc(s) { return String(s == null ? '' : s).replace(/[&<>"']/g, function(c) { return ({ '&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;' })[c]; }); }
+
+	// --- Open / close ---
+	window.pkOpenDesignModal = function(panel) {
+		gid('pk-dm-overlay').classList.add('pk-open');
+		document.body.style.overflow = 'hidden';
+		if (panel) pkSwitchDmPanel(panel);
+		renderCustomMsList();
+	};
+	function close() {
+		gid('pk-dm-overlay').classList.remove('pk-open');
+		document.body.style.overflow = '';
+	}
+	gid('pk-dm-close').addEventListener('click', close);
+	gid('pk-dm-cancel').addEventListener('click', close);
+	gid('pk-dm-overlay').addEventListener('click', function(e) {
+		if (e.target === this) close();
+	});
+	document.addEventListener('keydown', function(e) {
+		if ((e.key === 'Escape' || e.keyCode === 27) && gid('pk-dm-overlay').classList.contains('pk-open')) close();
+	});
+
+	// --- Tabs ---
+	function pkSwitchDmPanel(name) {
+		document.querySelectorAll('.pk-dm-tab').forEach(function(t) { t.classList.remove('pk-active'); });
+		document.querySelectorAll('.pk-dm-panel').forEach(function(p) { p.classList.remove('pk-active'); });
+		var tab = document.querySelector('.pk-dm-tab[data-pktab-dm="' + name + '"]');
+		var panel = gid('pk-dm-panel-' + name);
+		if (tab) tab.classList.add('pk-active');
+		if (panel) panel.classList.add('pk-active');
+	}
+	document.querySelectorAll('.pk-dm-tab').forEach(function(t) {
+		t.addEventListener('click', function() { pkSwitchDmPanel(t.dataset.pktabDm); });
+	});
+
+	// --- Colors panel ---
+	var swatches = document.querySelectorAll('.pk-dm-swatch');
+	swatches.forEach(function(sw) {
+		sw.addEventListener('click', function() {
+			swatches.forEach(function(s) { s.classList.remove('pk-selected'); });
+			sw.classList.add('pk-selected');
+			gid('pk-dm-color-primary').value     = sw.dataset.primary;
+			gid('pk-dm-color-primary-hex').value = sw.dataset.primary;
+			gid('pk-dm-color-accent').value      = sw.dataset.accent;
+			gid('pk-dm-color-accent-hex').value  = sw.dataset.accent;
+			if (sw.dataset.secondary) {
+				gid('pk-dm-color-secondary').value     = sw.dataset.secondary;
+				gid('pk-dm-color-secondary-hex').value = sw.dataset.secondary;
+				gid('pk-dm-gradient-enabled').checked  = true;
+			} else {
+				gid('pk-dm-color-secondary-hex').value = '';
+				gid('pk-dm-gradient-enabled').checked  = false;
+			}
+		});
+	});
+	function syncHex(colorId, hexId) {
+		gid(colorId).addEventListener('input', function() { gid(hexId).value = this.value; });
+		gid(hexId).addEventListener('input', function() {
+			if (/^#[0-9a-f]{6}$/i.test(this.value)) { gid(colorId).value = this.value; }
+		});
+	}
+	syncHex('pk-dm-color-primary',   'pk-dm-color-primary-hex');
+	syncHex('pk-dm-color-accent',    'pk-dm-color-accent-hex');
+	syncHex('pk-dm-color-secondary', 'pk-dm-color-secondary-hex');
+
+	// --- Overlay buttons ---
+	document.querySelectorAll('.pk-dm-overlay-btn').forEach(function(btn) {
+		btn.addEventListener('click', function() {
+			document.querySelectorAll('.pk-dm-overlay-btn').forEach(function(b) { b.classList.remove('pk-active'); });
+			btn.classList.add('pk-active');
+			gid('pk-dm-hero-overlay').value = btn.dataset.overlay;
+		});
+	});
+
+	// --- Font picker ---
+	function pkLoadFont(key) {
+		if (!key) return;
+		if (document.querySelector('link[data-pk-font="' + key + '"]')) return;
+		var link = document.createElement('link');
+		link.rel = 'stylesheet';
+		link.href = 'https://fonts.googleapis.com/css2?family=' + key.replace(/ /g, '+') + '&display=swap';
+		link.setAttribute('data-pk-font', key);
+		document.head.appendChild(link);
+	}
+	function pkRenderFontPicker() {
+		var container = gid('pk-dm-font-picker');
+		var sample = <?= json_encode($park_name) ?>;
+		var html = '';
+		for (var i = 0; i < PK_FONTS.length; i++) {
+			var f = PK_FONTS[i];
+			var active = f.key === pkSelectedFont;
+			html += '<div class="pk-dm-font-card' + (active ? ' pk-active' : '') + '" data-font-key="' + esc(f.key) + '">'
+				 +    '<div class="pk-dm-font-sample" style="font-family:' + f.family + '">' + esc(sample) + '</div>'
+				 +    '<div class="pk-dm-font-label">' + esc(f.label) + '</div>'
+				 + '</div>';
+			pkLoadFont(f.key);
+		}
+		container.innerHTML = html;
+		container.addEventListener('click', function(e) {
+			var card = e.target.closest('.pk-dm-font-card');
+			if (!card) return;
+			pkSelectedFont = card.dataset.fontKey;
+			container.querySelectorAll('.pk-dm-font-card').forEach(function(c) {
+				c.classList.toggle('pk-active', c === card);
+			});
+		});
+	}
+	pkRenderFontPicker();
+
+	// --- Markdown preview toggles ---
+	document.querySelectorAll('[data-pkmd-target]').forEach(function(btn) {
+		btn.addEventListener('click', function() {
+			var field  = btn.dataset.pkmdField;
+			var target = btn.dataset.pkmdTarget;
+			var ta     = gid('pk-dm-' + (field === 'about' ? 'about-text' : 'history-text'));
+			var pv     = gid('pk-dm-' + field + '-preview');
+			btn.parentElement.querySelectorAll('button').forEach(function(b) { b.classList.remove('pk-active'); });
+			btn.classList.add('pk-active');
+			if (target === 'preview') {
+				ta.style.display = 'none';
+				pv.style.display = '';
+				if (typeof marked !== 'undefined' && typeof DOMPurify !== 'undefined') {
+					pv.innerHTML = DOMPurify.sanitize(marked.parse(ta.value || ''));
+				} else {
+					pv.textContent = ta.value;
+				}
+			} else {
+				ta.style.display = '';
+				pv.style.display = 'none';
+			}
+		});
+	});
+
+	// --- Quick-add snippets ---
+	document.querySelectorAll('[data-pkquick]').forEach(function(btn) {
+		btn.addEventListener('click', function() {
+			var key   = btn.dataset.pkquick;
+			var field = btn.dataset.pkfield;
+			var ta    = gid('pk-dm-' + (field === 'about' ? 'about-text' : 'history-text'));
+			if (!ta) return;
+			// Switch to Write mode
+			var writeBtn = document.querySelector('[data-pkmd-field="' + field + '"][data-pkmd-target="edit"]');
+			if (writeBtn && !writeBtn.classList.contains('pk-active')) writeBtn.click();
+			var snippet = PK_QUICKS[key] || '';
+			if (!snippet) return;
+			var existing = ta.value;
+			var sep = existing.length === 0 ? '' : (existing.endsWith('\n\n') ? '' : (existing.endsWith('\n') ? '\n' : '\n\n'));
+			ta.value = existing + sep + snippet;
+			ta.focus();
+			ta.setSelectionRange(ta.value.length, ta.value.length);
+		});
+	});
+
+	// --- Milestones ---
+	function renderCustomMsList() {
+		var list = gid('pk-dm-ms-list');
+		if (!list) return;
+		var newestFirst = gid('pk-dm-ms-newest-first').checked;
+		customMs.sort(function(a, b) {
+			var ad = a.MilestoneDate || '', bd = b.MilestoneDate || '';
+			return newestFirst ? bd.localeCompare(ad) : ad.localeCompare(bd);
+		});
+		if (customMs.length === 0) {
+			list.innerHTML = '<div style="padding:14px;font-size:12px;color:#a0aec0">No custom milestones yet.</div>';
+			return;
+		}
+		var html = '';
+		for (var i = 0; i < customMs.length; i++) {
+			var m = customMs[i];
+			var dateStr = m.MilestoneDate || '';
+			if (dateStr && dateStr !== '0000-00-00') {
+				var d = new Date(dateStr + 'T00:00:00');
+				if (!isNaN(d.getTime())) dateStr = d.toLocaleDateString('en-US', { month:'short', day:'numeric', year:'numeric' });
+			}
+			var icon = (m.Icon || 'fa-star').replace(/[^a-z0-9-]/g, '');
+			html += '<div class="pk-dm-ms-row" data-ms-id="' + m.MilestoneId + '">'
+				 +    '<i class="fas ' + icon + '"></i>'
+				 +    '<span class="pk-dm-ms-desc">' + esc(m.Description) + '</span>'
+				 +    '<span class="pk-dm-ms-date">' + dateStr + '</span>'
+				 +    '<button type="button" data-tip="Delete" onclick="pkDeleteParkMilestone(' + m.MilestoneId + ')"><i class="fas fa-trash"></i></button>'
+				 + '</div>';
+		}
+		list.innerHTML = html;
+	}
+	gid('pk-dm-ms-newest-first').addEventListener('change', renderCustomMsList);
+
+	// Icon grid selection
+	var iconGrid = gid('pk-dm-ms-icons');
+	iconGrid.addEventListener('click', function(e) {
+		var opt = e.target.closest('.pk-dm-ms-icon-opt');
+		if (!opt) return;
+		iconGrid.querySelectorAll('.pk-dm-ms-icon-opt').forEach(function(o) { o.classList.remove('pk-active'); });
+		opt.classList.add('pk-active');
+		pkSelectedIcon = opt.dataset.icon;
+	});
+
+	gid('pk-dm-ms-add-btn').addEventListener('click', function() {
+		var desc = gid('pk-dm-ms-add-desc').value.trim();
+		var date = gid('pk-dm-ms-add-date').value;
+		var err  = gid('pk-dm-ms-add-err');
+		err.style.display = 'none';
+		if (!desc) { err.textContent = 'Description is required.'; err.style.display = ''; return; }
+		if (!date) { err.textContent = 'Date is required.'; err.style.display = ''; return; }
+		var btn = this; btn.disabled = true; btn.innerHTML = '<i class="fas fa-spinner fa-spin"></i>';
+		var fd = new FormData();
+		fd.append('Description', desc);
+		fd.append('MilestoneDate', date);
+		fd.append('Icon', pkSelectedIcon);
+		fetch(BASE_UIR + 'ParkAjax/park/' + PARK_ID + '/addmilestone', { method: 'POST', body: fd })
+			.then(function(r) { return r.json(); })
+			.then(function(result) {
+				if (result && result.status === 0) {
+					customMs.push({
+						MilestoneId: result.milestoneId,
+						Icon: pkSelectedIcon,
+						Description: desc,
+						MilestoneDate: date
+					});
+					renderCustomMsList();
+					gid('pk-dm-ms-add-desc').value = '';
+					gid('pk-dm-ms-add-date').value = '';
+					iconGrid.querySelectorAll('.pk-dm-ms-icon-opt').forEach(function(o) { o.classList.remove('pk-active'); });
+					iconGrid.querySelector('[data-icon="fa-star"]').classList.add('pk-active');
+					pkSelectedIcon = 'fa-star';
+				} else {
+					err.textContent = (result && result.error) || 'Failed to add milestone.';
+					err.style.display = '';
+				}
+			})
+			.catch(function() {
+				err.textContent = 'Request failed.';
+				err.style.display = '';
+			})
+			.finally(function() {
+				btn.disabled = false;
+				btn.innerHTML = '<i class="fas fa-plus"></i> Add';
+			});
+	});
+
+	window.pkDeleteParkMilestone = function(id) {
+		if (!confirm('Delete this milestone?')) return;
+		var fd = new FormData();
+		fd.append('MilestoneId', id);
+		fetch(BASE_UIR + 'ParkAjax/park/' + PARK_ID + '/deletemilestone', { method: 'POST', body: fd })
+			.then(function(r) { return r.json(); })
+			.then(function(result) {
+				if (result && result.status === 0) {
+					customMs = customMs.filter(function(m) { return m.MilestoneId !== id; });
+					renderCustomMsList();
+				} else {
+					alert((result && result.error) || 'Failed to delete milestone.');
+				}
+			})
+			.catch(function() { alert('Request failed.'); });
+	};
+
+	// --- Save ---
+	gid('pk-dm-save').addEventListener('click', function() {
+		var btn = this; btn.disabled = true; btn.innerHTML = '<i class="fas fa-spinner fa-spin"></i> Saving...';
+		var errEl = gid('pk-dm-error'); errEl.style.display = 'none';
+		var fd = new FormData();
+		fd.append('AboutText', gid('pk-dm-about-text').value);
+		fd.append('OurHistory', gid('pk-dm-history-text').value);
+		fd.append('ColorPrimary', gid('pk-dm-color-primary').value);
+		fd.append('ColorAccent', gid('pk-dm-color-accent').value);
+		fd.append('ColorSecondary', gid('pk-dm-gradient-enabled').checked ? gid('pk-dm-color-secondary').value : '');
+		fd.append('HeroOverlay', gid('pk-dm-hero-overlay').value);
+		fd.append('NameFont', pkSelectedFont || '');
+		var msConfig = {};
+		document.querySelectorAll('#pk-dm-ms-toggles input[data-pkms-type]').forEach(function(t) {
+			msConfig[t.dataset.pkmsType] = t.checked ? 1 : 0;
+		});
+		msConfig['newest_first'] = gid('pk-dm-ms-newest-first').checked ? 1 : 0;
+		fd.append('MilestoneConfig', JSON.stringify(msConfig));
+
+		fd.append('Tagline', gid('pk-dm-tagline').value);
+		fd.append('Announcement', gid('pk-dm-announcement').value);
+		fd.append('AnnouncementUntil', gid('pk-dm-announcement-until').value);
+
+		var socialPayload = {};
+		document.querySelectorAll('.pk-dm-social-input').forEach(function(inp) {
+			var v = (inp.value || '').trim();
+			if (v) socialPayload[inp.dataset.pksocial] = v;
+		});
+		fd.append('SocialLinks', Object.keys(socialPayload).length ? JSON.stringify(socialPayload) : '');
+
+		fetch(BASE_UIR + 'ParkAjax/park/' + PARK_ID + '/savedesign', { method: 'POST', body: fd })
+			.then(function(r) { return r.json(); })
+			.then(function(result) {
+				if (result && result.status === 0) {
+					window.location.reload();
+				} else {
+					errEl.textContent = (result && result.error) || 'Save failed.';
+					errEl.style.display = 'block';
+					btn.disabled = false;
+					btn.innerHTML = '<i class="fas fa-save"></i> Save Changes';
+				}
+			})
+			.catch(function(e) {
+				errEl.textContent = 'Request failed: ' + e.message;
+				errEl.style.display = 'block';
+				btn.disabled = false;
+				btn.innerHTML = '<i class="fas fa-save"></i> Save Changes';
+			});
+	});
+
+	// --- Announcement char counter (shows past 240) ---
+	(function() {
+		var ta = gid('pk-dm-announcement'); var counter = gid('pk-dm-announcement-count');
+		if (!ta || !counter) return;
+		function upd() {
+			var n = ta.value.length;
+			if (n > 240) {
+				counter.style.display = 'block';
+				counter.textContent = n + ' / 280';
+				counter.style.color = n >= 280 ? '#c53030' : '';
+			} else {
+				counter.style.display = 'none';
+			}
+		}
+		ta.addEventListener('input', upd); upd();
+	})();
+
+	// --- Social clear buttons ---
+	document.querySelectorAll('.pk-dm-social-clear').forEach(function(btn) {
+		btn.addEventListener('click', function() {
+			var slug = btn.dataset.pksocialClear;
+			var inp = document.querySelector('.pk-dm-social-input[data-pksocial="' + slug + '"]');
+			if (inp) { inp.value = ''; inp.focus(); }
+		});
+	});
+
+	// Initial render
+	renderCustomMsList();
+})();
+</script>
 <?php endif; ?>

--- a/system/lib/ork3/class.Kingdom.php
+++ b/system/lib/ork3/class.Kingdom.php
@@ -36,6 +36,36 @@ class Kingdom  extends Ork3 {
 			$response['KingdomInfo']['Active'] = $this->kingdom->active;
 			$response['KingdomInfo']['Description'] = $this->kingdom->description ?? '';
 			$response['KingdomInfo']['Url'] = $this->kingdom->url ?? '';
+			// --- Kingdom design (1:1 supplemental, always-present row) ---
+			$this->db->Clear();
+			$design = new yapo($this->db, DB_PREFIX . 'kingdom_design');
+			$design->clear();
+			$design->kingdom_id = $this->kingdom->kingdom_id;
+			if (!$design->find()) {
+				$design->clear();
+				$design->kingdom_id   = $this->kingdom->kingdom_id;
+				$design->hero_overlay = 'med';
+				$design->save();
+				$design->clear();
+				$this->db->Clear();
+				$design->kingdom_id = $this->kingdom->kingdom_id;
+				$design->find();
+			}
+			$response['KingdomInfo']['AboutText']       = (string)$design->about_text;
+			$response['KingdomInfo']['OurHistory']      = (string)$design->our_history;
+			$response['KingdomInfo']['ColorPrimary']    = $design->color_primary;
+			$response['KingdomInfo']['ColorAccent']     = $design->color_accent;
+			$response['KingdomInfo']['ColorSecondary']  = $design->color_secondary;
+			$response['KingdomInfo']['HeroOverlay']     = $design->hero_overlay ?: 'med';
+			$response['KingdomInfo']['NameFont']        = $design->name_font;
+			$response['KingdomInfo']['MilestoneConfig'] = $design->milestone_config;
+			$response['KingdomInfo']['Tagline']             = (string)$design->tagline;
+			$response['KingdomInfo']['SocialLinks']         = (string)$design->social_links;
+			$response['KingdomInfo']['Announcement']        = (string)$design->announcement;
+			$response['KingdomInfo']['AnnouncementUntil']   = $design->announcement_until;
+			$response['KingdomInfo']['MonarchReignStarted'] = $design->monarch_reign_started;
+			$response['KingdomInfo']['RegentReignStarted']  = $design->regent_reign_started;
+			$response['KingdomInfo']['ReignLore']           = (string)$design->reign_lore;
 		} else {
 			$response['Status'] = InvalidParameter();
 		}
@@ -283,7 +313,38 @@ class Kingdom  extends Ork3 {
 			$response['KingdomInfo']['ParentKingdomId'] = $this->kingdom->parent_kingdom_id;
 			$response['KingdomInfo']['Description'] = $this->kingdom->description ?? '';
 			$response['KingdomInfo']['Url'] = $this->kingdom->url ?? '';
-			
+
+			// --- Kingdom design (1:1 supplemental, always-present row) ---
+			$this->db->Clear();
+			$design = new yapo($this->db, DB_PREFIX . 'kingdom_design');
+			$design->clear();
+			$design->kingdom_id = $this->kingdom->kingdom_id;
+			if (!$design->find()) {
+				$design->clear();
+				$design->kingdom_id   = $this->kingdom->kingdom_id;
+				$design->hero_overlay = 'med';
+				$design->save();
+				$design->clear();
+				$this->db->Clear();
+				$design->kingdom_id = $this->kingdom->kingdom_id;
+				$design->find();
+			}
+			$response['KingdomInfo']['AboutText']       = (string)$design->about_text;
+			$response['KingdomInfo']['OurHistory']      = (string)$design->our_history;
+			$response['KingdomInfo']['ColorPrimary']    = $design->color_primary;
+			$response['KingdomInfo']['ColorAccent']     = $design->color_accent;
+			$response['KingdomInfo']['ColorSecondary']  = $design->color_secondary;
+			$response['KingdomInfo']['HeroOverlay']     = $design->hero_overlay ?: 'med';
+			$response['KingdomInfo']['NameFont']        = $design->name_font;
+			$response['KingdomInfo']['MilestoneConfig'] = $design->milestone_config;
+			$response['KingdomInfo']['Tagline']             = (string)$design->tagline;
+			$response['KingdomInfo']['SocialLinks']         = (string)$design->social_links;
+			$response['KingdomInfo']['Announcement']        = (string)$design->announcement;
+			$response['KingdomInfo']['AnnouncementUntil']   = $design->announcement_until;
+			$response['KingdomInfo']['MonarchReignStarted'] = $design->monarch_reign_started;
+			$response['KingdomInfo']['RegentReignStarted']  = $design->regent_reign_started;
+			$response['KingdomInfo']['ReignLore']           = (string)$design->reign_lore;
+
 			// Fetch configs
 			$response['KingdomConfiguration'] = Common::get_configs($request['KingdomId']);
 			
@@ -337,7 +398,15 @@ class Kingdom  extends Ork3 {
 			$this->kingdom->parent_kingdom_id = $request['ParentKingdomId'];
 			$this->kingdom->modified = date("Y-m-d H:i:s", time());
 			$this->kingdom->save();
-			
+			$_new_kingdom_id = (int)$this->kingdom->kingdom_id;
+			// Always-present design row so reads don't need PHP-side defaults.
+			$this->db->Clear();
+			$_design_seed = new yapo($this->db, DB_PREFIX . 'kingdom_design');
+			$_design_seed->clear();
+			$_design_seed->kingdom_id   = $_new_kingdom_id;
+			$_design_seed->hero_overlay = 'med';
+			$_design_seed->save();
+
 			$c = new Common();
 			$c->add_config($mundane_id, CFG_KINGDOM, 'fixed', $this->kingdom->kingdom_id, 'AveragePeriod', 
 				array('Type'=>$request['AttendancePeriodType'],'Period'=>$request['AttendancePeriod']), 1, array('Type'=>array('month','week')));
@@ -504,7 +573,17 @@ class Kingdom  extends Ork3 {
 				if (isset($request['Url'])) $this->kingdom->url = $request['Url'];
 				$this->kingdom->modified = date("Y-m-d H:i:s", time());
 				$this->kingdom->save();
-				
+				if (isset($request['Description']) && trim((string)$request['Description']) !== '') {
+					$this->db->Clear();
+					$_design_sync = new yapo($this->db, DB_PREFIX . 'kingdom_design');
+					$_design_sync->clear();
+					$_design_sync->kingdom_id = (int)$this->kingdom->kingdom_id;
+					if ($_design_sync->find() && trim((string)$_design_sync->about_text) !== '') {
+						$_design_sync->about_text = (string)$request['Description'];
+						$_design_sync->save();
+					}
+				}
+
 				Ork3::$Lib->heraldry->SetKingdomHeraldry($request);
 				
 				$c = new Common();
@@ -740,6 +819,332 @@ class Kingdom  extends Ork3 {
         } while ($this->kingdom->next());
         return $response;
     }
+
+	/**
+	 * Save kingdom profile design (header colors/font/overlay, about + our history markdown,
+	 * milestone visibility config). Uses AUTH_KINGDOM/AUTH_EDIT.
+	 */
+	public function SetKingdomDesign($request)
+	{
+		$kingdom_id = (int)($request['KingdomId'] ?? 0);
+		if ($kingdom_id <= 0) return InvalidParameter('KingdomId is required.');
+		$mundane_id = Ork3::$Lib->authorization->IsAuthorized($request['Token']);
+		if (!($mundane_id > 0) || !Ork3::$Lib->authorization->HasAuthority($mundane_id, AUTH_KINGDOM, $kingdom_id, AUTH_EDIT)) {
+			return NoAuthorization();
+		}
+		require_once(__DIR__ . '/class.ProfanityFilter.php');
+		$pf = new ProfanityFilter();
+		foreach (['AboutText' => 'AboutText', 'OurHistory' => 'OurHistory'] as $field => $label) {
+			if (isset($request[$field]) && trim((string)$request[$field]) !== '') {
+				if ($pf->containsProfanity((string)$request[$field])) {
+					return InvalidParameter($label, ProfanityFilter::ERROR_MESSAGE);
+				}
+			}
+		}
+		$this->db->Clear();
+		$design = new yapo($this->db, DB_PREFIX . 'kingdom_design');
+		$design->clear();
+		$design->kingdom_id = $kingdom_id;
+		if (!$design->find()) {
+			$design->clear();
+			$design->kingdom_id   = $kingdom_id;
+			$design->hero_overlay = 'med';
+			$design->save();
+			$design->clear();
+			$this->db->Clear();
+			$design->kingdom_id = $kingdom_id;
+			$design->find();
+		}
+		$ABOUT_LIMIT = 10000;
+		foreach (['AboutText' => 'about_text', 'OurHistory' => 'our_history'] as $req => $col) {
+			if (isset($request[$req])) {
+				$v = (string)$request[$req];
+				if (strlen($v) > $ABOUT_LIMIT) {
+					return InvalidParameter($req . ' is limited to ' . number_format($ABOUT_LIMIT) . ' characters.');
+				}
+				$design->$col = $v;
+			}
+		}
+		$hexCols = ['ColorPrimary' => 'color_primary', 'ColorAccent' => 'color_accent', 'ColorSecondary' => 'color_secondary'];
+		foreach ($hexCols as $req => $col) {
+			if (!array_key_exists($req, $request)) continue;
+			$v = trim((string)$request[$req]);
+			if ($v === '') { $design->$col = null; continue; }
+			if (!preg_match('/^#[0-9a-fA-F]{6}$/', $v)) {
+				return InvalidParameter($req . ' must be a 6-digit hex color (e.g. #2c5282).');
+			}
+			$design->$col = strtolower($v);
+		}
+		if (array_key_exists('HeroOverlay', $request)) {
+			$ho = strtolower(trim((string)$request['HeroOverlay']));
+			if (!in_array($ho, ['low','med','high','vignette'], true)) $ho = 'med';
+			$design->hero_overlay = $ho;
+		}
+		if (array_key_exists('NameFont', $request)) {
+			$nf = trim((string)$request['NameFont']);
+			if ($nf !== '' && !preg_match('/^[A-Za-z0-9 ]{1,100}$/', $nf)) {
+				return InvalidParameter('Font name contains unexpected characters.');
+			}
+			$design->name_font = $nf === '' ? null : $nf;
+		}
+		if (array_key_exists('MilestoneConfig', $request)) {
+			$mc = (string)$request['MilestoneConfig'];
+			if ($mc !== '') {
+				$decoded = json_decode($mc, true);
+				if (!is_array($decoded)) {
+					return InvalidParameter('Milestone config must be valid JSON.');
+				}
+			}
+			$design->milestone_config = $mc === '' ? null : $mc;
+		}
+
+		if (array_key_exists('Tagline', $request)) {
+			$tg = trim((string)$request['Tagline']);
+			if (strlen($tg) > 160) {
+				return InvalidParameter('Tagline is limited to 160 characters.');
+			}
+			if ($tg !== '' && $pf->containsProfanity($tg)) {
+				return InvalidParameter('Tagline', ProfanityFilter::ERROR_MESSAGE);
+			}
+			$design->tagline = $tg === '' ? null : $tg;
+		}
+
+		if (array_key_exists('SocialLinks', $request)) {
+			$sl = trim((string)$request['SocialLinks']);
+			$cleanLinks = [];
+			if ($sl !== '') {
+				$decoded = json_decode($sl, true);
+				if (!is_array($decoded)) {
+					return InvalidParameter('SocialLinks must be valid JSON.');
+				}
+				$allowed = ['discord','facebook','instagram','threads','bluesky','twitter','youtube','amtwiki'];
+				foreach ($decoded as $slug => $url) {
+					if (!in_array($slug, $allowed, true)) continue;
+					$url = trim((string)$url);
+					if ($url === '') continue;
+					if (preg_match('#^http://#i', $url)) {
+						$url = 'https://' . substr($url, 7);
+					} elseif (!preg_match('#^https://#i', $url)) {
+						$url = 'https://' . ltrim($url, '/');
+					}
+					if (strlen($url) > 500) {
+						return InvalidParameter('SocialLinks.' . $slug . ' URL too long.');
+					}
+					if (!filter_var($url, FILTER_VALIDATE_URL)) {
+						return InvalidParameter('SocialLinks.' . $slug . ' is not a valid URL.');
+					}
+					$cleanLinks[$slug] = $url;
+				}
+			}
+			$design->social_links = empty($cleanLinks) ? null : json_encode($cleanLinks);
+		}
+
+		if (array_key_exists('Announcement', $request)) {
+			$an = trim((string)$request['Announcement']);
+			if (strlen($an) > 280) {
+				return InvalidParameter('Announcement is limited to 280 characters.');
+			}
+			if ($an !== '' && $pf->containsProfanity($an)) {
+				return InvalidParameter('Announcement', ProfanityFilter::ERROR_MESSAGE);
+			}
+			$design->announcement = $an === '' ? null : $an;
+		}
+
+		if (array_key_exists('AnnouncementUntil', $request)) {
+			$au = trim((string)$request['AnnouncementUntil']);
+			if ($au === '') {
+				$design->announcement_until = null;
+			} else {
+				$ts = strtotime($au);
+				if ($ts === false) {
+					return InvalidParameter('AnnouncementUntil must be a valid date.');
+				}
+				$design->announcement_until = date('Y-m-d', $ts);
+			}
+		}
+
+		foreach (['MonarchReignStarted' => 'monarch_reign_started', 'RegentReignStarted' => 'regent_reign_started'] as $req => $col) {
+			if (!array_key_exists($req, $request)) continue;
+			$v = trim((string)$request[$req]);
+			if ($v === '') { $design->$col = null; continue; }
+			$ts = strtotime($v);
+			if ($ts === false) {
+				return InvalidParameter($req . ' must be a valid date.');
+			}
+			$design->$col = date('Y-m-d', $ts);
+		}
+
+		if (array_key_exists('ReignLore', $request)) {
+			$rl = (string)$request['ReignLore'];
+			if (strlen($rl) > 2000) {
+				return InvalidParameter('ReignLore is limited to 2,000 characters.');
+			}
+			if (trim($rl) !== '' && $pf->containsProfanity($rl)) {
+				return InvalidParameter('ReignLore', ProfanityFilter::ERROR_MESSAGE);
+			}
+			$design->reign_lore = trim($rl) === '' ? null : $rl;
+		}
+
+		$design->save();
+		return Success($kingdom_id);
+	}
+
+	public function GetKingdomMilestones($request)
+	{
+		$kingdom_id = (int)($request['KingdomId'] ?? 0);
+		if ($kingdom_id <= 0) return InvalidParameter('KingdomId is required.');
+		$this->db->Clear();
+		$ms = new yapo($this->db, DB_PREFIX . 'kingdom_milestones');
+		$ms->clear();
+		$ms->kingdom_id = $kingdom_id;
+		$rows = [];
+		if ($ms->find()) {
+			do {
+				$rows[] = [
+					'MilestoneId'   => (int)$ms->milestone_id,
+					'KingdomId'     => (int)$ms->kingdom_id,
+					'Icon'          => $ms->icon,
+					'Description'   => $ms->description,
+					'MilestoneDate' => $ms->milestone_date,
+				];
+			} while ($ms->next());
+		}
+		return ['Status' => Success(), 'Milestones' => $rows];
+	}
+
+	public function AddKingdomMilestone($request)
+	{
+		$kingdom_id = (int)($request['KingdomId'] ?? 0);
+		if ($kingdom_id <= 0) return InvalidParameter('KingdomId is required.');
+		$mundane_id = Ork3::$Lib->authorization->IsAuthorized($request['Token']);
+		if (!($mundane_id > 0) || !Ork3::$Lib->authorization->HasAuthority($mundane_id, AUTH_KINGDOM, $kingdom_id, AUTH_EDIT)) {
+			return NoAuthorization();
+		}
+		require_once(__DIR__ . '/class.ProfanityFilter.php');
+		$pf = new ProfanityFilter();
+		$desc = trim((string)($request['Description'] ?? ''));
+		if ($desc === '') return InvalidParameter('Description is required.');
+		if (strlen($desc) > 500) $desc = substr($desc, 0, 500);
+		if ($pf->containsProfanity($desc)) {
+			return InvalidParameter('Description', ProfanityFilter::ERROR_MESSAGE);
+		}
+		$dateRaw = trim((string)($request['MilestoneDate'] ?? ''));
+		if ($dateRaw === '') return InvalidParameter('Date is required.');
+		$ts = strtotime($dateRaw);
+		if ($ts === false) return InvalidParameter('Invalid date.');
+		$icon = trim((string)($request['Icon'] ?? 'fa-star'));
+		if (!preg_match('/^fa-[a-z0-9-]+$/', $icon)) $icon = 'fa-star';
+		$this->db->Clear();
+		$ms = new yapo($this->db, DB_PREFIX . 'kingdom_milestones');
+		$ms->clear();
+		$ms->kingdom_id     = $kingdom_id;
+		$ms->icon           = $icon;
+		$ms->description    = $desc;
+		$ms->milestone_date = date('Y-m-d', $ts);
+		$ms->save();
+		return Success((int)$ms->milestone_id);
+	}
+
+	public function DeleteKingdomMilestone($request)
+	{
+		$kingdom_id   = (int)($request['KingdomId']   ?? 0);
+		$milestone_id = (int)($request['MilestoneId'] ?? 0);
+		if ($kingdom_id <= 0 || $milestone_id <= 0) return InvalidParameter('KingdomId and MilestoneId required.');
+		$mundane_id = Ork3::$Lib->authorization->IsAuthorized($request['Token']);
+		if (!($mundane_id > 0) || !Ork3::$Lib->authorization->HasAuthority($mundane_id, AUTH_KINGDOM, $kingdom_id, AUTH_EDIT)) {
+			return NoAuthorization();
+		}
+		$this->db->Clear();
+		$ms = new yapo($this->db, DB_PREFIX . 'kingdom_milestones');
+		$ms->clear();
+		$ms->milestone_id = $milestone_id;
+		$ms->kingdom_id   = $kingdom_id;
+		if (!$ms->find()) return InvalidParameter('Milestone not found.');
+		$ms->delete();
+		return Success();
+	}
+
+	/**
+	 * Derived kingdom milestones — computed from attendance data scoped by kingdom_id.
+	 * Cached at 300s TTL.
+	 */
+	public function GetDerivedKingdomMilestones($request)
+	{
+		$kingdom_id = (int)(is_array($request) ? ($request['KingdomId'] ?? 0) : $request);
+		if ($kingdom_id <= 0) return ['Status' => InvalidParameter('KingdomId is required.'), 'Milestones' => []];
+		$key = Ork3::$Lib->ghettocache->key(['KingdomId' => $kingdom_id]);
+		if (($cache = Ork3::$Lib->ghettocache->get(__CLASS__ . '.' . __FUNCTION__, $key, 300)) !== false)
+			return $cache;
+		$out = [];
+		// 1) First recorded attendance anywhere in the kingdom.
+		$this->db->Clear();
+		$r = $this->db->query("SELECT MIN(date) AS first_date FROM " . DB_PREFIX . "attendance WHERE kingdom_id = $kingdom_id AND date >= '1988-01-01'");
+		if ($r !== false && $r->size() > 0) {
+			$r->next();
+			$fd = $r->first_date;
+			if ($fd && $fd !== '0000-00-00') {
+				$out[] = [
+					'Type'          => 'first_attendance',
+					'Icon'          => 'fa-door-open',
+					'Description'   => 'First recorded attendance in the kingdom',
+					'MilestoneDate' => $fd,
+					'IsDerived'     => true,
+				];
+			}
+		}
+		// 2) Attendance count crossings — kingdoms are larger than parks, so scaled up.
+		$this->db->Clear();
+		$r = $this->db->query("SELECT COUNT(*) AS total FROM " . DB_PREFIX . "attendance WHERE kingdom_id = $kingdom_id");
+		$total = 0;
+		if ($r !== false && $r->size() > 0) { $r->next(); $total = (int)$r->total; }
+		$thresholds = [1000, 5000, 10000, 50000, 100000, 500000];
+		foreach ($thresholds as $n) {
+			if ($total < $n) break;
+			$this->db->Clear();
+			$offset = $n - 1;
+			$rr = $this->db->query("SELECT date FROM " . DB_PREFIX . "attendance WHERE kingdom_id = $kingdom_id AND date >= '1988-01-01' ORDER BY date ASC LIMIT 1 OFFSET $offset");
+			if ($rr !== false && $rr->size() > 0) {
+				$rr->next();
+				$d = $rr->date;
+				if ($d && $d !== '0000-00-00') {
+					$out[] = [
+						'Type'          => 'attendance_count',
+						'Icon'          => 'fa-clipboard-list',
+						'Description'   => number_format($n) . 'th attendance recorded',
+						'MilestoneDate' => $d,
+						'IsDerived'     => true,
+					];
+				}
+			}
+		}
+		// 3) Distinct-member crossings — scaled up for kingdom size.
+		$this->db->Clear();
+		$r = $this->db->query("SELECT COUNT(DISTINCT mundane_id) AS members FROM " . DB_PREFIX . "attendance WHERE kingdom_id = $kingdom_id");
+		$members = 0;
+		if ($r !== false && $r->size() > 0) { $r->next(); $members = (int)$r->members; }
+		$memberThresholds = [100, 500, 1000, 5000, 10000];
+		foreach ($memberThresholds as $n) {
+			if ($members < $n) break;
+			$this->db->Clear();
+			$offset = $n - 1;
+			$rr = $this->db->query("SELECT MIN(date) AS first_date FROM " . DB_PREFIX . "attendance WHERE kingdom_id = $kingdom_id AND date >= '1988-01-01' GROUP BY mundane_id ORDER BY first_date ASC LIMIT 1 OFFSET $offset");
+			if ($rr !== false && $rr->size() > 0) {
+				$rr->next();
+				$d = $rr->first_date;
+				if ($d && $d !== '0000-00-00') {
+					$out[] = [
+						'Type'          => 'distinct_members',
+						'Icon'          => 'fa-users',
+						'Description'   => number_format($n) . 'th distinct member attended',
+						'MilestoneDate' => $d,
+						'IsDerived'     => true,
+					];
+				}
+			}
+		}
+		$response = ['Status' => Success(), 'Milestones' => $out];
+		return Ork3::$Lib->ghettocache->cache(__CLASS__ . '.' . __FUNCTION__, $key, $response);
+	}
 
 }
 

--- a/system/lib/ork3/class.Park.php
+++ b/system/lib/ork3/class.Park.php
@@ -497,6 +497,34 @@ class Park extends Ork3
 			$response[ 'Description' ] = stripslashes( nl2br( $this->park->description ) );
 			$response[ 'GoogleGeocode' ] = $this->park->google_geocode;
 			$response[ 'Location' ] = $this->park->location;
+			// --- Park design (1:1 supplemental, always-present row) ---
+			$this->db->Clear();
+			$design = new yapo( $this->db, DB_PREFIX . 'park_design' );
+			$design->clear();
+			$design->park_id = $this->park->park_id;
+			if ( !$design->find() ) {
+				// Defensive: seed missing row (migration backfills, but new parks pre-seed code may not yet exist on a fresh prod DB)
+				$design->clear();
+				$design->park_id     = $this->park->park_id;
+				$design->hero_overlay = 'med';
+				$design->save();
+				$design->clear();
+				$this->db->Clear();
+				$design->park_id = $this->park->park_id;
+				$design->find();
+			}
+			$response[ 'AboutText' ]       = (string)$design->about_text;
+			$response[ 'OurHistory' ]      = (string)$design->our_history;
+			$response[ 'ColorPrimary' ]    = $design->color_primary;
+			$response[ 'ColorAccent' ]     = $design->color_accent;
+			$response[ 'ColorSecondary' ]  = $design->color_secondary;
+			$response[ 'HeroOverlay' ]     = $design->hero_overlay ?: 'med';
+			$response[ 'NameFont' ]          = $design->name_font;
+			$response[ 'MilestoneConfig' ]   = $design->milestone_config;
+			$response[ 'Tagline' ]           = (string)$design->tagline;
+			$response[ 'SocialLinks' ]       = (string)$design->social_links;
+			$response[ 'Announcement' ]      = (string)$design->announcement;
+			$response[ 'AnnouncementUntil' ] = $design->announcement_until;
 		} else {
 			$response[ 'Status' ] = InvalidParameter();
 		}
@@ -744,6 +772,13 @@ class Park extends Ork3
 			$this->park->directions     = '';
 			$this->park->save();
 			$new_park_id = (int)$this->park->park_id;
+			// Always-present design row so reads don't need PHP-side defaults.
+			$this->db->Clear();
+			$_design_seed = new yapo( $this->db, DB_PREFIX . 'park_design' );
+			$_design_seed->clear();
+			$_design_seed->park_id      = $new_park_id;
+			$_design_seed->hero_overlay = 'med';
+			$_design_seed->save();
 			$t = new Treasury();
 			$t->create_accounts( $mundane_id, 'park', $new_park_id, $request[ 'KingdomId' ] );
 			$c = new Common();
@@ -894,6 +929,16 @@ class Park extends Ork3
 					if ( $_changed ) {
 						Ork3::$Lib->dangeraudit->audit( __CLASS__ . '::' . __FUNCTION__, $_audit_req, 'Park', (int)$this->park->park_id, $_audit_prior, $_audit_post );
 					}
+					if ( isset( $request[ 'Description' ] ) && trim( (string)$request[ 'Description' ] ) !== '' ) {
+						$this->db->Clear();
+						$_design_sync = new yapo( $this->db, DB_PREFIX . 'park_design' );
+						$_design_sync->clear();
+						$_design_sync->park_id = (int)$this->park->park_id;
+						if ( $_design_sync->find() && trim( (string)$_design_sync->about_text ) !== '' ) {
+							$_design_sync->about_text = (string)$request[ 'Description' ];
+							$_design_sync->save();
+						}
+					}
 					$response = Success( $this->park->park_id );
 				} else {
 					$response = InvalidParameter( 'ParkId could not be found.' );
@@ -1023,5 +1068,304 @@ class Park extends Ork3
 			$response = InvalidParameter( NULL, 'Problem processing request.' );
 		}
 		return $response;
+	}
+
+	/**
+	 * Save park profile design (header colors/font/overlay, about + our history markdown,
+	 * milestone visibility config). Uses the same AUTH_PARK/AUTH_EDIT gate as SetParkDetails.
+	 * Updates only the fields present in $request — callers can save one tab at a time.
+	 */
+	public function SetParkDesign( $request )
+	{
+		$park_id = (int)( $request[ 'ParkId' ] ?? 0 );
+		if ( $park_id <= 0 ) return InvalidParameter( 'ParkId is required.' );
+		$mundane_id = Ork3::$Lib->authorization->IsAuthorized( $request[ 'Token' ] );
+		if ( !( $mundane_id > 0 ) || !Ork3::$Lib->authorization->HasAuthority( $mundane_id, AUTH_PARK, $park_id, AUTH_EDIT ) ) {
+			return NoAuthorization();
+		}
+		require_once( __DIR__ . '/class.ProfanityFilter.php' );
+		$pf = new ProfanityFilter();
+		foreach ( [ 'AboutText' => 'AboutText', 'OurHistory' => 'OurHistory', 'Tagline' => 'Tagline', 'Announcement' => 'Announcement' ] as $field => $label ) {
+			if ( isset( $request[ $field ] ) && trim( (string)$request[ $field ] ) !== '' ) {
+				if ( $pf->containsProfanity( (string)$request[ $field ] ) ) {
+					return InvalidParameter( $label, ProfanityFilter::ERROR_MESSAGE );
+				}
+			}
+		}
+		$this->db->Clear();
+		$design = new yapo( $this->db, DB_PREFIX . 'park_design' );
+		$design->clear();
+		$design->park_id = $park_id;
+		if ( !$design->find() ) {
+			$design->clear();
+			$design->park_id      = $park_id;
+			$design->hero_overlay = 'med';
+			$design->save();
+			$design->clear();
+			$this->db->Clear();
+			$design->park_id = $park_id;
+			$design->find();
+		}
+		$ABOUT_LIMIT = 10000;
+		foreach ( [ 'AboutText' => 'about_text', 'OurHistory' => 'our_history' ] as $req => $col ) {
+			if ( isset( $request[ $req ] ) ) {
+				$v = (string)$request[ $req ];
+				if ( strlen( $v ) > $ABOUT_LIMIT ) {
+					return InvalidParameter( $req . ' is limited to ' . number_format( $ABOUT_LIMIT ) . ' characters.' );
+				}
+				$design->$col = $v;
+			}
+		}
+		$hexCols = [ 'ColorPrimary' => 'color_primary', 'ColorAccent' => 'color_accent', 'ColorSecondary' => 'color_secondary' ];
+		foreach ( $hexCols as $req => $col ) {
+			if ( !array_key_exists( $req, $request ) ) continue;
+			$v = trim( (string)$request[ $req ] );
+			if ( $v === '' ) { $design->$col = null; continue; }
+			if ( !preg_match( '/^#[0-9a-fA-F]{6}$/', $v ) ) {
+				return InvalidParameter( $req . ' must be a 6-digit hex color (e.g. #2c5282).' );
+			}
+			$design->$col = strtolower( $v );
+		}
+		if ( array_key_exists( 'HeroOverlay', $request ) ) {
+			$ho = strtolower( trim( (string)$request[ 'HeroOverlay' ] ) );
+			if ( !in_array( $ho, [ 'low', 'med', 'high', 'vignette' ], true ) ) $ho = 'med';
+			$design->hero_overlay = $ho;
+		}
+		if ( array_key_exists( 'NameFont', $request ) ) {
+			$nf = trim( (string)$request[ 'NameFont' ] );
+			if ( $nf !== '' && !preg_match( '/^[A-Za-z0-9 ]{1,100}$/', $nf ) ) {
+				return InvalidParameter( 'Font name contains unexpected characters.' );
+			}
+			$design->name_font = $nf === '' ? null : $nf;
+		}
+		if ( array_key_exists( 'MilestoneConfig', $request ) ) {
+			$mc = (string)$request[ 'MilestoneConfig' ];
+			if ( $mc !== '' ) {
+				$decoded = json_decode( $mc, true );
+				if ( !is_array( $decoded ) ) {
+					return InvalidParameter( 'Milestone config must be valid JSON.' );
+				}
+			}
+			$design->milestone_config = $mc === '' ? null : $mc;
+		}
+		if ( array_key_exists( 'Tagline', $request ) ) {
+			$tg = trim( (string)$request[ 'Tagline' ] );
+			if ( strlen( $tg ) > 160 ) {
+				return InvalidParameter( 'Tagline is limited to 160 characters.' );
+			}
+			$design->tagline = $tg === '' ? null : $tg;
+		}
+		if ( array_key_exists( 'SocialLinks', $request ) ) {
+			$sl = trim( (string)$request[ 'SocialLinks' ] );
+			if ( $sl === '' ) {
+				$design->social_links = null;
+			} else {
+				$decoded = json_decode( $sl, true );
+				if ( !is_array( $decoded ) ) {
+					return InvalidParameter( 'Social links must be valid JSON.' );
+				}
+				$clean = [ ];
+				foreach ( $decoded as $platform => $url ) {
+					$url = trim( (string)$url );
+					if ( $url === '' ) continue;
+					if ( preg_match( '#^http://#i', $url ) ) {
+						$url = 'https://' . substr( $url, 7 );
+					} elseif ( !preg_match( '#^https://#i', $url ) ) {
+						$url = 'https://' . ltrim( $url, '/' );
+					}
+					if ( strlen( $url ) > 500 ) {
+						return InvalidParameter( 'Social link for ' . $platform . ' must be 500 characters or fewer.' );
+					}
+					$clean[ (string)$platform ] = $url;
+				}
+				$design->social_links = empty( $clean ) ? null : json_encode( $clean );
+			}
+		}
+		if ( array_key_exists( 'Announcement', $request ) ) {
+			$an = trim( (string)$request[ 'Announcement' ] );
+			if ( strlen( $an ) > 280 ) {
+				return InvalidParameter( 'Announcement is limited to 280 characters.' );
+			}
+			$design->announcement = $an === '' ? null : $an;
+		}
+		if ( array_key_exists( 'AnnouncementUntil', $request ) ) {
+			$au = trim( (string)$request[ 'AnnouncementUntil' ] );
+			if ( $au === '' ) {
+				$design->announcement_until = null;
+			} else {
+				$ts = strtotime( $au );
+				if ( $ts === false ) {
+					return InvalidParameter( 'Announcement "Show until" must be a valid date.' );
+				}
+				$design->announcement_until = date( 'Y-m-d', $ts );
+			}
+		}
+		$design->save();
+		return Success( $park_id );
+	}
+
+	/**
+	 * Custom (officer-authored) park milestones. Stored rows; mirrors GetCustomMilestones on Player.
+	 */
+	public function GetParkMilestones( $request )
+	{
+		$park_id = (int)( $request[ 'ParkId' ] ?? 0 );
+		if ( $park_id <= 0 ) return InvalidParameter( 'ParkId is required.' );
+		$this->db->Clear();
+		$ms = new yapo( $this->db, DB_PREFIX . 'park_milestones' );
+		$ms->clear();
+		$ms->park_id = $park_id;
+		$rows = [ ];
+		if ( $ms->find() ) {
+			do {
+				$rows[] = [
+					'MilestoneId'   => (int)$ms->milestone_id,
+					'ParkId'        => (int)$ms->park_id,
+					'Icon'          => $ms->icon,
+					'Description'   => $ms->description,
+					'MilestoneDate' => $ms->milestone_date,
+				];
+			} while ( $ms->next() );
+		}
+		return [ 'Status' => Success(), 'Milestones' => $rows ];
+	}
+
+	public function AddParkMilestone( $request )
+	{
+		$park_id = (int)( $request[ 'ParkId' ] ?? 0 );
+		if ( $park_id <= 0 ) return InvalidParameter( 'ParkId is required.' );
+		$mundane_id = Ork3::$Lib->authorization->IsAuthorized( $request[ 'Token' ] );
+		if ( !( $mundane_id > 0 ) || !Ork3::$Lib->authorization->HasAuthority( $mundane_id, AUTH_PARK, $park_id, AUTH_EDIT ) ) {
+			return NoAuthorization();
+		}
+		require_once( __DIR__ . '/class.ProfanityFilter.php' );
+		$pf = new ProfanityFilter();
+		$desc = trim( (string)( $request[ 'Description' ] ?? '' ) );
+		if ( $desc === '' ) return InvalidParameter( 'Description is required.' );
+		if ( strlen( $desc ) > 500 ) $desc = substr( $desc, 0, 500 );
+		if ( $pf->containsProfanity( $desc ) ) {
+			return InvalidParameter( 'Description', ProfanityFilter::ERROR_MESSAGE );
+		}
+		$dateRaw = trim( (string)( $request[ 'MilestoneDate' ] ?? '' ) );
+		if ( $dateRaw === '' ) return InvalidParameter( 'Date is required.' );
+		$ts = strtotime( $dateRaw );
+		if ( $ts === false ) return InvalidParameter( 'Invalid date.' );
+		$icon = trim( (string)( $request[ 'Icon' ] ?? 'fa-star' ) );
+		if ( !preg_match( '/^fa-[a-z0-9-]+$/', $icon ) ) $icon = 'fa-star';
+		$this->db->Clear();
+		$ms = new yapo( $this->db, DB_PREFIX . 'park_milestones' );
+		$ms->clear();
+		$ms->park_id        = $park_id;
+		$ms->icon           = $icon;
+		$ms->description    = $desc;
+		$ms->milestone_date = date( 'Y-m-d', $ts );
+		$ms->save();
+		return Success( (int)$ms->milestone_id );
+	}
+
+	public function DeleteParkMilestone( $request )
+	{
+		$park_id      = (int)( $request[ 'ParkId' ]      ?? 0 );
+		$milestone_id = (int)( $request[ 'MilestoneId' ] ?? 0 );
+		if ( $park_id <= 0 || $milestone_id <= 0 ) return InvalidParameter( 'ParkId and MilestoneId required.' );
+		$mundane_id = Ork3::$Lib->authorization->IsAuthorized( $request[ 'Token' ] );
+		if ( !( $mundane_id > 0 ) || !Ork3::$Lib->authorization->HasAuthority( $mundane_id, AUTH_PARK, $park_id, AUTH_EDIT ) ) {
+			return NoAuthorization();
+		}
+		$this->db->Clear();
+		$ms = new yapo( $this->db, DB_PREFIX . 'park_milestones' );
+		$ms->clear();
+		$ms->milestone_id = $milestone_id;
+		$ms->park_id      = $park_id;
+		if ( !$ms->find() ) return InvalidParameter( 'Milestone not found.' );
+		$ms->delete();
+		return Success();
+	}
+
+	/**
+	 * Derived milestones — computed from attendance data, not stored. These
+	 * are appended into the same timeline as custom milestones. Each derived
+	 * entry has a stable `Type` so visibility toggles in milestone_config can
+	 * include/exclude entire categories.
+	 */
+	public function GetDerivedParkMilestones( $request )
+	{
+		$park_id = (int)( is_array( $request ) ? ( $request[ 'ParkId' ] ?? 0 ) : $request );
+		if ( $park_id <= 0 ) return [ 'Status' => InvalidParameter( 'ParkId is required.' ), 'Milestones' => [ ] ];
+		$key = Ork3::$Lib->ghettocache->key( [ 'ParkId' => $park_id ] );
+		if ( ( $cache = Ork3::$Lib->ghettocache->get( __CLASS__ . '.' . __FUNCTION__, $key, 300 ) ) !== false )
+			return $cache;
+		$out = [ ];
+		// 1) First recorded attendance at this park (floor at 1988 to filter junk dates).
+		$this->db->Clear();
+		$r = $this->db->query( "SELECT MIN(date) AS first_date FROM " . DB_PREFIX . "attendance WHERE park_id = $park_id AND date >= '1988-01-01'" );
+		if ( $r !== false && $r->size() > 0 ) {
+			$r->next();
+			$fd = $r->first_date;
+			if ( $fd && $fd !== '0000-00-00' ) {
+				$out[] = [
+					'Type'          => 'first_attendance',
+					'Icon'          => 'fa-door-open',
+					'Description'   => 'First recorded attendance at the park',
+					'MilestoneDate' => $fd,
+					'IsDerived'     => true,
+				];
+			}
+		}
+		// 2) Attendance count crossings — 1000, 5000, 10000, 25000, 50000, 100000.
+		$this->db->Clear();
+		$r = $this->db->query( "SELECT COUNT(*) AS total FROM " . DB_PREFIX . "attendance WHERE park_id = $park_id" );
+		$total = 0;
+		if ( $r !== false && $r->size() > 0 ) { $r->next(); $total = (int)$r->total; }
+		$thresholds = [ 1000, 5000, 10000, 25000, 50000, 100000 ];
+		foreach ( $thresholds as $n ) {
+			if ( $total < $n ) break;
+			// Date of the Nth recorded attendance (chronological order).
+			$this->db->Clear();
+			$offset = $n - 1;
+			$rr = $this->db->query( "SELECT date FROM " . DB_PREFIX . "attendance WHERE park_id = $park_id AND date >= '1988-01-01' ORDER BY date ASC LIMIT 1 OFFSET $offset" );
+			if ( $rr !== false && $rr->size() > 0 ) {
+				$rr->next();
+				$d = $rr->date;
+				if ( $d && $d !== '0000-00-00' ) {
+					$out[] = [
+						'Type'          => 'attendance_count',
+						'Icon'          => 'fa-clipboard-list',
+						'Description'   => number_format( $n ) . 'th attendance recorded',
+						'MilestoneDate' => $d,
+						'IsDerived'     => true,
+					];
+				}
+			}
+		}
+		// 3) Distinct-member crossings — 50, 100, 250, 500, 1000.
+		$this->db->Clear();
+		$r = $this->db->query( "SELECT COUNT(DISTINCT mundane_id) AS members FROM " . DB_PREFIX . "attendance WHERE park_id = $park_id" );
+		$members = 0;
+		if ( $r !== false && $r->size() > 0 ) { $r->next(); $members = (int)$r->members; }
+		$memberThresholds = [ 50, 100, 250, 500, 1000 ];
+		foreach ( $memberThresholds as $n ) {
+			if ( $members < $n ) break;
+			// Date the Nth distinct member first showed up — earliest 'first attendance' across all members,
+			// then take the Nth one in chronological order of first-attendance.
+			$this->db->Clear();
+			$offset = $n - 1;
+			$rr = $this->db->query( "SELECT MIN(date) AS first_date FROM " . DB_PREFIX . "attendance WHERE park_id = $park_id AND date >= '1988-01-01' GROUP BY mundane_id ORDER BY first_date ASC LIMIT 1 OFFSET $offset" );
+			if ( $rr !== false && $rr->size() > 0 ) {
+				$rr->next();
+				$d = $rr->first_date;
+				if ( $d && $d !== '0000-00-00' ) {
+					$out[] = [
+						'Type'          => 'distinct_members',
+						'Icon'          => 'fa-users',
+						'Description'   => number_format( $n ) . 'th distinct member attended',
+						'MilestoneDate' => $d,
+						'IsDerived'     => true,
+					];
+				}
+			}
+		}
+		$response = [ 'Status' => Success(), 'Milestones' => $out ];
+		return Ork3::$Lib->ghettocache->cache( __CLASS__ . '.' . __FUNCTION__, $key, $response );
 	}
 }

--- a/system/lib/ork3/class.Unit.php
+++ b/system/lib/ork3/class.Unit.php
@@ -173,6 +173,34 @@ class Unit extends Ork3 {
 					'Url' => $this->unit->url,
 					'History' => $this->unit->history
 				);
+			$this->db->Clear();
+			$design = new yapo($this->db, DB_PREFIX . 'unit_design');
+			$design->clear();
+			$design->unit_id = $this->unit->unit_id;
+			if (!$design->find()) {
+				$design->clear();
+				$design->unit_id      = $this->unit->unit_id;
+				$design->hero_overlay = 'med';
+				$design->save();
+				$design->clear();
+				$this->db->Clear();
+				$design->unit_id = $this->unit->unit_id;
+				$design->find();
+			}
+			$response['Unit']['AboutText']       = (string)$design->about_text;
+			$response['Unit']['OurHistory']      = (string)$design->our_history;
+			$response['Unit']['ColorPrimary']    = $design->color_primary;
+			$response['Unit']['ColorAccent']     = $design->color_accent;
+			$response['Unit']['ColorSecondary']  = $design->color_secondary;
+			$response['Unit']['HeroOverlay']     = $design->hero_overlay ?: 'med';
+			$response['Unit']['NameFont']        = $design->name_font;
+			$response['Unit']['MilestoneConfig'] = $design->milestone_config;
+			$response['Unit']['Tagline']            = (string)$design->tagline;
+			$response['Unit']['SocialLinks']        = (string)$design->social_links;
+			$response['Unit']['Announcement']       = (string)$design->announcement;
+			$response['Unit']['AnnouncementUntil']  = $design->announcement_until;
+			$response['Unit']['RecruitmentStatus']  = (string)$design->recruitment_status;
+			$response['Unit']['HowToJoin']          = (string)$design->how_to_join;
 		} else {
 			$response['Status'] = InvalidParameter();
 		}
@@ -296,6 +324,12 @@ class Unit extends Ork3 {
 			$this->unit->modified = date("Y-m-d H:i:s");
 			$this->unit->save();
     		$request['UnitId'] = $this->unit->unit_id;
+			$this->db->Clear();
+			$_design_seed = new yapo($this->db, DB_PREFIX . 'unit_design');
+			$_design_seed->clear();
+			$_design_seed->unit_id      = (int)$this->unit->unit_id;
+			$_design_seed->hero_overlay = 'med';
+			$_design_seed->save();
 
     		if (strlen($request['Heraldry']) > 0) {
 				logtrace("CreateUnit() :2", $request);
@@ -354,6 +388,22 @@ class Unit extends Ork3 {
 				logtrace("SetUnit() :SetUnitHeraldry()",null);
 				Ork3::$Lib->heraldry->SetUnitHeraldry($request);
 			}
+			$this->db->Clear();
+			$_design_sync = new yapo($this->db, DB_PREFIX . 'unit_design');
+			$_design_sync->clear();
+			$_design_sync->unit_id = (int)$this->unit->unit_id;
+			if ($_design_sync->find()) {
+				$_dirty = false;
+				if (isset($request['Description']) && trim((string)$request['Description']) !== '' && trim((string)$_design_sync->about_text) !== '') {
+					$_design_sync->about_text = trim((string)$request['Description']);
+					$_dirty = true;
+				}
+				if (isset($request['History']) && trim((string)$request['History']) !== '' && trim((string)$_design_sync->our_history) !== '') {
+					$_design_sync->our_history = trim((string)$request['History']);
+					$_dirty = true;
+				}
+				if ($_dirty) $_design_sync->save();
+			}
 			return Success();
 		}
 		return NoAuthorization();
@@ -396,6 +446,249 @@ class Unit extends Ork3 {
 		} else {
 			return InvalidParameter('Unit not found.');
 		}
+	}
+
+	public function SetUnitDesign($request) {
+		$unit_id = (int)($request['UnitId'] ?? 0);
+		if ($unit_id <= 0) return InvalidParameter('UnitId is required.');
+		$mundane_id = Ork3::$Lib->authorization->IsAuthorized($request['Token']);
+		if (!($mundane_id > 0) || !Ork3::$Lib->authorization->HasAuthority($mundane_id, AUTH_UNIT, $unit_id, AUTH_EDIT)) {
+			return NoAuthorization();
+		}
+		require_once(__DIR__ . '/class.ProfanityFilter.php');
+		$pf = new ProfanityFilter();
+		foreach (['AboutText' => 'AboutText', 'OurHistory' => 'OurHistory', 'Tagline' => 'Tagline', 'Announcement' => 'Announcement', 'HowToJoin' => 'HowToJoin'] as $field => $label) {
+			if (isset($request[$field]) && trim((string)$request[$field]) !== '') {
+				if ($pf->containsProfanity((string)$request[$field])) {
+					return InvalidParameter($label, ProfanityFilter::ERROR_MESSAGE);
+				}
+			}
+		}
+		$this->db->Clear();
+		$design = new yapo($this->db, DB_PREFIX . 'unit_design');
+		$design->clear();
+		$design->unit_id = $unit_id;
+		if (!$design->find()) {
+			$design->clear();
+			$design->unit_id      = $unit_id;
+			$design->hero_overlay = 'med';
+			$design->save();
+			$design->clear();
+			$this->db->Clear();
+			$design->unit_id = $unit_id;
+			$design->find();
+		}
+		$ABOUT_LIMIT = 10000;
+		foreach (['AboutText' => 'about_text', 'OurHistory' => 'our_history'] as $req => $col) {
+			if (isset($request[$req])) {
+				$v = (string)$request[$req];
+				if (strlen($v) > $ABOUT_LIMIT) {
+					return InvalidParameter($req . ' is limited to ' . number_format($ABOUT_LIMIT) . ' characters.');
+				}
+				$design->$col = $v;
+			}
+		}
+		$hexCols = ['ColorPrimary' => 'color_primary', 'ColorAccent' => 'color_accent', 'ColorSecondary' => 'color_secondary'];
+		foreach ($hexCols as $req => $col) {
+			if (!array_key_exists($req, $request)) continue;
+			$v = trim((string)$request[$req]);
+			if ($v === '') { $design->$col = null; continue; }
+			if (!preg_match('/^#[0-9a-fA-F]{6}$/', $v)) {
+				return InvalidParameter($req . ' must be a 6-digit hex color (e.g. #2c5282).');
+			}
+			$design->$col = strtolower($v);
+		}
+		if (array_key_exists('HeroOverlay', $request)) {
+			$ho = strtolower(trim((string)$request['HeroOverlay']));
+			if (!in_array($ho, ['low','med','high','vignette'], true)) $ho = 'med';
+			$design->hero_overlay = $ho;
+		}
+		if (array_key_exists('NameFont', $request)) {
+			$nf = trim((string)$request['NameFont']);
+			if ($nf !== '' && !preg_match('/^[A-Za-z0-9 ]{1,100}$/', $nf)) {
+				return InvalidParameter('Font name contains unexpected characters.');
+			}
+			$design->name_font = $nf === '' ? null : $nf;
+		}
+		if (array_key_exists('MilestoneConfig', $request)) {
+			$mc = (string)$request['MilestoneConfig'];
+			if ($mc !== '') {
+				$decoded = json_decode($mc, true);
+				if (!is_array($decoded)) {
+					return InvalidParameter('Milestone config must be valid JSON.');
+				}
+			}
+			$design->milestone_config = $mc === '' ? null : $mc;
+		}
+		if (array_key_exists('Tagline', $request)) {
+			$tg = trim((string)$request['Tagline']);
+			if (strlen($tg) > 160) {
+				return InvalidParameter('Tagline is limited to 160 characters.');
+			}
+			$design->tagline = $tg === '' ? null : $tg;
+		}
+		if (array_key_exists('SocialLinks', $request)) {
+			$sl = trim((string)$request['SocialLinks']);
+			if ($sl === '') {
+				$design->social_links = null;
+			} else {
+				$decoded = json_decode($sl, true);
+				if (!is_array($decoded)) {
+					return InvalidParameter('Social links must be valid JSON.');
+				}
+				$clean = [];
+				foreach ($decoded as $platform => $url) {
+					$url = trim((string)$url);
+					if ($url === '') continue;
+					if (preg_match('#^http://#i', $url)) {
+						$url = 'https://' . substr($url, 7);
+					} elseif (!preg_match('#^https://#i', $url)) {
+						$url = 'https://' . ltrim($url, '/');
+					}
+					if (strlen($url) > 500) {
+						return InvalidParameter('Social link for ' . $platform . ' must be 500 characters or fewer.');
+					}
+					$clean[(string)$platform] = $url;
+				}
+				$design->social_links = empty($clean) ? null : json_encode($clean);
+			}
+		}
+		if (array_key_exists('Announcement', $request)) {
+			$an = trim((string)$request['Announcement']);
+			if (strlen($an) > 280) {
+				return InvalidParameter('Announcement is limited to 280 characters.');
+			}
+			$design->announcement = $an === '' ? null : $an;
+		}
+		if (array_key_exists('AnnouncementUntil', $request)) {
+			$au = trim((string)$request['AnnouncementUntil']);
+			if ($au === '') {
+				$design->announcement_until = null;
+			} else {
+				$ts = strtotime($au);
+				if ($ts === false) {
+					return InvalidParameter('Announcement "Show until" must be a valid date.');
+				}
+				$design->announcement_until = date('Y-m-d', $ts);
+			}
+		}
+		if (array_key_exists('RecruitmentStatus', $request)) {
+			$rs = strtolower(trim((string)$request['RecruitmentStatus']));
+			if ($rs === '' || $rs === 'none' || $rs === 'unset') {
+				$design->recruitment_status = null;
+			} elseif (in_array($rs, ['open','invite','closed'], true)) {
+				$design->recruitment_status = $rs;
+			} else {
+				return InvalidParameter('Recruitment status must be open, invite, or closed.');
+			}
+		}
+		if (array_key_exists('HowToJoin', $request)) {
+			$hj = (string)$request['HowToJoin'];
+			if (strlen($hj) > 5000) {
+				return InvalidParameter('HowToJoin is limited to 5,000 characters.');
+			}
+			$design->how_to_join = trim($hj) === '' ? null : $hj;
+		}
+		$design->save();
+		return Success($unit_id);
+	}
+
+	public function GetUnitMilestones($request) {
+		$unit_id = (int)($request['UnitId'] ?? 0);
+		if ($unit_id <= 0) return InvalidParameter('UnitId is required.');
+		$this->db->Clear();
+		$ms = new yapo($this->db, DB_PREFIX . 'unit_milestones');
+		$ms->clear();
+		$ms->unit_id = $unit_id;
+		$rows = [];
+		if ($ms->find()) {
+			do {
+				$rows[] = [
+					'MilestoneId'   => (int)$ms->milestone_id,
+					'UnitId'        => (int)$ms->unit_id,
+					'Icon'          => $ms->icon,
+					'Description'   => $ms->description,
+					'MilestoneDate' => $ms->milestone_date,
+				];
+			} while ($ms->next());
+		}
+		return ['Status' => Success(), 'Milestones' => $rows];
+	}
+
+	public function AddUnitMilestone($request) {
+		$unit_id = (int)($request['UnitId'] ?? 0);
+		if ($unit_id <= 0) return InvalidParameter('UnitId is required.');
+		$mundane_id = Ork3::$Lib->authorization->IsAuthorized($request['Token']);
+		if (!($mundane_id > 0) || !Ork3::$Lib->authorization->HasAuthority($mundane_id, AUTH_UNIT, $unit_id, AUTH_EDIT)) {
+			return NoAuthorization();
+		}
+		require_once(__DIR__ . '/class.ProfanityFilter.php');
+		$pf = new ProfanityFilter();
+		$desc = trim((string)($request['Description'] ?? ''));
+		if ($desc === '') return InvalidParameter('Description is required.');
+		if (strlen($desc) > 500) $desc = substr($desc, 0, 500);
+		if ($pf->containsProfanity($desc)) {
+			return InvalidParameter('Description', ProfanityFilter::ERROR_MESSAGE);
+		}
+		$dateRaw = trim((string)($request['MilestoneDate'] ?? ''));
+		if ($dateRaw === '') return InvalidParameter('Date is required.');
+		$ts = strtotime($dateRaw);
+		if ($ts === false) return InvalidParameter('Invalid date.');
+		$icon = trim((string)($request['Icon'] ?? 'fa-star'));
+		if (!preg_match('/^fa-[a-z0-9-]+$/', $icon)) $icon = 'fa-star';
+		$this->db->Clear();
+		$ms = new yapo($this->db, DB_PREFIX . 'unit_milestones');
+		$ms->clear();
+		$ms->unit_id        = $unit_id;
+		$ms->icon           = $icon;
+		$ms->description    = $desc;
+		$ms->milestone_date = date('Y-m-d', $ts);
+		$ms->save();
+		return Success((int)$ms->milestone_id);
+	}
+
+	public function DeleteUnitMilestone($request) {
+		$unit_id      = (int)($request['UnitId']      ?? 0);
+		$milestone_id = (int)($request['MilestoneId'] ?? 0);
+		if ($unit_id <= 0 || $milestone_id <= 0) return InvalidParameter('UnitId and MilestoneId required.');
+		$mundane_id = Ork3::$Lib->authorization->IsAuthorized($request['Token']);
+		if (!($mundane_id > 0) || !Ork3::$Lib->authorization->HasAuthority($mundane_id, AUTH_UNIT, $unit_id, AUTH_EDIT)) {
+			return NoAuthorization();
+		}
+		$this->db->Clear();
+		$ms = new yapo($this->db, DB_PREFIX . 'unit_milestones');
+		$ms->clear();
+		$ms->milestone_id = $milestone_id;
+		$ms->unit_id      = $unit_id;
+		if (!$ms->find()) return InvalidParameter('Milestone not found.');
+		$ms->delete();
+		return Success();
+	}
+
+	public function GetDerivedUnitMilestones($request) {
+		$unit_id = (int)(is_array($request) ? ($request['UnitId'] ?? 0) : $request);
+		if ($unit_id <= 0) return ['Status' => InvalidParameter('UnitId is required.'), 'Milestones' => []];
+		$key = Ork3::$Lib->ghettocache->key(['UnitId' => $unit_id]);
+		if (($cache = Ork3::$Lib->ghettocache->get(__CLASS__ . '.' . __FUNCTION__, $key, 300)) !== false)
+			return $cache;
+		$out = [];
+		$this->db->Clear();
+		$r = $this->db->query("SELECT MIN(a.date) AS first_date FROM " . DB_PREFIX . "attendance a JOIN " . DB_PREFIX . "unit_mundane um ON um.mundane_id = a.mundane_id WHERE um.unit_id = $unit_id AND a.date >= '1988-01-01'");
+		if ($r !== false && $r->size() > 0) {
+			$r->next();
+			$fd = $r->first_date;
+			if ($fd && $fd !== '0000-00-00') {
+				$out[] = [
+					'Type'          => 'first_member_activity',
+					'Icon'          => 'fa-door-open',
+					'Description'   => 'First recorded activity by a member',
+					'MilestoneDate' => $fd,
+					'IsDerived'     => true,
+				];
+			}
+		}
+		$response = ['Status' => Success(), 'Milestones' => $out];
+		return Ork3::$Lib->ghettocache->cache(__CLASS__ . '.' . __FUNCTION__, $key, $response);
 	}
 
 }


### PR DESCRIPTION
Brings the Player profile customization pattern to Park, Kingdom, and Unit — adds a **Design** modal in every org hero so officers can shape their org's public profile, plus a phase-two round of cross-org additions (tagline, social links, announcement banner) and org-specific extras (kingdom reign banner, unit recruitment status, unit "How to Join").

## What's in

### Phase 1 — Header / About / Milestones (Park, Kingdom, Unit)

| Feature | Park | Kingdom | Unit |
|---|---|---|---|
| Custom primary/gradient/accent colors + heraldry overlay strength + decorative name font | ✅ | ✅ | ✅ |
| Markdown About content (backfilled from legacy `description`) | ✅ | ✅ | ✅ |
| Markdown **Our History** section | ✅ | ✅ | ✅ (backfilled from native `ork_unit.history`) |
| **Milestones timeline** — admin-authored custom + auto-derived from attendance | ✅ | ✅ | ✅ (custom + first-recorded-member-activity) |
| Hero **Design** button gated to existing edit perms | ✅ | ✅ | ✅ |
| **About tab** (created from scratch where absent) | already had one | ✨ new | ✨ new (with About + Members tabs) |

### Phase 2 — Cross-org extras + org-specific additions

- **Tagline** — italic motto line under the org name
- **Announcement banner** — amber pinned message above the hero with optional auto-expiration date
- **Connect** — admin enters URLs for Discord / Facebook / Instagram / Threads / Bluesky / Twitter / YouTube / Amtwiki. URLs are normalized (`http://`, `www.`, bare hostnames → `https://`). Rendered as compact circular icon-only pills in the org's selected accent color. Lives in the **Quick Links sidebar** as a Connect subhead on Park/Kingdom, and as a compact horizontal strip on Unit (no sidebar).
- **Kingdom Reign Banner** — current Monarch + Regent with player photo + admin-set reign-since dates + optional Markdown lore.
- **Unit Recruitment Status** pill (Open / Invite Only / Closed) next to the type badge.
- **Unit How to Join** — optional Markdown section between About and Our History.

## Database

7 new migrations under `db-migrations/2026-05-1[67]-…`:
- `ork_park_design`, `ork_kingdom_design`, `ork_unit_design` (1:1, FK + CASCADE)
- `ork_park_milestones`, `ork_kingdom_milestones`, `ork_unit_milestones` (custom rows)
- A single combined migration for the Phase 2 columns

All migrations are **idempotent** — re-running is a no-op:
- Prepared-statement engine convert runs `ALTER TABLE … ENGINE=InnoDB` only when not already InnoDB
- `CREATE TABLE IF NOT EXISTS` on tables, `ADD COLUMN IF NOT EXISTS` on columns
- Backfills use `INSERT IGNORE` + `TRIM()`-guarded `UPDATE…JOIN`

`ork_park`, `ork_kingdom`, `ork_unit` are converted MyISAM → InnoDB to support FK constraints (matching the same conversion already done on `ork_mundane` for player design).

## Architecture & conventions honored

- **Per-org design tables**, not a shared `org_design` — matches the player pattern's rejection of JSON-blob and shared-table alternatives. Each org's schema evolves independently.
- **GhettoCache wrap** on derived milestone computation (300s TTL keyed on org id), avoiding repeated OFFSET scans of `ork_attendance` on cached page hits.
- **Sync-forward guard**: when an officer saves description through the legacy Edit Details modal, the new value mirrors into `about_text` only when **both** the request is non-empty **and** the design row already has content — preventing a blank legacy save from wiping Design-modal content.
- **`InvalidParameter` convention**: single-arg human message for non-profanity errors (`InvalidParameter('Tagline is limited to 160 characters.')`); `($field, ProfanityFilter::ERROR_MESSAGE)` only for profanity (so the AJAX layer can route inline-field errors).
- **Yapo discipline**: `$this->db->Clear()` between every `save()` and subsequent `find()`.
- **No native `title=`** on new UI — `data-tip` with scoped `[data-tip]::after` CSS (including the JS-generated milestone delete button and every Connect pill).
- **Dark-mode override on every new visual surface** — every modal panel, banner, pill, timeline, reign banner, recruitment pill.

## QA process

The Park prototype went through **two cycles** of a multi-agent QA protocol — SDET + Principal Architect QA in parallel → Senior FSE fixes → QA Review verification → integration. Findings across the two cycles: 1 unused saved field (accent color), 1 broken error UX (swapped `InvalidParameter` args), 1 performance risk (uncached deep-OFFSET queries), 1 data-loss path (sync-forward overwriting on empty save), plus migration idempotency, hard-rule violations (no native `title=`), dark-mode gaps, AJAX contract inconsistency. All resolved.

Kingdom and Unit were built in parallel afterwards with those lessons baked into their briefs preemptively — verified post-hoc by spot-checking each of the 14 conventions across both implementations.

## Verification

- All 14 modified PHP/template files lint clean (`php -l`).
- All three org profile pages return HTTP 200 with zero `Fatal/Parse/Warning/Notice`.
- Migrations apply cleanly twice in a row (idempotent).
- Backfill stats: 392 parks → `about_text` from legacy description, 2,567 units → `about_text` from `description`, 1,736 units → `our_history` from native `ork_unit.history`.

## Test plan

- [ ] Sign in as a Park officer; visit `Park/profile/<id>`; click **Design** in the hero. Test each tab (Header / About / Milestones / Header again for Phase 2). Confirm saved colors/fonts/tagline/announcement/social links/custom milestones all render on the public profile.
- [ ] Sign in as a Kingdom officer; visit `Kingdom/profile/<id>`. Same flow. Also test the **Reign Banner** by setting Monarch/Regent reign-since dates and adding lore.
- [ ] Sign in as a Unit Manager; visit `Unit/index/<id>`. Same flow. Test the **Recruitment Status** pill (Open / Invite Only / Closed) appearing next to the type badge. Test **How to Join** Markdown rendering.
- [ ] Test the legacy Edit Details modal still works on Park (it should both update `description` and forward-sync into `about_text` if Design modal has been used).
- [ ] Toggle dark mode (moon icon in the site header) on each org profile and confirm the new surfaces remain readable.
- [ ] Enter a social URL without `https://` (e.g., `discord.gg/abc` or `www.facebook.com/foo`) — confirm it saves and renders as `https://…`.
- [ ] Set an announcement with a past `Show until` date — confirm it does not render.
- [ ] Re-run all 7 migrations against the deployed DB — confirm idempotency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)