### PR TITLE
Enhancement: Amtgard weather forecast page (/Weather)

### DIFF
--- a/bin/refresh-weather.php
+++ b/bin/refresh-weather.php
@@ -19,7 +19,12 @@ require_once dirname(__DIR__) . '/startup.php';
 
 $start = microtime(true);
 $count = Ork3::$Lib->weather->refresh_all_active_parks();
-$dt    = round((microtime(true) - $start) * 1000);
+$park_ms = round((microtime(true) - $start) * 1000);
 
-fprintf(STDOUT, "[%s] refreshed %d parks in %dms\n", date('Y-m-d H:i:s'), $count, $dt);
+$ev_start = microtime(true);
+$ev_count = Ork3::$Lib->weather->warm_event_venue_coords(14);
+$ev_ms = round((microtime(true) - $ev_start) * 1000);
+
+fprintf(STDOUT, "[%s] refreshed %d parks in %dms; warmed %d event venues in %dms\n",
+	date('Y-m-d H:i:s'), $count, $park_ms, $ev_count, $ev_ms);
 exit($count > 0 ? 0 : 1);

--- a/bin/refresh-weather.php
+++ b/bin/refresh-weather.php
@@ -1,0 +1,25 @@
+#!/usr/bin/env php
+<?php
+/**
+ * Refreshes the ork_park_weather cache for all active parks.
+ * Designed to be invoked from cron every ~30 minutes:
+ *
+ *     # /etc/cron.d/ork-weather (or root's crontab)
+ *     0,30 * * * * www-data /usr/bin/php /var/www/ORK3/bin/refresh-weather.php >> /var/log/ork-weather.log 2>&1
+ *
+ *   (Above uses '0,30' rather than the standard star-slash-30 because the
+ *   shorthand closes the PHP doc-comment block.)
+ *
+ * Not strictly required — the on-read lazy fallback in Weather::for_park()
+ * keeps data fresh enough for any single page render. The cron just keeps
+ * the cache warm so users never pay the ~500ms Open-Meteo round trip.
+ */
+
+require_once dirname(__DIR__) . '/startup.php';
+
+$start = microtime(true);
+$count = Ork3::$Lib->weather->refresh_all_active_parks();
+$dt    = round((microtime(true) - $start) * 1000);
+
+fprintf(STDOUT, "[%s] refreshed %d parks in %dms\n", date('Y-m-d H:i:s'), $count, $dt);
+exit($count > 0 ? 0 : 1);

--- a/db-migrations/2026-05-17-park-weather.sql
+++ b/db-migrations/2026-05-17-park-weather.sql
@@ -1,0 +1,24 @@
+-- Park weather cache
+-- Stores per-park current weather + 7-day forecast fetched from Open-Meteo.
+-- Refreshed every ~30 min by bin/refresh-weather.php (cron), with a lazy
+-- fallback when a render finds a stale row. One row per park; truncate-safe.
+--
+-- Denormalized "current" and "today" columns are for cheap aggregate reads
+-- ("show me parks with rain coming up"). The full forecast lives in
+-- forecast_json for richer per-park displays.
+
+CREATE TABLE `ork_park_weather` (
+  `park_id`           int(11)        NOT NULL,
+  `fetched_at`        datetime       NOT NULL,
+  `current_temp_f`    decimal(5,2)   DEFAULT NULL,
+  `current_code`      tinyint unsigned DEFAULT NULL,
+  `current_is_day`    tinyint(1)     DEFAULT NULL,
+  `current_wind_mph`  decimal(5,1)   DEFAULT NULL,
+  `today_high_f`      decimal(5,2)   DEFAULT NULL,
+  `today_low_f`       decimal(5,2)   DEFAULT NULL,
+  `today_precip_pct`  tinyint unsigned DEFAULT NULL,
+  `forecast_json`     longtext       CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
+  PRIMARY KEY (`park_id`),
+  KEY `ix_fetched_at` (`fetched_at`),
+  KEY `ix_today_precip` (`today_precip_pct`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/orkui/controller/controller.Admin.php
+++ b/orkui/controller/controller.Admin.php
@@ -2459,6 +2459,29 @@ class Controller_Admin extends Controller {
 			}
 			echo json_encode($out);
 
+		} elseif ($action === 'serverhealth_weather_refresh') {
+			// Capture the previous newest fetched_at so we can show "last
+			// successful refresh was X ago" alongside this run's outcome.
+			global $DB;
+			$DB->Clear();
+			$rs = $DB->DataSet("SELECT MAX(fetched_at) AS prev FROM " . DB_PREFIX . "park_weather");
+			$prev = ($rs && $rs->Size() > 0 && $rs->Next()) ? $rs->prev : null;
+			$prev_age_min = $prev ? round((time() - strtotime($prev)) / 60) : null;
+
+			$start = microtime(true);
+			$count = Ork3::$Lib->weather->refresh_all_active_parks();
+			$elapsed_ms = (int)round((microtime(true) - $start) * 1000);
+
+			echo json_encode([
+				'status'  => 0,
+				'weather' => [
+					'count'                => $count,
+					'elapsed_ms'           => $elapsed_ms,
+					'previous_fetched_at'  => $prev,
+					'previous_age_min'     => $prev_age_min,
+				],
+			]);
+
 		} else {
 			echo json_encode(['status' => 1, 'error' => 'Unknown action']);
 		}

--- a/orkui/controller/controller.AttendanceAjax.php
+++ b/orkui/controller/controller.AttendanceAjax.php
@@ -77,9 +77,48 @@ class Controller_AttendanceAjax extends Controller {
 				];
 			}
 			echo json_encode(['status' => 0, 'entries' => array_values($entries)]);
+		} elseif ($action === 'weather') {
+			// Historic weather for /Attendance/park/{id} day pages.
+			// Route: AttendanceAjax/park/{park_id}/weather/{YYYY-MM-DD}
+			$date = $parts[2] ?? '';
+			if (!preg_match('/^\d{4}-\d{2}-\d{2}$/', $date)) {
+				echo json_encode(['status' => 1, 'error' => 'Invalid date']);
+				exit;
+			}
+			$wx = Ork3::$Lib->weather->archive_for_date($park_id, $date);
+			echo json_encode(['status' => 0, 'weather' => $wx]);
 		} else {
 			echo json_encode(['status' => 1, 'error' => 'Unknown action']);
 		}
+		exit;
+	}
+
+	/**
+	 * Coord-based historic weather lookup.
+	 * Route: AttendanceAjax/weather_at/{lat}/{lng}/{YYYY-MM-DD}
+	 * Used by callers whose location isn't a park (e.g., an event with its own
+	 * venue coords). Same auth/cache/output shape as the park-based version.
+	 */
+	public function weather_at($p = null) {
+		header('Content-Type: application/json');
+		if (!isset($this->session->user_id)) {
+			echo json_encode(['status' => 5, 'error' => 'Not logged in']);
+			exit;
+		}
+		$parts = explode('/', $p ?? '');
+		$lat   = $parts[0] ?? '';
+		$lng   = $parts[1] ?? '';
+		$date  = $parts[2] ?? '';
+		if (!is_numeric($lat) || !is_numeric($lng)) {
+			echo json_encode(['status' => 1, 'error' => 'Invalid coordinates']);
+			exit;
+		}
+		if (!preg_match('/^\d{4}-\d{2}-\d{2}$/', $date)) {
+			echo json_encode(['status' => 1, 'error' => 'Invalid date']);
+			exit;
+		}
+		$wx = Ork3::$Lib->weather->archive_for_coords((float)$lat, (float)$lng, $date);
+		echo json_encode(['status' => 0, 'weather' => $wx]);
 		exit;
 	}
 

--- a/orkui/controller/controller.Park.php
+++ b/orkui/controller/controller.Park.php
@@ -78,6 +78,7 @@ class Controller_Park extends Controller
 
 		$this->data['park_days']        = $this->Park->get_park_parkdays( $park_id );
 		$this->data['park_info']        = $this->Park->get_park_details( $park_id );
+		$this->data['park_weather']     = Ork3::$Lib->weather->for_park( $park_id );
 		$this->data['park_officers']    = $this->Park->GetOfficers(['ParkId' => $park_id, 'Token' => $this->session->token]);
 		$this->data['park_tournaments'] = $this->Reports->get_tournaments( null, null, $park_id );
 

--- a/orkui/controller/controller.Weather.php
+++ b/orkui/controller/controller.Weather.php
@@ -29,7 +29,46 @@ class Controller_Weather extends Controller {
 		}
 		$this->template = '../revised-frontend/Weather_index.tpl';
 		$this->data['page_title'] = 'Weather Forecast';
-		$this->data['Rundown']         = Ork3::$Lib->weather->daily_summary(date('Y-m-d'));
+		$today = date('Y-m-d');
+		$this->data['SelectedDate']    = $today;
+		$this->data['Rundown']         = Ork3::$Lib->weather->daily_summary($today);
+		$this->data['PlayToday']       = Ork3::$Lib->weather->play_for_date($today);
 		$this->data['UpcomingEvents']  = Ork3::$Lib->weather->upcoming_events_with_forecast(7);
+		// 7-day strip of pills (today + next 6 days)
+		$strip = array();
+		for ($i = 0; $i < 7; $i++) {
+			$d = date('Y-m-d', strtotime("+$i days"));
+			$strip[] = array(
+				'date'      => $d,
+				'day_label' => $i === 0 ? 'Today' : date('D', strtotime($d)),
+				'date_label'=> date('M j', strtotime($d)),
+				'is_today'  => $i === 0,
+			);
+		}
+		$this->data['DateStrip'] = $strip;
+	}
+
+	/**
+	 * Per-day data fetched by the date-pill switcher.
+	 * Route: Weather/day/{YYYY-MM-DD}
+	 */
+	public function day($p = null) {
+		header('Content-Type: application/json');
+		if (!isset($this->session->user_id)) {
+			echo json_encode(array('status' => 5, 'error' => 'Not logged in'));
+			exit;
+		}
+		$date = trim($p ?? '');
+		if (!preg_match('/^\d{4}-\d{2}-\d{2}$/', $date)) {
+			echo json_encode(array('status' => 1, 'error' => 'Invalid date'));
+			exit;
+		}
+		echo json_encode(array(
+			'status'   => 0,
+			'date'     => $date,
+			'rundown'  => Ork3::$Lib->weather->daily_summary($date),
+			'play'     => Ork3::$Lib->weather->play_for_date($date),
+		));
+		exit;
 	}
 }

--- a/orkui/controller/controller.Weather.php
+++ b/orkui/controller/controller.Weather.php
@@ -45,6 +45,11 @@ class Controller_Weather extends Controller {
 				'is_today'  => $i === 0,
 			);
 		}
+		$severities = Ork3::$Lib->weather->strip_severities(array_column($strip, 'date'));
+		foreach ($strip as &$pill) {
+			$pill['severity'] = $severities[$pill['date']] ?? 'ok';
+		}
+		unset($pill);
 		$this->data['DateStrip'] = $strip;
 	}
 

--- a/orkui/controller/controller.Weather.php
+++ b/orkui/controller/controller.Weather.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * Weather forecast dashboard.
+ *
+ *   /Weather  → HTML page (auth-required)
+ *
+ * Pulls from the existing ork_park_weather cache (refreshed every 30 min by
+ * bin/refresh-weather.php) plus an event list query. No new upstream calls
+ * at render time — the page is purely a presentation layer over data the
+ * cron is already keeping fresh.
+ */
+class Controller_Weather extends Controller {
+
+	public function __construct($call=null, $method=null) {
+		parent::__construct($call, $method);
+		unset($this->data['menu']['kingdom'], $this->data['menu']['park']);
+		$this->data['menu']['weather'] = array(
+			'url'     => UIR . 'Weather',
+			'display' => 'Weather <i class="fas fa-cloud-sun" style="font-size:11px;vertical-align:1px;"></i>',
+		);
+		$this->data['no_index'] = true;
+	}
+
+	public function index($action = null) {
+		if (!isset($this->session->user_id)) {
+			header('Location: ' . UIR . 'Login/login/Weather');
+			exit;
+		}
+		$this->template = '../revised-frontend/Weather_index.tpl';
+		$this->data['page_title'] = 'Weather Forecast';
+		$this->data['Rundown']         = Ork3::$Lib->weather->daily_summary(date('Y-m-d'));
+		$this->data['UpcomingEvents']  = Ork3::$Lib->weather->upcoming_events_with_forecast(7);
+	}
+}

--- a/orkui/template/default/Admin_serverhealth.tpl
+++ b/orkui/template/default/Admin_serverhealth.tpl
@@ -213,10 +213,12 @@ html[data-theme="dark"] .sh-lt-log { background: #1e2433; border-color: #4a5568;
 					<button class="sh-fs-btn" id="sh-fs-btn"><i class="fas fa-hdd"></i> Check Filesystem</button>
 					<button class="sh-fs-btn" id="sh-memcache-btn"><i class="fas fa-database"></i> Check Memcache</button>
 					<button class="sh-fs-btn" id="sh-opcache-btn"><i class="fab fa-php"></i> Check OPcache</button>
+					<button class="sh-fs-btn" id="sh-weather-btn"><i class="fas fa-cloud-sun"></i> Refresh Weather</button>
 				</div>
 				<div id="sh-fs-result"></div>
 				<div id="sh-memcache-result"></div>
 				<div id="sh-opcache-result"></div>
+				<div id="sh-weather-result"></div>
 			</div>
 		</div>
 
@@ -701,6 +703,24 @@ html[data-theme="dark"] .sh-lt-log { background: #1e2433; border-color: #4a5568;
 			html += renderFsRow('Wasted memory', wastedPct + '% (' + fmtBytes(o.memory_wasted) + ')', wastedCls);
 			html += renderFsRow('Cached scripts', fmtCount(o.scripts), '');
 			html += renderFsRow('Hit rate', (Math.round(o.hit_rate * 10) / 10) + '%', '');
+			return html;
+		},
+	});
+
+	wireCheckBtn({
+		btnId:    'sh-weather-btn',
+		resultId: 'sh-weather-result',
+		action:   'serverhealth_weather_refresh',
+		label:    'Refresh Weather',
+		render:   function(d) {
+			if (!d.weather) return '';
+			var w = d.weather;
+			var html = '';
+			html += renderFsRow('Parks refreshed', fmtCount(w.count), '');
+			html += renderFsRow('Refresh duration', w.elapsed_ms + ' ms', '');
+			if (w.previous_fetched_at) {
+				html += renderFsRow('Previous fetch', w.previous_fetched_at + ' (' + w.previous_age_min + ' min ago)', '');
+			}
 			return html;
 		},
 	});

--- a/orkui/template/default/Attendance_park.tpl
+++ b/orkui/template/default/Attendance_park.tpl
@@ -402,6 +402,18 @@ html[data-theme="dark"] .att-qa-empty { color: var(--ork-text-muted); }
 				<i class="fas fa-calendar-day rp-header-icon"></i>
 				<h1 class="rp-header-title">Park Attendance &mdash; <?=htmlspecialchars($AttendanceDate)?></h1>
 			</div>
+			<?php
+				// Only attempt historic weather when the park has coords AND
+				// the date is far enough in the past for Open-Meteo's ERA5
+				// archive to have published (~5-day lag). Coords resolution
+				// falls back to the location-JSON blob when the scalar lat/lng
+				// columns aren't backfilled.
+				$_wxCutoff   = date('Y-m-d', strtotime('-5 days'));
+				$_wxEligible = ($pid > 0
+					&& Ork3::$Lib->weather->park_has_coords($pid)
+					&& $AttendanceDate < $_wxCutoff
+					&& $AttendanceDate >= '1940-01-01');
+			?>
 			<div class="rp-header-scope">
 <?php if ($pname) : ?>
 				<a class="rp-scope-chip" href="<?=UIR.'Park/profile/'.$pid?>">
@@ -447,6 +459,14 @@ html[data-theme="dark"] .att-qa-empty { color: var(--ork-text-muted); }
 			<div class="rp-stat-number"><?=count($class_counts)?></div>
 			<div class="rp-stat-label">Classes Played</div>
 		</div>
+		<?php if ($_wxEligible): ?>
+		<div class="rp-stat-card" id="att-wx-card"
+		     data-park="<?=(int)$pid?>" data-date="<?=htmlspecialchars($AttendanceDate)?>">
+			<div class="rp-stat-icon" id="att-wx-icon"><i class="fas fa-cloud-sun" style="opacity:.4"></i></div>
+			<div class="rp-stat-number" id="att-wx-temps" style="font-size:1.1rem;padding-top:3px;opacity:.5">—</div>
+			<div class="rp-stat-label" id="att-wx-meta"><em style="opacity:.6">loading historical…</em></div>
+		</div>
+		<?php endif; ?>
 	</div>
 
 	<!-- ── Body: form sidebar + main content ────────────── -->
@@ -1018,5 +1038,58 @@ $(function() {
 		});
 	});
 <?php endif; ?>
+
+	// Lazy-fill the historic weather card for this attendance day. Cache
+	// hits (memcache) come back almost instantly; cache misses make one
+	// ~500ms call to Open-Meteo's archive endpoint. The card starts hidden
+	// and reveals itself when data arrives so it doesn't render an empty
+	// placeholder if the archive has nothing.
+	(function() {
+		var card = document.getElementById('att-wx-card');
+		if (!card) return;
+		var pid = card.dataset.park;
+		var date = card.dataset.date;
+		if (!pid || !date) return;
+		function wxIcon(c) {
+			if (c === 0)                          return '☀️';
+			if (c === 1)                          return '🌤️';
+			if (c === 2)                          return '⛅';
+			if (c === 3)                          return '☁️';
+			if (c === 45 || c === 48)             return '🌫️';
+			if (c >= 51 && c <= 57)               return '🌦️';
+			if (c >= 61 && c <= 67)               return '🌧️';
+			if (c >= 71 && c <= 77)               return '❄️';
+			if (c >= 80 && c <= 82)               return '🌦️';
+			if (c === 85 || c === 86)             return '🌨️';
+			if (c >= 95 && c <= 99)               return '⛈️';
+			return '🌡️';
+		}
+		function showUnavailable() {
+			document.getElementById('att-wx-icon').innerHTML = '<i class="fas fa-cloud-sun" style="opacity:.35"></i>';
+			document.getElementById('att-wx-temps').innerHTML = '<span style="opacity:.55;font-size:12px;font-weight:400">unavailable</span>';
+			document.getElementById('att-wx-meta').innerHTML  = 'Historical';
+		}
+		fetch('<?=UIR?>AttendanceAjax/park/' + pid + '/weather/' + date, { credentials: 'same-origin' })
+			.then(function(r) { return r.json(); })
+			.then(function(d) {
+				if (!d || d.status !== 0 || !d.weather || d.weather.hi_f == null) { showUnavailable(); return; }
+				var w = d.weather;
+				var hi  = Math.round(w.hi_f), hiC = Math.round((w.hi_f - 32) * 5 / 9);
+				var lo  = w.lo_f != null ? Math.round(w.lo_f) : null;
+				var loC = w.lo_f != null ? Math.round((w.lo_f - 32) * 5 / 9) : null;
+				document.getElementById('att-wx-icon').textContent = wxIcon(w.code);
+				document.getElementById('att-wx-temps').style.opacity = '';
+				document.getElementById('att-wx-temps').innerHTML  = hi + '/' + hiC + '°' +
+					(lo != null ? '<div style="font-size:11px;color:var(--ork-text-muted,#718096);font-weight:400;margin-top:1px">L ' + lo + '/' + loC + '°</div>' : '');
+				var metaParts = ['Historical'];
+				if (w.precip_inches != null && w.precip_inches >= 0.1) {
+					var mm = Math.round(w.precip_inches * 25.4);
+					metaParts.push(w.precip_inches.toFixed(2) + '" / ' + mm + ' mm rain');
+				}
+				document.getElementById('att-wx-meta').innerHTML = metaParts.join(' · ') +
+					' <a href="https://open-meteo.com/" target="_blank" rel="noopener" title="Weather data by Open-Meteo.com" aria-label="Weather data by Open-Meteo.com" style="margin-left:4px;opacity:.55;text-decoration:none;font-size:10px">ⓘ</a>';
+			})
+			.catch(showUnavailable);
+	})();
 });
 </script>

--- a/orkui/template/default/default.tpl
+++ b/orkui/template/default/default.tpl
@@ -641,6 +641,11 @@ html[data-theme="dark"] .hm-prinz-card.hm-pinned {
 			</a>
 <?php endif; ?>
 <?php if (!empty($LoggedIn)): ?>
+			<a class="hm-find-item" href="<?= UIR ?>Weather">
+				<i class="fas fa-cloud-sun"></i> Weather Forecast
+			</a>
+<?php endif; ?>
+<?php if (!empty($LoggedIn)): ?>
 			<a class="hm-find-item" href="<?= UIR ?>Unit/unitlist">
 				<i class="fas fa-users"></i> Companies &amp; Households
 			</a>

--- a/orkui/template/revised-frontend/Eventnew_index.tpl
+++ b/orkui/template/revised-frontend/Eventnew_index.tpl
@@ -410,6 +410,65 @@ html[data-theme="dark"] .ev-ac-empty { color: var(--ork-text-muted); }
 		<div class="ev-stat-label">Website</div>
 	</a>
 	<?php endif; ?>
+	<?php
+		// Event forecast card.
+		// Date selection: if event is currently running (today ∈ [start, end]) show today;
+		// else if event is upcoming, show start day. Past events get no forecast.
+		// Either way, only renders when the chosen date is within the 7-day cache window.
+		$evWxDate     = null;
+		$evWxParkId   = $atParkId ?: $parkId;
+		$evWxLive     = false;  // live = today during a multi-day event
+		if ($evWxParkId && $eventStart) {
+			$_evStartDay = substr($eventStart, 0, 10);
+			$_evEndDay   = $eventEnd ? substr($eventEnd, 0, 10) : $_evStartDay;
+			// "Today" in the park's local timezone — not server time (Chicago).
+			$_today    = date('Y-m-d');
+			$_parkRow  = Ork3::$Lib->weather->for_park($evWxParkId);
+			if (!empty($_parkRow['forecast_json'])) {
+				$_pwx = @json_decode($_parkRow['forecast_json'], true);
+				if (!empty($_pwx['timezone'])) {
+					try { $_today = (new DateTime('now', new DateTimeZone($_pwx['timezone'])))->format('Y-m-d'); } catch (Exception $e) {}
+				}
+			}
+			if ($_today >= $_evStartDay && $_today <= $_evEndDay) {
+				$evWxDate = $_today;  $evWxLive = true;
+			} elseif ($_evStartDay > $_today) {
+				$evWxDate = $_evStartDay;
+			}
+		}
+		$evFC = ($evWxDate && $evWxParkId)
+			? Ork3::$Lib->weather->forecast_for_date($evWxParkId, $evWxDate)
+			: null;
+		if ($evFC && $evFC['hi_f'] !== null):
+			$c = (int)$evFC['code'];
+			$evIc = ($c===0)?'☀️':(($c===1)?'🌤️':(($c===2)?'⛅':(($c===3)?'☁️':(($c===45||$c===48)?'🌫️':(($c>=51&&$c<=57)?'🌦️':(($c>=61&&$c<=67)?'🌧️':(($c>=71&&$c<=77)?'❄️':(($c>=80&&$c<=82)?'🌦️':(($c===85||$c===86)?'🌨️':(($c>=95)?'⛈️':'🌡️'))))))))));
+			$evHiC = round(($evFC['hi_f']-32)*5/9);
+			$evLoC = $evFC['lo_f'] !== null ? round(($evFC['lo_f']-32)*5/9) : null;
+	?>
+	<?php $evBadges = Ork3::$Lib->weather->badges_for_date($evWxParkId, $evWxDate); ?>
+	<div class="ev-stat-card">
+		<div class="ev-stat-icon"><?= $evIc ?></div>
+		<div class="ev-stat-value" style="font-size:15px;padding-top:3px">
+			<?= round($evFC['hi_f']) ?>/<?= $evHiC ?>°<?php if ($evFC['lo_f'] !== null): ?> <span style="font-size:11px;color:var(--ork-text-muted,#718096)">L <?= round($evFC['lo_f']) ?>/<?= $evLoC ?>°</span><?php endif; ?>
+			<?php if (!empty($evFC['precip_pct']) && $evFC['precip_pct'] >= 20): ?>
+				<div style="font-size:11px;color:var(--ork-text-muted,#718096);margin-top:2px"><?= (int)$evFC['precip_pct'] ?>% rain</div>
+			<?php endif; ?>
+			<?php if ($evBadges): ?>
+				<div style="margin-top:4px;display:flex;flex-wrap:wrap;gap:3px;justify-content:center">
+					<?php foreach ($evBadges as $_b): ?>
+						<span title="<?= htmlspecialchars($_b['label']) ?>" style="display:inline-block;padding:1px 6px;border-radius:10px;font-size:10px;font-weight:600;background:<?= $_b['severity']==='warning'?'#fee2e2':'#fef3c7' ?>;color:<?= $_b['severity']==='warning'?'#991b1b':'#92400e' ?>;border:1px solid <?= $_b['severity']==='warning'?'#fca5a5':'#fcd34d' ?>"><?= $_b['icon'] ?> <?= htmlspecialchars($_b['label']) ?></span>
+					<?php endforeach; ?>
+				</div>
+			<?php endif; ?>
+		</div>
+		<div class="ev-stat-label">
+			<?= $evWxLive ? 'Today' : 'Forecast' ?>
+			<a href="https://open-meteo.com/" target="_blank" rel="noopener"
+			   title="Weather data by Open-Meteo.com" aria-label="Weather data by Open-Meteo.com"
+			   style="font-size:10px;color:var(--ork-text-muted,#a0aec0);text-decoration:none;margin-left:4px;opacity:.6">ⓘ</a>
+		</div>
+	</div>
+	<?php endif; ?>
 </div>
 
 <?php // ---- LAYOUT ---- ?>

--- a/orkui/template/revised-frontend/Eventnew_index.tpl
+++ b/orkui/template/revised-frontend/Eventnew_index.tpl
@@ -412,13 +412,40 @@ html[data-theme="dark"] .ev-ac-empty { color: var(--ork-text-muted); }
 	<?php endif; ?>
 	<?php
 		// Event forecast card.
-		// Date selection: if event is currently running (today ∈ [start, end]) show today;
-		// else if event is upcoming, show start day. Past events get no forecast.
-		// Either way, only renders when the chosen date is within the 7-day cache window.
-		$evWxDate     = null;
-		$evWxParkId   = $atParkId ?: $parkId;
-		$evWxLive     = false;  // live = today during a multi-day event
-		if ($evWxParkId && $eventStart) {
+		// Date selection. Three modes:
+		//   - 'live'       : today is inside [start, end] (today's forecast)
+		//   - 'forecast'   : event is upcoming AND start day is within the
+		//                     7-day forecast cache window
+		//   - 'historical' : event ended >5 days ago — lazy-fetched from the
+		//                     Open-Meteo archive endpoint via AJAX
+		// Past events <5 days back are still inside the archive lag → no card.
+		$evWxDate    = null;
+		$evWxParkId  = $atParkId ?: $parkId;
+		$evWxMode    = null;  // 'live' | 'forecast' | 'historical'
+		// Coord priority: event's own (event_calendardetail) → at_park → owning park.
+		// Historical mode uses these coords directly; live/forecast modes use the
+		// forecast cache keyed by park_id (event-specific coords don't have a
+		// per-park forecast cache, so they fall back to the at_park/park).
+		$evWxLat = null; $evWxLng = null;
+		global $DB; $DB->Clear();
+		$_evCdCo = $DB->DataSet("SELECT latitude, longitude FROM " . DB_PREFIX . "event_calendardetail
+			WHERE event_calendardetail_id = " . (int)($cd['EventCalendarDetailId'] ?? $detail_id ?? 0) . " LIMIT 1");
+		if ($_evCdCo && $_evCdCo->Size() > 0 && $_evCdCo->Next()
+			&& (float)$_evCdCo->latitude !== 0.0 && (float)$_evCdCo->longitude !== 0.0
+			&& $_evCdCo->latitude !== null && $_evCdCo->longitude !== null) {
+			$evWxLat = (float)$_evCdCo->latitude;
+			$evWxLng = (float)$_evCdCo->longitude;
+		}
+		if (($evWxLat === null || $evWxLng === null) && $evWxParkId) {
+			// Park coords with the same scalar→JSON fallback used everywhere else.
+			$_evParkCoords = Ork3::$Lib->weather->coords_for_park($evWxParkId);
+			if ($_evParkCoords !== null) {
+				$evWxLat = $_evParkCoords[0];
+				$evWxLng = $_evParkCoords[1];
+			}
+		}
+		$evWxHasCoords = ($evWxLat !== null && $evWxLng !== null);
+		if ($evWxHasCoords && $eventStart) {
 			$_evStartDay = substr($eventStart, 0, 10);
 			$_evEndDay   = $eventEnd ? substr($eventEnd, 0, 10) : $_evStartDay;
 			// "Today" in the park's local timezone — not server time (Chicago).
@@ -430,13 +457,18 @@ html[data-theme="dark"] .ev-ac-empty { color: var(--ork-text-muted); }
 					try { $_today = (new DateTime('now', new DateTimeZone($_pwx['timezone'])))->format('Y-m-d'); } catch (Exception $e) {}
 				}
 			}
+			$_archiveCutoff = date('Y-m-d', strtotime('-5 days'));
 			if ($_today >= $_evStartDay && $_today <= $_evEndDay) {
-				$evWxDate = $_today;  $evWxLive = true;
+				$evWxDate = $_today;       $evWxMode = 'live';
 			} elseif ($_evStartDay > $_today) {
-				$evWxDate = $_evStartDay;
+				$evWxDate = $_evStartDay;  $evWxMode = 'forecast';
+			} elseif ($_evEndDay < $_archiveCutoff && $_evStartDay >= '1940-01-01') {
+				$evWxDate = $_evStartDay;  $evWxMode = 'historical';
 			}
 		}
-		$evFC = ($evWxDate && $evWxParkId)
+		// For live/forecast: render from the cached 7-day forecast (server-side).
+		// For historical: render placeholder; JS lazy-fetches the archive.
+		$evFC = ($evWxMode === 'live' || $evWxMode === 'forecast')
 			? Ork3::$Lib->weather->forecast_for_date($evWxParkId, $evWxDate)
 			: null;
 		if ($evFC && $evFC['hi_f'] !== null):
@@ -462,11 +494,20 @@ html[data-theme="dark"] .ev-ac-empty { color: var(--ork-text-muted); }
 			<?php endif; ?>
 		</div>
 		<div class="ev-stat-label">
-			<?= $evWxLive ? 'Today' : 'Forecast' ?>
+			<?= $evWxMode === 'live' ? 'Today' : 'Forecast' ?>
 			<a href="https://open-meteo.com/" target="_blank" rel="noopener"
 			   title="Weather data by Open-Meteo.com" aria-label="Weather data by Open-Meteo.com"
 			   style="font-size:10px;color:var(--ork-text-muted,#a0aec0);text-decoration:none;margin-left:4px;opacity:.6">ⓘ</a>
 		</div>
+	</div>
+	<?php elseif ($evWxMode === 'historical'): ?>
+	<div class="ev-stat-card" id="ev-wx-historical"
+	     data-lat="<?= htmlspecialchars((string)$evWxLat) ?>"
+	     data-lng="<?= htmlspecialchars((string)$evWxLng) ?>"
+	     data-date="<?= htmlspecialchars($evWxDate) ?>">
+		<div class="ev-stat-icon" id="ev-wx-icon"><i class="fas fa-cloud-sun" style="opacity:.4"></i></div>
+		<div class="ev-stat-value" id="ev-wx-temps" style="font-size:15px;padding-top:3px;opacity:.5">—</div>
+		<div class="ev-stat-label" id="ev-wx-label"><em style="opacity:.6">loading historical…</em></div>
 	</div>
 	<?php endif; ?>
 </div>
@@ -1637,4 +1678,57 @@ var _fpEnd = flatpickr('#ev-fp-end', Object.assign({}, _fpOpts, {
 	});
 })();
 <?php endif; ?>
+
+// Lazy-fill historical weather card for past events. Identical pattern to
+// the Attendance day page: card renders immediately with a placeholder so
+// there's no layout shift; AJAX resolves and either fills the slot or
+// switches it to "unavailable" if the archive can't serve the date.
+(function() {
+	var card = document.getElementById('ev-wx-historical');
+	if (!card) return;
+	var lat  = card.dataset.lat;
+	var lng  = card.dataset.lng;
+	var date = card.dataset.date;
+	if (!lat || !lng || !date) return;
+	function wxIcon(c) {
+		if (c === 0)                  return '☀️';
+		if (c === 1)                  return '🌤️';
+		if (c === 2)                  return '⛅';
+		if (c === 3)                  return '☁️';
+		if (c === 45 || c === 48)     return '🌫️';
+		if (c >= 51 && c <= 57)       return '🌦️';
+		if (c >= 61 && c <= 67)       return '🌧️';
+		if (c >= 71 && c <= 77)       return '❄️';
+		if (c >= 80 && c <= 82)       return '🌦️';
+		if (c === 85 || c === 86)     return '🌨️';
+		if (c >= 95 && c <= 99)       return '⛈️';
+		return '🌡️';
+	}
+	function showUnavailable() {
+		document.getElementById('ev-wx-icon').innerHTML  = '<i class="fas fa-cloud-sun" style="opacity:.35"></i>';
+		document.getElementById('ev-wx-temps').innerHTML = '<span style="opacity:.55;font-size:12px;font-weight:400">unavailable</span>';
+		document.getElementById('ev-wx-label').innerHTML = 'Historical';
+	}
+	fetch('<?=UIR?>AttendanceAjax/weather_at/' + lat + '/' + lng + '/' + date, { credentials: 'same-origin' })
+		.then(function(r) { return r.json(); })
+		.then(function(d) {
+			if (!d || d.status !== 0 || !d.weather || d.weather.hi_f == null) { showUnavailable(); return; }
+			var w = d.weather;
+			var hi  = Math.round(w.hi_f), hiC = Math.round((w.hi_f - 32) * 5 / 9);
+			var lo  = w.lo_f != null ? Math.round(w.lo_f) : null;
+			var loC = w.lo_f != null ? Math.round((w.lo_f - 32) * 5 / 9) : null;
+			document.getElementById('ev-wx-icon').textContent = wxIcon(w.code);
+			document.getElementById('ev-wx-temps').style.opacity = '';
+			document.getElementById('ev-wx-temps').innerHTML = hi + '/' + hiC + '°' +
+				(lo != null ? ' <span style="font-size:11px;color:var(--ork-text-muted,#718096)">L ' + lo + '/' + loC + '°</span>' : '') +
+				(w.precip_inches != null && w.precip_inches >= 0.1
+					? '<div style="font-size:11px;color:var(--ork-text-muted,#718096);margin-top:2px">' + w.precip_inches.toFixed(2) + '" / ' + Math.round(w.precip_inches * 25.4) + ' mm rain</div>'
+					: '');
+			document.getElementById('ev-wx-label').innerHTML = 'Historical' +
+				' <a href="https://open-meteo.com/" target="_blank" rel="noopener"' +
+				' title="Weather data by Open-Meteo.com" aria-label="Weather data by Open-Meteo.com"' +
+				' style="font-size:10px;color:var(--ork-text-muted,#a0aec0);text-decoration:none;margin-left:4px;opacity:.6">ⓘ</a>';
+		})
+		.catch(showUnavailable);
+})();
 </script>

--- a/orkui/template/revised-frontend/Live_index.tpl
+++ b/orkui/template/revised-frontend/Live_index.tpl
@@ -411,14 +411,28 @@
 		}
 		eventLayers = eFresh;
 
-		// Fit bounds once on first stats with data
-		if (!initialBounds) {
-			const lats = [], lngs = [];
-			for (const pid in parksMeta)  { const p = parksMeta[pid];  if (p.lat && p.lng) { lats.push(p.lat); lngs.push(p.lng); } }
-			for (const eid in eventsMeta) { const e = eventsMeta[eid]; if (e.lat && e.lng && e.coord_source !== 'none') { lats.push(e.lat); lngs.push(e.lng); } }
-			if (lats.length > 0) {
-				initialBounds = [[Math.min(...lats), Math.min(...lngs)], [Math.max(...lats), Math.max(...lngs)]];
+		// Recompute "fit-all" bounds from the current park/event set every
+		// stats refresh. If a new park appeared outside the previously-fit
+		// area (e.g., a Florida signin while watching a Canadian-anchored
+		// view), expand the auto-fit envelope. When the viewer isn't
+		// focused on a specific park/event, also auto-fly out so the new
+		// arrival is visible without user action.
+		const lats = [], lngs = [];
+		for (const pid in parksMeta)  { const p = parksMeta[pid];  if (p.lat && p.lng) { lats.push(p.lat); lngs.push(p.lng); } }
+		for (const eid in eventsMeta) { const e = eventsMeta[eid]; if (e.lat && e.lng && e.coord_source !== 'none') { lats.push(e.lat); lngs.push(e.lng); } }
+		if (lats.length > 0) {
+			const newBounds = [[Math.min(...lats), Math.min(...lngs)], [Math.max(...lats), Math.max(...lngs)]];
+			const firstFit  = !initialBounds;
+			const extended  = initialBounds && (
+				newBounds[0][0] < initialBounds[0][0] || newBounds[0][1] < initialBounds[0][1] ||
+				newBounds[1][0] > initialBounds[1][0] || newBounds[1][1] > initialBounds[1][1]
+			);
+			initialBounds = newBounds;
+			if (firstFit) {
 				map.fitBounds(initialBounds, { padding: [40, 40] });
+			} else if (extended && !focusedId) {
+				// New park outside the previous envelope and viewer is just watching.
+				map.flyToBounds(initialBounds, { padding: [40, 40], duration: 0.8 });
 			}
 		}
 		applyCircles();
@@ -619,16 +633,19 @@
 		if (code >= 95 && code <= 99)           return ['⛈️', 'Thunderstorm'];
 		return ['', 'Unknown'];
 	}
+	// Format °F as "68°F / 20°C" — both units side by side for the US+CA audience.
+	function fmtTemp(f)      { return f == null ? '—' : `${Math.round(f)}°F / ${Math.round((f - 32) * 5 / 9)}°C`; }
+	function fmtTempShort(f) { return f == null ? '—' : `${Math.round(f)}/${Math.round((f - 32) * 5 / 9)}°`; }
 	function renderWeather(wx) {
 		const wrap = document.getElementById('lv-pi-weather');
 		if (!wx || wx.temp_f == null) { wrap.style.display = 'none'; return; }
 		const [icon, label] = wxIcon(wx.code, wx.is_day);
 		const now  = document.getElementById('lv-wx-now');
 		const meta = document.getElementById('lv-wx-meta');
-		now.textContent  = `${icon} ${Math.round(wx.temp_f)}°F`;
+		now.textContent  = `${icon} ${fmtTemp(wx.temp_f)}`;
 		const parts = [label];
 		if (wx.hi_f != null && wx.lo_f != null) {
-			parts.push(`H ${Math.round(wx.hi_f)}° / L ${Math.round(wx.lo_f)}°`);
+			parts.push(`H ${fmtTempShort(wx.hi_f)} / L ${fmtTempShort(wx.lo_f)}`);
 		}
 		if (wx.precip_pct != null && wx.precip_pct > 0) {
 			parts.push(`${wx.precip_pct}% precip`);

--- a/orkui/template/revised-frontend/Live_index.tpl
+++ b/orkui/template/revised-frontend/Live_index.tpl
@@ -85,6 +85,11 @@
 .lv-pi-stat { text-align: center; padding: 6px 4px; background: var(--ork-bg-secondary); border-radius: 4px; }
 .lv-pi-stat .lv-num { font-size: 20px; font-weight: 700; color: #48bb78; line-height: 1; }
 .lv-pi-stat .lv-lbl { font-size: 9px; color: var(--ork-text-muted); text-transform: uppercase; letter-spacing: .06em; margin-top: 4px; }
+.lv-pi-weather { margin-top: 10px; padding: 8px 10px; background: var(--ork-bg-secondary); border-radius: 4px; display: flex; align-items: center; gap: 8px; font-size: 12px; color: var(--ork-text); }
+.lv-pi-weather .lv-wx-now { font-weight: 600; }
+.lv-pi-weather .lv-wx-meta { color: var(--ork-text-muted); flex: 1; }
+.lv-pi-weather .lv-wx-attr { color: var(--ork-text-muted); text-decoration: none; font-size: 11px; opacity: 0.6; }
+.lv-pi-weather .lv-wx-attr:hover { opacity: 1; }
 
 .lv-ticker-head { padding: 12px 16px; border-bottom: 1px solid var(--ork-border); font-size: 11px; text-transform: uppercase; letter-spacing: .1em; color: var(--ork-text-muted); display: flex; justify-content: space-between; align-items: center; }
 .lv-ticker { flex: 1 1 auto; overflow-y: auto; padding: 8px 0; }
@@ -163,6 +168,12 @@
 				<div class="lv-pi-stat"><div class="lv-num" id="lv-pi-day">0</div><div class="lv-lbl">past 24h</div></div>
 				<div class="lv-pi-stat"><div class="lv-num" id="lv-pi-3h">0</div><div class="lv-lbl">past 3h</div></div>
 				<div class="lv-pi-stat"><div class="lv-num" id="lv-pi-30m">0</div><div class="lv-lbl">past 30m</div></div>
+			</div>
+			<div class="lv-pi-weather" id="lv-pi-weather" style="display:none">
+				<span class="lv-wx-now" id="lv-wx-now">—</span>
+				<span class="lv-wx-meta" id="lv-wx-meta">—</span>
+				<a class="lv-wx-attr" href="https://open-meteo.com/" target="_blank" rel="noopener"
+				   title="Weather data by Open-Meteo.com" aria-label="Weather data by Open-Meteo.com">ⓘ</a>
 			</div>
 		</div>
 		<div class="lv-ticker-head">
@@ -588,6 +599,42 @@
 		piDay.textContent = src ? (src.day || 0) : 0;
 		pi3h.textContent  = src ? (src.h3  || 0) : 0;
 		pi30m.textContent = src ? (src.m30 || 0) : 0;
+		renderWeather(src && src.weather);
+	}
+	// WMO weather code → emoji + label.
+	// Reference: https://open-meteo.com/en/docs (weather_code field)
+	function wxIcon(code, isDay) {
+		const sun  = isDay ? '☀️' : '🌙';
+		if (code === 0)                         return [sun,  'Clear'];
+		if (code === 1)                         return [isDay ? '🌤️' : '🌙', 'Mostly clear'];
+		if (code === 2)                         return ['⛅', 'Partly cloudy'];
+		if (code === 3)                         return ['☁️', 'Overcast'];
+		if (code === 45 || code === 48)         return ['🌫️', 'Fog'];
+		if (code >= 51 && code <= 57)           return ['🌦️', 'Drizzle'];
+		if (code >= 61 && code <= 65)           return ['🌧️', 'Rain'];
+		if (code === 66 || code === 67)         return ['🌧️', 'Freezing rain'];
+		if (code >= 71 && code <= 77)           return ['❄️', 'Snow'];
+		if (code >= 80 && code <= 82)           return ['🌦️', 'Showers'];
+		if (code === 85 || code === 86)         return ['🌨️', 'Snow showers'];
+		if (code >= 95 && code <= 99)           return ['⛈️', 'Thunderstorm'];
+		return ['', 'Unknown'];
+	}
+	function renderWeather(wx) {
+		const wrap = document.getElementById('lv-pi-weather');
+		if (!wx || wx.temp_f == null) { wrap.style.display = 'none'; return; }
+		const [icon, label] = wxIcon(wx.code, wx.is_day);
+		const now  = document.getElementById('lv-wx-now');
+		const meta = document.getElementById('lv-wx-meta');
+		now.textContent  = `${icon} ${Math.round(wx.temp_f)}°F`;
+		const parts = [label];
+		if (wx.hi_f != null && wx.lo_f != null) {
+			parts.push(`H ${Math.round(wx.hi_f)}° / L ${Math.round(wx.lo_f)}°`);
+		}
+		if (wx.precip_pct != null && wx.precip_pct > 0) {
+			parts.push(`${wx.precip_pct}% precip`);
+		}
+		meta.textContent = parts.join(' · ');
+		wrap.style.display = 'flex';
 	}
 	document.getElementById('lv-pi-close').addEventListener('click', () => {
 		piPanel.classList.remove('open'); focusedId = null; focusedKind = null;

--- a/orkui/template/revised-frontend/Parknew_index.tpl
+++ b/orkui/template/revised-frontend/Parknew_index.tpl
@@ -294,6 +294,44 @@
 		<div class="pk-stat-value"><?= count($eventList) ?></div>
 		<div class="pk-stat-label">Event<?= count($eventList) != 1 ? 's' : '' ?></div>
 	</div>
+	<?php
+	// Park weather card — only render when we have a valid current temp.
+	$wx = $park_weather ?? null;
+	$wxTemp = $wx['current_temp_f'] ?? null;
+	if ($wxTemp !== null):
+		$wxCode  = (int)($wx['current_code']  ?? -1);
+		$wxIsDay = (int)($wx['current_is_day'] ?? 1);
+		// WMO code → emoji + short label (mirrors Live ticker logic)
+		$wxIcon  = '';
+		$wxLabel = '';
+		if     ($wxCode === 0)                          { $wxIcon = $wxIsDay ? '☀️' : '🌙';  $wxLabel = 'Clear'; }
+		elseif ($wxCode === 1)                          { $wxIcon = $wxIsDay ? '🌤️' : '🌙'; $wxLabel = 'Mostly clear'; }
+		elseif ($wxCode === 2)                          { $wxIcon = '⛅';  $wxLabel = 'Partly cloudy'; }
+		elseif ($wxCode === 3)                          { $wxIcon = '☁️';  $wxLabel = 'Overcast'; }
+		elseif ($wxCode === 45 || $wxCode === 48)       { $wxIcon = '🌫️'; $wxLabel = 'Fog'; }
+		elseif ($wxCode >= 51 && $wxCode <= 57)         { $wxIcon = '🌦️'; $wxLabel = 'Drizzle'; }
+		elseif ($wxCode >= 61 && $wxCode <= 67)         { $wxIcon = '🌧️'; $wxLabel = 'Rain'; }
+		elseif ($wxCode >= 71 && $wxCode <= 77)         { $wxIcon = '❄️';  $wxLabel = 'Snow'; }
+		elseif ($wxCode >= 80 && $wxCode <= 82)         { $wxIcon = '🌦️'; $wxLabel = 'Showers'; }
+		elseif ($wxCode === 85 || $wxCode === 86)       { $wxIcon = '🌨️'; $wxLabel = 'Snow showers'; }
+		elseif ($wxCode >= 95 && $wxCode <= 99)         { $wxIcon = '⛈️'; $wxLabel = 'Thunderstorm'; }
+	?>
+	<div class="pk-stat-card pk-stat-card-weather">
+		<div class="pk-stat-icon"><?= $wxIcon ?: '🌡️' ?></div>
+		<div class="pk-stat-value"><?= round($wxTemp) ?>°F</div>
+		<div class="pk-stat-label">
+			<?= htmlspecialchars($wxLabel) ?>
+			<?php if (isset($wx['today_high_f'], $wx['today_low_f'])): ?>
+				<br><span style="font-size:.85em;color:var(--ork-text-muted,#718096)">H <?= round($wx['today_high_f']) ?>° / L <?= round($wx['today_low_f']) ?>°<?php
+					if (!empty($wx['today_precip_pct'])) echo ' · ' . (int)$wx['today_precip_pct'] . '% rain';
+				?></span>
+			<?php endif; ?>
+			<a href="https://open-meteo.com/" target="_blank" rel="noopener"
+			   title="Weather data by Open-Meteo.com" aria-label="Weather data by Open-Meteo.com"
+			   style="font-size:10px;color:var(--ork-text-muted,#a0aec0);text-decoration:none;margin-left:4px;opacity:.6">ⓘ</a>
+		</div>
+	</div>
+	<?php endif; ?>
 </div>
 
 <!-- =============================================

--- a/orkui/template/revised-frontend/Parknew_index.tpl
+++ b/orkui/template/revised-frontend/Parknew_index.tpl
@@ -157,16 +157,36 @@
 		}
 		foreach ($_pdOccs as $_pdOcc) {
 			$_pdTitle = !empty($_pd['Online']) ? '(Online) ' . $_pdLabel : $_pdLabel;
-			$pkCalParkDays[] = ['title'=>$_pdTitle,'start'=>$_pdOcc.'T'.$_pdTimeStr,'color'=>$_pdColor];
+			$pkCalParkDays[] = ['title'=>$_pdTitle,'start'=>$_pdOcc.'T'.$_pdTimeStr,'color'=>$_pdColor,'online'=>!empty($_pd['Online'])];
 		}
+		// Lookup: first upcoming occurrence per park-day-id, for the schedule cards' forecast badges
+		if (!empty($_pdOccs)) { $pdNextDateById[(int)$_pd['ParkDayId']] = $_pdOccs[0]; }
+	}
+	if (!isset($pdNextDateById)) { $pdNextDateById = []; }
+
+	// Next Park Day: earliest upcoming IN-PERSON occurrence. Online park days
+	// (Discord/Zoom A&S, virtual fighter practice prep, etc.) are excluded —
+	// the card drives field/weather decisions, which don't apply to online.
+	$nextParkDayDate = null;
+	$_inPersonStarts = array_column(array_filter($pkCalParkDays, function($e) { return empty($e['online']); }), 'start');
+	if (!empty($_inPersonStarts)) {
+		sort($_inPersonStarts);
+		$nextParkDayDate = substr($_inPersonStarts[0], 0, 10);
 	}
 
-	// Next Park Day: earliest upcoming occurrence across all park days
-	$nextParkDayDate = null;
-	if (!empty($pkCalParkDays)) {
-		$_starts = array_column($pkCalParkDays, 'start');
-		sort($_starts);
-		$nextParkDayDate = substr($_starts[0], 0, 10);
+	// "Today" anchor for forecast-vs-current labelling.
+	// Open-Meteo returns dates in each park's local timezone (we use timezone=auto)
+	// so the right comparison is "today in this park's local time" — not server time
+	// (Chicago) and not the viewer's time (could be anywhere).
+	$parkLocalToday = date('Y-m-d');  // sensible fallback
+	if (!empty($park_weather['forecast_json'])) {
+		$_wxDecoded = @json_decode($park_weather['forecast_json'], true);
+		$_wxTz      = $_wxDecoded['timezone'] ?? null;
+		if ($_wxTz) {
+			try {
+				$parkLocalToday = (new DateTime('now', new DateTimeZone($_wxTz)))->format('Y-m-d');
+			} catch (Exception $e) { /* fall back to server-local */ }
+		}
 	}
 
 	// Active Players: last sign-in within the past 6 months — matches the Players tab subtitle
@@ -264,11 +284,46 @@
      ZONE 2: Stats Row
      ============================================= -->
 <div class="pk-stats-row">
+	<?php
+		// Forecast for the next park day (when within the 7-day cache window)
+		$nextPdForecast = ($nextParkDayDate && $park_weather)
+			? Ork3::$Lib->weather->forecast_for_date($park_id, $nextParkDayDate)
+			: null;
+	?>
 	<div class="pk-stat-card<?= count($parkDayList) > 0 ? ' pk-stat-card-link' : '' ?>"<?php if (count($parkDayList) > 0): ?> onclick="pkActivateTab('about')"<?php endif; ?>>
 		<div class="pk-stat-icon"><i class="fas fa-calendar-check"></i></div>
 		<?php if ($nextParkDayDate): ?>
 			<div class="pk-stat-value" style="font-size:1.1rem"><?= date('M j', strtotime($nextParkDayDate)) ?></div>
 			<div class="pk-stat-sub"><?= date('l', strtotime($nextParkDayDate)) ?></div>
+			<?php if ($nextPdForecast && $nextPdForecast['hi_f'] !== null):
+				// WMO code → emoji (daytime; forecast doesn't distinguish day/night)
+				$fcCode = (int)$nextPdForecast['code'];
+				if     ($fcCode === 0)                        { $fcIcon = '☀️'; }
+				elseif ($fcCode === 1)                        { $fcIcon = '🌤️'; }
+				elseif ($fcCode === 2)                        { $fcIcon = '⛅'; }
+				elseif ($fcCode === 3)                        { $fcIcon = '☁️'; }
+				elseif ($fcCode === 45 || $fcCode === 48)     { $fcIcon = '🌫️'; }
+				elseif ($fcCode >= 51 && $fcCode <= 57)       { $fcIcon = '🌦️'; }
+				elseif ($fcCode >= 61 && $fcCode <= 67)       { $fcIcon = '🌧️'; }
+				elseif ($fcCode >= 71 && $fcCode <= 77)       { $fcIcon = '❄️'; }
+				elseif ($fcCode >= 80 && $fcCode <= 82)       { $fcIcon = '🌦️'; }
+				elseif ($fcCode === 85 || $fcCode === 86)     { $fcIcon = '🌨️'; }
+				elseif ($fcCode >= 95 && $fcCode <= 99)       { $fcIcon = '⛈️'; }
+				else                                          { $fcIcon = '🌡️'; }
+				$fcHiC = round(($nextPdForecast['hi_f'] - 32) * 5 / 9);
+				$fcLoC = $nextPdForecast['lo_f'] !== null ? round(($nextPdForecast['lo_f'] - 32) * 5 / 9) : null;
+			?>
+				<div class="pk-stat-sub" style="margin-top:2px;font-size:11px">
+					<?php if ($nextParkDayDate !== $parkLocalToday): ?><span style="font-style:italic;opacity:.55;margin-right:3px">forecast</span><?php endif; ?>
+					<?= $fcIcon ?> <?= round($nextPdForecast['hi_f']) ?>/<?= $fcHiC ?>°<?php
+						if ($nextPdForecast['lo_f'] !== null) echo ' · <span style="opacity:.7">L ' . round($nextPdForecast['lo_f']) . '/' . $fcLoC . '°</span>';
+						if (!empty($nextPdForecast['precip_pct']) && $nextPdForecast['precip_pct'] >= 20) echo ' · ' . (int)$nextPdForecast['precip_pct'] . '% rain';
+					?>
+					<?php foreach (Ork3::$Lib->weather->badges_for_date($park_id, $nextParkDayDate) as $_b): ?>
+						<span class="pk-wx-badge pk-wx-<?= $_b['severity'] ?>" title="<?= htmlspecialchars($_b['label']) ?>"><?= $_b['icon'] ?> <?= htmlspecialchars($_b['label']) ?></span>
+					<?php endforeach; ?>
+				</div>
+			<?php endif; ?>
 		<?php else: ?>
 			<div class="pk-stat-value">&mdash;</div>
 		<?php endif; ?>
@@ -295,10 +350,12 @@
 		<div class="pk-stat-label">Event<?= count($eventList) != 1 ? 's' : '' ?></div>
 	</div>
 	<?php
-	// Park weather card — only render when we have a valid current temp.
+	// Park weather card — only render when we have a valid current temp AND the
+	// Next Park Day card isn't already showing today/upcoming forecast (which
+	// would make this redundant).
 	$wx = $park_weather ?? null;
 	$wxTemp = $wx['current_temp_f'] ?? null;
-	if ($wxTemp !== null):
+	if ($wxTemp !== null && empty($nextPdForecast)):
 		$wxCode  = (int)($wx['current_code']  ?? -1);
 		$wxIsDay = (int)($wx['current_is_day'] ?? 1);
 		// WMO code → emoji + short label (mirrors Live ticker logic)
@@ -316,13 +373,21 @@
 		elseif ($wxCode === 85 || $wxCode === 86)       { $wxIcon = '🌨️'; $wxLabel = 'Snow showers'; }
 		elseif ($wxCode >= 95 && $wxCode <= 99)         { $wxIcon = '⛈️'; $wxLabel = 'Thunderstorm'; }
 	?>
+	<?php
+		// Pair of °F / °C for the US + Canadian audience.
+		$wxTempC      = ($wxTemp - 32) * 5 / 9;
+		$wxTodayHi    = $wx['today_high_f'] ?? null;
+		$wxTodayLo    = $wx['today_low_f']  ?? null;
+		$wxTodayHiC   = $wxTodayHi !== null ? ($wxTodayHi - 32) * 5 / 9 : null;
+		$wxTodayLoC   = $wxTodayLo !== null ? ($wxTodayLo - 32) * 5 / 9 : null;
+	?>
 	<div class="pk-stat-card pk-stat-card-weather">
 		<div class="pk-stat-icon"><?= $wxIcon ?: '🌡️' ?></div>
-		<div class="pk-stat-value"><?= round($wxTemp) ?>°F</div>
+		<div class="pk-stat-value" style="font-size:1.1rem"><?= round($wxTemp) ?>°F / <?= round($wxTempC) ?>°C</div>
 		<div class="pk-stat-label">
 			<?= htmlspecialchars($wxLabel) ?>
-			<?php if (isset($wx['today_high_f'], $wx['today_low_f'])): ?>
-				<br><span style="font-size:.85em;color:var(--ork-text-muted,#718096)">H <?= round($wx['today_high_f']) ?>° / L <?= round($wx['today_low_f']) ?>°<?php
+			<?php if ($wxTodayHi !== null && $wxTodayLo !== null): ?>
+				<br><span style="font-size:.85em;color:var(--ork-text-muted,#718096)">H <?= round($wxTodayHi) ?>/<?= round($wxTodayHiC) ?>° · L <?= round($wxTodayLo) ?>/<?= round($wxTodayLoC) ?>°<?php
 					if (!empty($wx['today_precip_pct'])) echo ' · ' . (int)$wx['today_precip_pct'] . '% rain';
 				?></span>
 			<?php endif; ?>
@@ -614,6 +679,37 @@
 										</a>
 									<?php endif; ?>
 								<?php endif; ?>
+							<?php
+								// Forecast for the next occurrence of THIS park day, when in-person and within the 7-day cache window
+								$_pdNext = $pdNextDateById[(int)$day['ParkDayId']] ?? null;
+								$_pdFC   = (empty($day['Online']) && $_pdNext)
+									? Ork3::$Lib->weather->forecast_for_date($park_id, $_pdNext)
+									: null;
+								if ($_pdFC && $_pdFC['hi_f'] !== null):
+									$c = (int)$_pdFC['code'];
+									$ic = ($c===0)?'☀️':(($c===1)?'🌤️':(($c===2)?'⛅':(($c===3)?'☁️':(($c===45||$c===48)?'🌫️':(($c>=51&&$c<=57)?'🌦️':(($c>=61&&$c<=67)?'🌧️':(($c>=71&&$c<=77)?'❄️':(($c>=80&&$c<=82)?'🌦️':(($c===85||$c===86)?'🌨️':(($c>=95)?'⛈️':'🌡️'))))))))));
+									$hiC = round(($_pdFC['hi_f']-32)*5/9);
+									$loC = $_pdFC['lo_f'] !== null ? round(($_pdFC['lo_f']-32)*5/9) : null;
+							?>
+								<?php $_pdBadges = Ork3::$Lib->weather->badges_for_date($park_id, $_pdNext); ?>
+								<div class="pk-schedule-forecast" style="margin-top:6px;padding:6px 8px;background:var(--ork-bg-secondary,#f7fafc);border-radius:4px;font-size:11px;color:var(--ork-text-muted,#718096)">
+									<?php if ($_pdNext !== $parkLocalToday): ?><em style="opacity:.75;margin-right:3px">forecast</em><?php endif; ?>
+									<span style="font-size:13px"><?= $ic ?></span>
+									<span style="color:var(--ork-text,#2d3748);font-weight:600;margin-left:4px"><?= round($_pdFC['hi_f']) ?>/<?= $hiC ?>°</span>
+									<?php if ($_pdFC['lo_f'] !== null): ?>
+										<span style="margin-left:6px">L <?= round($_pdFC['lo_f']) ?>/<?= $loC ?>°</span>
+									<?php endif; ?>
+									<?php if (!empty($_pdFC['precip_pct']) && $_pdFC['precip_pct'] >= 20): ?>
+										<span style="margin-left:6px"><?= (int)$_pdFC['precip_pct'] ?>% rain</span>
+									<?php endif; ?>
+									<?php foreach ($_pdBadges as $_b): ?>
+										<span class="pk-wx-badge pk-wx-<?= $_b['severity'] ?>" title="<?= htmlspecialchars($_b['label']) ?>" style="margin-left:6px"><?= $_b['icon'] ?> <?= htmlspecialchars($_b['label']) ?></span>
+									<?php endforeach; ?>
+									<a href="https://open-meteo.com/" target="_blank" rel="noopener"
+									   title="Weather data by Open-Meteo.com" aria-label="Weather data by Open-Meteo.com"
+									   style="font-size:10px;color:var(--ork-text-muted,#a0aec0);text-decoration:none;margin-left:6px;opacity:.6">ⓘ</a>
+								</div>
+							<?php endif; ?>
 							<?php if (!empty($day['Description'])): ?>
 								<p class="pk-schedule-desc"><?= htmlspecialchars($day['Description']) ?></p>
 							<?php endif; ?>
@@ -683,6 +779,21 @@
 									<?php if (0 != $event['NextDate']): ?>
 										<?= date('M. j, Y', strtotime($event['NextDate'])) ?>
 										<?php if (strtotime($event['NextDate']) < time()): ?><span class='event-past-badge'>Past</span><?php endif; ?>
+										<?php
+											// Forecast badge when the event date is within the 7-day cache window
+											$evDateStr = substr($event['NextDate'], 0, 10);
+											$evFC = (strtotime($event['NextDate']) >= time() && $park_weather)
+												? Ork3::$Lib->weather->forecast_for_date($park_id, $evDateStr)
+												: null;
+											if ($evFC && $evFC['hi_f'] !== null):
+												$c = (int)$evFC['code'];
+												$ic = ($c===0)?'☀️':(($c===1)?'🌤️':(($c===2)?'⛅':(($c===3)?'☁️':(($c>=51&&$c<=67)?'🌧️':(($c>=71&&$c<=77)?'❄️':(($c>=80&&$c<=82)?'🌦️':(($c>=95)?'⛈️':'🌡️')))))));
+												$hiC = round(($evFC['hi_f']-32)*5/9);
+										?>
+										<br><span style="font-size:11px;color:var(--ork-text-muted,#718096)"><?php if ($evDateStr !== $parkLocalToday): ?><em style="opacity:.7;margin-right:2px">forecast</em> <?php endif; ?><?= $ic ?> <?= round($evFC['hi_f']) ?>/<?= $hiC ?>°<?php
+											if (!empty($evFC['precip_pct']) && $evFC['precip_pct'] >= 20) echo ' · ' . (int)$evFC['precip_pct'] . '%';
+										?><?php foreach (Ork3::$Lib->weather->badges_for_date($park_id, $evDateStr) as $_b): ?> <span class="pk-wx-badge pk-wx-<?= $_b['severity'] ?>" title="<?= htmlspecialchars($_b['label']) ?>"><?= $_b['icon'] ?></span><?php endforeach; ?></span>
+										<?php endif; ?>
 									<?php endif; ?>
 								</td>
 								<td class="pk-date-col" style="text-align:center"><?= (int)($event['RsvpGoing'] ?? 0) ?: '—' ?></td>
@@ -1910,6 +2021,13 @@ html[data-theme="dark"] .fc-button { background: var(--ork-bg-secondary); border
 html[data-theme="dark"] .fc-button:hover { background: var(--ork-bg-tertiary); }
 html[data-theme="dark"] .fc-button-primary:not(:disabled):active,
 html[data-theme="dark"] .fc-button-primary:not(:disabled).fc-button-active { background: var(--ork-bg-tertiary); border-color: var(--ork-border); }
+
+/* Weather safety badges (heat, cold, storm, UV, wind) */
+.pk-wx-badge { display:inline-block; padding:1px 6px; border-radius:10px; font-size:10px; font-weight:600; line-height:1.4; vertical-align:middle; white-space:nowrap; }
+.pk-wx-caution { background:#fef3c7; color:#92400e; border:1px solid #fcd34d; }
+.pk-wx-warning { background:#fee2e2; color:#991b1b; border:1px solid #fca5a5; }
+html[data-theme="dark"] .pk-wx-caution { background:#422006; color:#fcd34d; border-color:#78350f; }
+html[data-theme="dark"] .pk-wx-warning { background:#450a0a; color:#fca5a5; border-color:#7f1d1d; }
 
 /* ============================================================
    </style>

--- a/orkui/template/revised-frontend/Weather_index.tpl
+++ b/orkui/template/revised-frontend/Weather_index.tpl
@@ -115,7 +115,7 @@
 	$comingUp = '';
 	if ($ec > 0) {
 		$comingUp = '<a href="#upcoming-events" class="wx-events-link">' . $ec . ' ' . ($ec === 1 ? 'event' : 'events') .
-			' scheduled in the next 7 days</a>.';
+			' in the week ahead</a>.';
 		if ($econ > 0) {
 			$comingUp .= ' ' . $econ . ' ' . ($econ === 1 ? 'falls' : 'fall') . ' on days with concerning forecasts; the rest look favorable.';
 		} else {
@@ -127,6 +127,14 @@
 	if (empty($leadParts) && !$standoutLine && !$comingUp) {
 		$leadParts[] = 'Calm conditions across the realm today.';
 	}
+
+	// Human-readable reason for a missing forecast — mirrors the JS version
+	$wxStatusText = function($s) {
+		if ($s === 'dormant')     return 'no recent activity — weather not tracked';
+		if ($s === 'no_coords')   return 'park location not set';
+		if ($s === 'unavailable') return 'forecast unavailable';
+		return '';
+	};
 
 	// WMO code → emoji (used by the events list)
 	$wxIcon = function($c) {
@@ -147,8 +155,36 @@
 ?>
 
 <style>
-.wx-root { max-width: 1100px; margin: 0 auto; padding: 16px 12px 40px; }
-.wx-rundown { background: var(--ork-card-bg, #fff); border: 1px solid var(--ork-border, #e2e8f0); border-radius: 10px; padding: 18px 22px; margin-bottom: 20px; box-shadow: 0 1px 3px rgba(0,0,0,0.04); }
+.wx-root { max-width: 1100px; margin: 0 auto; padding: 12px 12px 16px; display: flex; flex-direction: column; gap: 12px; }
+.wx-root > .wx-rundown,
+.wx-root > .wx-strip,
+.wx-root > .wx-map-card,
+.wx-root > .wx-lists,
+.wx-root > .wx-lists > .wx-play,
+.wx-root > .wx-lists > .wx-events { margin-bottom: 0; }
+
+/* Layout: explicit pixel heights for the map + lists so they don't change
+   when content reflows (rundown longer on warning-heavy days, banner
+   appearing/disappearing, day with 18 parks vs 162). The internal scroll on
+   each list keeps long content contained without resizing the card. */
+@media (min-width: 900px) {
+	.wx-map-card { display: flex; flex-direction: column; }
+	.wx-map-card .wx-map { height: 500px; }
+	.wx-lists { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; }
+	.wx-lists > .wx-play,
+	.wx-lists > .wx-events { display: flex; flex-direction: column; height: 400px; }
+	.wx-lists > .wx-play > #wx-play-body,
+	.wx-lists > .wx-events > .wx-events-body { flex: 1 1 auto; overflow-y: auto; min-height: 0; }
+}
+@media (max-width: 899px) {
+	/* Narrow screens: free-flowing stack, modest map */
+	.wx-map-card .wx-map { height: 320px; }
+	.wx-lists > .wx-events { margin-top: 12px; }
+}
+.wx-rundown { background: var(--ork-card-bg, #fff); border: 1px solid var(--ork-border, #e2e8f0); border-radius: 10px; padding: 14px 20px; box-shadow: 0 1px 3px rgba(0,0,0,0.04); }
+/* Fixed rundown height so warning-heavy days don't push the map down.
+   Short days have some breathing room; long days scroll internally. */
+.wx-rundown { height: 140px; overflow-y: auto; }
 .wx-rundown h2 { margin: 0 0 10px; font-size: 14px; font-weight: 700; text-transform: uppercase; letter-spacing: .08em; color: var(--ork-text-muted, #718096); background: none; border: none; padding: 0; border-radius: 0; text-shadow: none; box-shadow: none; }
 .wx-rundown p { margin: 0 0 8px; font-size: 14.5px; line-height: 1.55; color: var(--ork-text, #2d3748); }
 .wx-rundown p:last-child { margin-bottom: 0; }
@@ -159,18 +195,20 @@
 .wx-rundown .wx-events-link:hover { border-bottom-style: solid; }
 
 .wx-events { background: var(--ork-card-bg, #fff); border: 1px solid var(--ork-border, #e2e8f0); border-radius: 10px; padding: 14px 18px; }
-.wx-events-header { display: flex; align-items: center; justify-content: space-between; margin-bottom: 12px; padding-bottom: 8px; border-bottom: 1px solid var(--ork-border, #e2e8f0); }
+.wx-events-header { display: flex; align-items: center; justify-content: space-between; margin-bottom: 10px; padding-bottom: 8px; border-bottom: 1px solid var(--ork-border, #e2e8f0); flex: 0 0 auto; }
 .wx-events-header h2 { margin: 0; font-size: 14px; font-weight: 700; text-transform: uppercase; letter-spacing: .08em; color: var(--ork-text-muted, #718096); background: none; border: none; padding: 0; border-radius: 0; text-shadow: none; box-shadow: none; }
 .wx-events-header .wx-events-attr { font-size: 11px; color: var(--ork-text-muted, #a0aec0); }
 .wx-events-header .wx-events-attr a { color: inherit; text-decoration: none; }
 .wx-events-header .wx-events-attr a:hover { color: var(--ork-link); }
 
 .wx-event { display: grid; grid-template-columns: 70px 1fr auto; gap: 14px; padding: 10px 0; border-bottom: 1px solid var(--ork-border, #edf2f7); align-items: center; }
+.wx-event[data-lat]:hover, .wx-event[data-park-id]:hover { background: var(--ork-bg-secondary, #f7fafc); cursor: pointer; }
 .wx-event:last-child { border-bottom: 0; }
 .wx-event-date { font-size: 12px; color: var(--ork-text-muted, #718096); font-variant-numeric: tabular-nums; text-align: center; }
 .wx-event-date .wx-event-month { display: block; font-size: 10px; text-transform: uppercase; letter-spacing: .08em; }
 .wx-event-date .wx-event-day   { display: block; font-size: 20px; font-weight: 700; color: var(--ork-text, #2d3748); line-height: 1.1; }
 .wx-event-date .wx-event-dow   { display: block; font-size: 10px; }
+.wx-event-range { font-style: italic; }
 .wx-event-main { min-width: 0; }
 .wx-event-name { font-size: 14.5px; font-weight: 600; color: var(--ork-text, #2d3748); }
 .wx-event-name a { color: inherit; text-decoration: none; }
@@ -191,20 +229,51 @@ html[data-theme="dark"] .wx-event-badge-caution { background: #422006; color: #f
 .wx-empty { padding: 30px 12px; text-align: center; color: var(--ork-text-muted, #a0aec0); font-style: italic; }
 
 /* Date strip */
-.wx-strip { display: flex; gap: 6px; margin: 20px 0 14px; flex-wrap: wrap; }
-.wx-pill { flex: 1 1 0; min-width: 70px; padding: 8px 10px; border-radius: 8px; background: var(--ork-card-bg, #fff); border: 1px solid var(--ork-border, #e2e8f0); cursor: pointer; text-align: center; transition: background .12s, border-color .12s, transform .12s; }
+.wx-strip { display: flex; gap: 6px; flex-wrap: wrap; }
+.wx-pill { position: relative; flex: 1 1 0; min-width: 70px; padding: 8px 10px; border-radius: 8px; background: var(--ork-card-bg, #fff); border: 1px solid var(--ork-border, #e2e8f0); cursor: pointer; text-align: center; color: var(--ork-text, #2d3748); font-family: inherit; transition: background .12s, border-color .12s; outline: none; }
 .wx-pill:hover { background: var(--ork-bg-secondary, #f7fafc); }
-.wx-pill.active { border-color: var(--ork-link-bright, #2b6cb0); background: var(--ork-link-bright, #2b6cb0); color: #fff; }
-.wx-pill.active .wx-pill-date { color: rgba(255,255,255,0.85); }
+/* Active pill: uniform 2px blue border + subtle tint. Use negative margin
+   so the thicker border doesn't shift sibling pills. */
+.wx-pill.active { border: 2px solid var(--ork-link-bright, #2b6cb0); margin: -1px; background: rgba(43, 108, 176, 0.08); }
+/* Keyboard focus-visible ring (only when navigating with keyboard) */
+.wx-pill:focus-visible { box-shadow: 0 0 0 2px var(--ork-link-bright, #2b6cb0); }
+html[data-theme="dark"] .wx-pill { color: var(--ork-text, #e2e8f0); }
+html[data-theme="dark"] .wx-pill:hover { background: rgba(255,255,255,0.04); }
+html[data-theme="dark"] .wx-pill.active { background: rgba(99, 179, 237, 0.10); border-color: #63b3ed; }
+html[data-theme="dark"] .wx-pill:focus-visible { box-shadow: 0 0 0 2px #63b3ed; }
 .wx-pill-day { font-size: 11px; font-weight: 700; text-transform: uppercase; letter-spacing: .06em; }
 .wx-pill-date { font-size: 11px; color: var(--ork-text-muted, #718096); margin-top: 2px; }
+.wx-pill-dot { display: block; width: 7px; height: 7px; border-radius: 50%; margin: 5px auto 0; }
 
 /* Play list */
-.wx-play { background: var(--ork-card-bg, #fff); border: 1px solid var(--ork-border, #e2e8f0); border-radius: 10px; padding: 14px 18px; margin-bottom: 20px; }
-.wx-play-header { display: flex; align-items: center; justify-content: space-between; margin-bottom: 12px; padding-bottom: 8px; border-bottom: 1px solid var(--ork-border, #e2e8f0); }
+.wx-play { background: var(--ork-card-bg, #fff); border: 1px solid var(--ork-border, #e2e8f0); border-radius: 10px; padding: 14px 18px; }
+.wx-play-header { display: flex; align-items: center; justify-content: space-between; gap: 10px; margin-bottom: 10px; padding-bottom: 8px; border-bottom: 1px solid var(--ork-border, #e2e8f0); flex: 0 0 auto; }
 .wx-play-header h2 { margin: 0; font-size: 14px; font-weight: 700; text-transform: uppercase; letter-spacing: .08em; color: var(--ork-text-muted, #718096); background: none; border: none; padding: 0; border-radius: 0; text-shadow: none; box-shadow: none; }
-.wx-play-count { font-size: 11px; color: var(--ork-text-muted, #a0aec0); }
+.wx-play-controls { display: flex; align-items: center; gap: 10px; font-size: 11px; color: var(--ork-text-muted, #a0aec0); }
+/* Fixed widths on count + toggle so changing mode/search doesn't reflow the header. */
+.wx-play-count { font-size: 11px; color: var(--ork-text-muted, #a0aec0); min-width: 70px; text-align: right; font-variant-numeric: tabular-nums; }
+.wx-play-toggle { background: transparent; border: 1px solid var(--ork-border, #cbd5e0); color: var(--ork-link-bright, #2b6cb0); font-size: 11px; font-weight: 600; padding: 3px 8px; border-radius: 6px; cursor: pointer; min-width: 140px; text-align: center; }
+.wx-play-toggle.wx-invisible { visibility: hidden; }
+.wx-play-toggle:hover { background: var(--ork-bg-secondary, #f7fafc); }
+html[data-theme="dark"] .wx-play-toggle:hover { background: rgba(255,255,255,0.05); }
+/* Mode is conveyed by label text + the banner — no loud active-fill needed. */
+.wx-play-toggle.active { background: rgba(43, 108, 176, 0.10); border-color: var(--ork-link-bright, #2b6cb0); }
+html[data-theme="dark"] .wx-play-toggle.active { background: rgba(99, 179, 237, 0.12); border-color: #63b3ed; color: #63b3ed; }
+.wx-play-search { background: var(--ork-card-bg, #fff); border: 1px solid var(--ork-border, #cbd5e0); border-radius: 6px; padding: 3px 8px; font-size: 12px; color: var(--ork-text, #2d3748); width: 130px; outline: none; }
+.wx-play-search:focus { border-color: var(--ork-link-bright, #2b6cb0); }
+html[data-theme="dark"] .wx-play-search { background: var(--ork-bg-secondary, #1a202c); color: var(--ork-text, #e2e8f0); }
+.wx-play-row.wx-filtered { display: none; }
+
+/* Filter-state banner — appears between the header and the list when the
+   "flagged" mode is active so users understand they're seeing a curated subset. */
+.wx-play-mode { display: none; align-items: center; gap: 8px; padding: 6px 10px; margin: 0 0 8px; border-radius: 6px; background: #fef3c7; color: #92400e; border: 1px solid #fcd34d; font-size: 11.5px; }
+.wx-play-mode .wx-play-mode-icon { font-size: 14px; }
+.wx-play-mode .wx-play-mode-clear { margin-left: auto; background: transparent; border: 0; color: #92400e; text-decoration: underline; font-size: 11px; cursor: pointer; padding: 0; }
+.wx-play.is-flagged-mode .wx-play-mode { display: flex; }
+html[data-theme="dark"] .wx-play-mode { background: #422006; color: #fcd34d; border-color: #78350f; }
+html[data-theme="dark"] .wx-play-mode .wx-play-mode-clear { color: #fcd34d; }
 .wx-play-row { display: grid; grid-template-columns: 1fr auto; gap: 14px; padding: 9px 0; border-bottom: 1px solid var(--ork-border, #edf2f7); align-items: center; }
+.wx-play-row[data-park-id]:hover { background: var(--ork-bg-secondary, #f7fafc); cursor: pointer; }
 .wx-play-row:last-child { border-bottom: 0; }
 .wx-play-main { min-width: 0; }
 .wx-play-park { font-size: 14px; font-weight: 600; color: var(--ork-text, #2d3748); }
@@ -216,7 +285,51 @@ html[data-theme="dark"] .wx-event-badge-caution { background: #422006; color: #f
 .wx-play-wx .wx-play-empty { font-size: 11px; color: var(--ork-text-muted, #a0aec0); font-style: italic; }
 
 .wx-loading { padding: 20px; text-align: center; color: var(--ork-text-muted, #a0aec0); font-style: italic; }
+
+/* Map */
+.wx-map-card { background: var(--ork-card-bg, #fff); border: 1px solid var(--ork-border, #e2e8f0); border-radius: 10px; padding: 14px 18px; }
+.wx-map-header { display: flex; align-items: center; justify-content: space-between; margin-bottom: 12px; padding-bottom: 8px; border-bottom: 1px solid var(--ork-border, #e2e8f0); gap: 10px; }
+.wx-map-header h2 { margin: 0; font-size: 14px; font-weight: 700; text-transform: uppercase; letter-spacing: .08em; color: var(--ork-text-muted, #718096); background: none; border: none; padding: 0; border-radius: 0; text-shadow: none; box-shadow: none; }
+#wx-zoom-out { display: none; background: transparent; border: 1px solid var(--ork-border, #cbd5e0); color: var(--ork-text-muted, #718096); font-size: 11px; padding: 2px 8px; border-radius: 6px; cursor: pointer; white-space: nowrap; flex-shrink: 0; }
+#wx-zoom-out:hover { background: var(--ork-bg-secondary, #f7fafc); color: var(--ork-text, #2d3748); }
+html[data-theme="dark"] #wx-zoom-out:hover { background: rgba(255,255,255,0.05); }
+#wx-zoom-out.visible { display: inline-block; }
+.wx-map-legend { display: flex; gap: 10px; font-size: 11px; color: var(--ork-text-muted, #718096); flex-wrap: wrap; }
+.wx-map-legend span { display: inline-flex; align-items: center; gap: 4px; }
+.wx-map-legend i { display: inline-block; width: 10px; height: 10px; border-radius: 50%; border: 1px solid rgba(0,0,0,0.2); }
+.wx-map { width: 100%; height: 360px; border-radius: 6px; overflow: hidden; }
+html[data-theme="dark"] .wx-map { background: #1a202c; }
+/* Tone down Leaflet's default white zoom controls in dark mode */
+html[data-theme="dark"] .wx-map .leaflet-bar a,
+html[data-theme="dark"] .wx-map .leaflet-bar a:hover { background: #2d3748; color: #e2e8f0; border-bottom-color: #4a5568; }
+html[data-theme="dark"] .wx-map .leaflet-bar a:hover { background: #4a5568; }
+html[data-theme="dark"] .wx-map .leaflet-bar { border-color: #4a5568; box-shadow: 0 1px 3px rgba(0,0,0,0.5); }
+html[data-theme="dark"] .wx-map .leaflet-bar a.leaflet-disabled { background: #1a202c; color: #4a5568; }
+/* Leaflet popups in dark mode */
+html[data-theme="dark"] .wx-map .leaflet-popup-content-wrapper { background: #2d3748; color: #e2e8f0; box-shadow: 0 3px 14px rgba(0,0,0,0.6); }
+html[data-theme="dark"] .wx-map .leaflet-popup-tip { background: #2d3748; }
+html[data-theme="dark"] .wx-map .leaflet-popup-close-button { color: #a0aec0; }
+html[data-theme="dark"] .wx-map .leaflet-popup-close-button:hover { color: #e2e8f0; }
+html[data-theme="dark"] .wx-map-popup .wx-pp-meta { color: #a0aec0; }
+html[data-theme="dark"] .wx-map .leaflet-tooltip { background: #2d3748; color: #e2e8f0; border-color: #4a5568; box-shadow: 0 1px 3px rgba(0,0,0,0.5); }
+html[data-theme="dark"] .wx-map .leaflet-tooltip-top:before { border-top-color: #2d3748; }
+html[data-theme="dark"] .wx-map .leaflet-tooltip-bottom:before { border-bottom-color: #2d3748; }
+html[data-theme="dark"] .wx-map .leaflet-tooltip-left:before { border-left-color: #2d3748; }
+html[data-theme="dark"] .wx-map .leaflet-tooltip-right:before { border-right-color: #2d3748; }
+.wx-map-popup { font-size: 12px; line-height: 1.4; }
+.wx-map-popup .wx-pp-name { font-weight: 700; font-size: 13px; }
+.wx-map-popup .wx-pp-name a { color: var(--ork-link-bright, #2b6cb0); text-decoration: none; }
+.wx-map-popup .wx-pp-name a:hover { text-decoration: underline; }
+.wx-map-popup .wx-pp-meta { color: var(--ork-text-muted, #718096); font-size: 11px; margin-top: 2px; }
+.wx-map-popup .wx-pp-wx { margin-top: 4px; font-weight: 600; }
+.wx-map-popup .wx-pp-badges { margin-top: 4px; display: flex; flex-wrap: wrap; gap: 4px; }
+.wx-map-popup .wx-pp-badges .wx-event-badge { margin-left: 0; padding: 2px 8px; font-size: 10.5px; }
+
+.wx-play-row.wx-hidden, .wx-event.wx-hidden { display: none; }
 </style>
+
+<link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css">
+<script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" defer></script>
 
 <div class="wx-root" data-selected-date="<?= htmlspecialchars($selected) ?>">
 
@@ -243,21 +356,71 @@ html[data-theme="dark"] .wx-event-badge-caution { background: #422006; color: #f
 			        data-date="<?= htmlspecialchars($pill['date']) ?>">
 				<div class="wx-pill-day"><?= htmlspecialchars($pill['day_label']) ?></div>
 				<div class="wx-pill-date"><?= htmlspecialchars($pill['date_label']) ?></div>
+				<?php
+					if ($pill['severity'] === 'warning')     { $dotStyle = 'background:#e53e3e;'; $dotTitle = 'Weather warning'; }
+					elseif ($pill['severity'] === 'caution') { $dotStyle = 'background:#dd6b20;'; $dotTitle = 'Weather caution'; }
+					else                                     { $dotStyle = 'visibility:hidden;';  $dotTitle = ''; }
+				?>
+				<span class="wx-pill-dot" style="<?= $dotStyle ?>"<?= $dotTitle ? ' title="' . $dotTitle . '"' : '' ?>></span>
 			</button>
 		<?php endforeach; ?>
 	</div>
 
+	<!-- ── Map (for selected day) ──────────────────────────── -->
+	<div class="wx-map-card" id="wx-map-card">
+		<div class="wx-map-header">
+			<h2 id="wx-map-title">🗺️ Conditions Map — Today</h2>
+			<button id="wx-zoom-out">Esc — Reset Zoom</button>
+			<div class="wx-map-legend">
+				<span><i style="background:#e53e3e;"></i>Warning</span>
+				<span><i style="background:#dd6b20;"></i>Caution</span>
+				<span><i style="background:#48bb78;"></i>Favorable</span>
+				<span><i style="background:#a0aec0;"></i>No forecast</span>
+			</div>
+		</div>
+		<div class="wx-map" id="wx-map"></div>
+	</div>
+
+	<!-- ── Lists (play + events, side-by-side on wide screens) ── -->
+	<div class="wx-lists">
+
 	<!-- ── Play list (for selected day) ───────────────────── -->
+	<?php
+		// Flagged = anything with a warning or caution badge. When any exist,
+		// they're the only rows shown by default (severity-sorted); a button
+		// reveals the full alphabetical list. When none exist, show the whole
+		// list alphabetically and hide the toggle.
+		$flaggedCount = 0;
+		foreach ($playToday as $p) { if (!empty($p['badges'])) $flaggedCount++; }
+		$initialMode = $flaggedCount > 0 ? 'flagged' : 'all';
+	?>
 	<div class="wx-play" id="wx-play">
 		<div class="wx-play-header">
 			<h2 id="wx-play-title">🏕️ Play Today</h2>
-			<span class="wx-play-count" id="wx-play-count"><?= count($playToday) ?> parks</span>
+			<div class="wx-play-controls">
+				<input type="search" class="wx-play-search" id="wx-play-search" placeholder="Filter parks…" autocomplete="off">
+				<span class="wx-play-count" id="wx-play-count">
+					<?php if ($initialMode === 'flagged'): ?>
+						<?= $flaggedCount ?> of <?= count($playToday) ?>
+					<?php else: ?>
+						<?= count($playToday) ?> parks
+					<?php endif; ?>
+				</span>
+				<?php if ($flaggedCount > 0): ?>
+					<button class="wx-play-toggle" id="wx-play-toggle" data-mode="flagged"><?= count($playToday) > $flaggedCount ? 'Show all ' . count($playToday) : 'A–Z' ?></button>
+				<?php endif; ?>
+			</div>
+		</div>
+		<div class="wx-play-mode" id="wx-play-mode">
+			<span class="wx-play-mode-icon">⚠️</span>
+			<span>Showing only parks with <strong>weather concerns</strong> today.</span>
+			<button type="button" class="wx-play-mode-clear" id="wx-play-mode-clear">Show all parks</button>
 		</div>
 		<div id="wx-play-body">
 			<?php if (empty($playToday)): ?>
 				<div class="wx-empty">No in-person play scheduled.</div>
 			<?php else: ?>
-				<?php foreach ($playToday as $p):
+				<?php foreach ($playToday as $i => $p):
 					$fc = $p['forecast'] ?? null;
 					$kshort = Weather::short_kingdom($p['kingdom_name'] ?? '');
 					$scheds = array();
@@ -265,11 +428,18 @@ html[data-theme="dark"] .wx-event-badge-caution { background: #422006; color: #f
 						$t = $s['time'] ? date('g:i A', strtotime($s['time'])) : '';
 						$scheds[] = htmlspecialchars($s['purpose']) . ($t ? " at $t" : '');
 					}
+					$flagged = !empty($p['badges']);
+					$hideClass = ($initialMode === 'flagged' && !$flagged) ? ' wx-hidden' : '';
 				?>
-				<div class="wx-play-row">
+				<div class="wx-play-row<?= $hideClass ?>"
+				     data-park-id="<?= (int)$p['park_id'] ?>"
+				     data-park-name="<?= htmlspecialchars(mb_strtolower($p['park_name'])) ?>"
+				     data-severity="<?= (int)($p['_score'] ?? 0) ?>"
+				     data-flagged="<?= $flagged ? '1' : '0' ?>"
+				     <?php if ($p['lat'] !== null): ?>data-lat="<?= htmlspecialchars((string)$p['lat']) ?>" data-lng="<?= htmlspecialchars((string)$p['lng']) ?>"<?php endif; ?>>
 					<div class="wx-play-main">
 						<div class="wx-play-park">
-							<a href="<?= UIR ?>Park/profile/<?= (int)$p['park_id'] ?>"><?= htmlspecialchars($p['park_name']) ?></a>
+							<a href="<?= UIR ?>Park/profile/<?= (int)$p['park_id'] ?>" class="wx-jump" target="_blank" rel="noopener"><?= htmlspecialchars($p['park_name']) ?></a>
 						</div>
 						<div class="wx-play-meta">
 							<?= implode(' &middot; ', $scheds) ?><?php if ($kshort): ?> &middot; <?= htmlspecialchars($kshort) ?><?php endif; ?>
@@ -292,7 +462,7 @@ html[data-theme="dark"] .wx-event-badge-caution { background: #422006; color: #f
 								</div>
 							<?php endif; ?>
 						<?php else: ?>
-							<div class="wx-play-empty">forecast unavailable</div>
+							<div class="wx-play-empty"><?= htmlspecialchars($wxStatusText($p['forecast_status'] ?? 'unavailable')) ?></div>
 						<?php endif; ?>
 					</div>
 				</div>
@@ -304,9 +474,10 @@ html[data-theme="dark"] .wx-event-badge-caution { background: #422006; color: #f
 	<!-- ── Upcoming Events ─────────────────────────────────── -->
 	<div class="wx-events" id="upcoming-events">
 		<div class="wx-events-header">
-			<h2>📅 Upcoming Events — next 7 days</h2>
+			<h2 id="wx-events-title">📅 Upcoming Events — in the week ahead</h2>
 			<span class="wx-events-attr">Weather by <a href="https://open-meteo.com/" target="_blank" rel="noopener">Open-Meteo</a></span>
 		</div>
+		<div class="wx-events-body">
 
 		<?php if (empty($events)): ?>
 			<div class="wx-empty">No events scheduled in the next 7 days.</div>
@@ -317,7 +488,12 @@ html[data-theme="dark"] .wx-event-badge-caution { background: #422006; color: #f
 				$today = date('Y-m-d');
 				$isToday = ($dayDate === $today);
 			?>
-			<div class="wx-event">
+			<div class="wx-event"
+			     data-event-cd-id="<?= (int)$ev['event_calendardetail_id'] ?>"
+			     data-event-start="<?= htmlspecialchars(substr($ev['event_start'], 0, 10)) ?>"
+			     data-event-end="<?= htmlspecialchars(substr($ev['event_end'] ?? $ev['event_start'], 0, 10)) ?>"
+			     <?php if (!empty($ev['lat']) && !empty($ev['lng'])): ?>data-lat="<?= htmlspecialchars((string)$ev['lat']) ?>" data-lng="<?= htmlspecialchars((string)$ev['lng']) ?>" data-name="<?= htmlspecialchars($ev['name']) ?>"<?php endif; ?>
+			     <?php if (!empty($ev['park_id'])): ?>data-park-id="<?= (int)$ev['park_id'] ?>"<?php endif; ?>>
 				<div class="wx-event-date">
 					<span class="wx-event-month"><?= date('M', $ts) ?></span>
 					<span class="wx-event-day"><?= date('j', $ts) ?></span>
@@ -325,15 +501,25 @@ html[data-theme="dark"] .wx-event-badge-caution { background: #422006; color: #f
 				</div>
 				<div class="wx-event-main">
 					<div class="wx-event-name">
-						<a href="<?= UIR ?>Event/detail/<?= (int)$ev['event_id'] ?>/<?= (int)$ev['event_calendardetail_id'] ?>">
+						<a href="<?= UIR ?>Event/detail/<?= (int)$ev['event_id'] ?>/<?= (int)$ev['event_calendardetail_id'] ?>" class="wx-jump" target="_blank" rel="noopener">
 							<?= htmlspecialchars($ev['name']) ?>
 						</a>
 					</div>
 					<div class="wx-event-loc">
 						<?php $kingdomShort = Weather::short_kingdom($ev['kingdom_name'] ?? '');
 						      $parts = array();
+						      $endDate = substr($ev['event_end'] ?? $ev['event_start'], 0, 10);
+						      $tsEnd = strtotime($endDate);
+						      if ($endDate > $dayDate) {
+						          $rangeLabel = date('M j', $ts) . '–' . (
+						              date('n', $ts) === date('n', $tsEnd) ? date('j', $tsEnd) : date('M j', $tsEnd)
+						          );
+						      } else {
+						          $rangeLabel = date('M j', $ts);
+						      }
+						      $parts[] = '<span class="wx-event-range">' . $rangeLabel . '</span>';
 						      if (!empty($ev['park_id']) && !empty($ev['park_name'])) {
-						          $parts[] = '<a href="' . UIR . 'Park/profile/' . (int)$ev['park_id'] . '">' . htmlspecialchars($ev['park_name']) . '</a>';
+						          $parts[] = '<a href="' . UIR . 'Park/profile/' . (int)$ev['park_id'] . '" class="wx-jump" target="_blank" rel="noopener">' . htmlspecialchars($ev['park_name']) . '</a>';
 						      }
 						      if ($kingdomShort !== '') $parts[] = htmlspecialchars($kingdomShort);
 						      echo implode(' · ', $parts);
@@ -367,13 +553,20 @@ html[data-theme="dark"] .wx-event-badge-caution { background: #422006; color: #f
 			</div>
 			<?php endforeach; ?>
 		<?php endif; ?>
+		</div>
 	</div>
+
+	</div><!-- /.wx-lists -->
 
 </div>
 
 <script>
 (function() {
 	var UIR = '<?= UIR ?>';
+	// Server-computed today in the server's local timezone — use this wherever
+	// JS code needs to know "is this date today?". JS's new Date().toISOString()
+	// returns UTC and will be off by one for users west of UTC late at night.
+	var WX_TODAY = '<?= htmlspecialchars(date('Y-m-d')) ?>';
 	var wxIcon = function(c) {
 		c = +c;
 		if (c === 0)                  return '☀️';
@@ -451,7 +644,7 @@ html[data-theme="dark"] .wx-event-badge-caution { background: #422006; color: #f
 		if (standout) {
 			var icons = { 'Extreme heat':'🥵', 'Frostbite risk':'🥶', 'Thunderstorms':'⛈️', 'Severe wind':'💨', 'Very high UV':'🌞' };
 			var pieces = (standout.flags || []).map(function(f) { return (icons[f] || '⚠️') + ' ' + esc(f); });
-			standoutLine = '<a href="' + UIR + 'Park/profile/' + standout.park_id + '" class="wx-jump-park" data-park-id="' + standout.park_id + '">' + esc(standout.name) + '</a> carries the worst forecast — ' + pieces.join(' · ');
+			standoutLine = '<a href="' + UIR + 'Park/profile/' + standout.park_id + '" class="wx-jump-park" data-park-id="' + standout.park_id + '" target="_blank" rel="noopener">' + esc(standout.name) + '</a> carries the worst forecast — ' + pieces.join(' · ');
 			if (standout.app_hi_f != null) {
 				standoutLine += ' (' + tempPair(standout.app_hi_f) + ' apparent).';
 			} else {
@@ -466,26 +659,149 @@ html[data-theme="dark"] .wx-event-badge-caution { background: #422006; color: #f
 		var html = '';
 		if (leadParts.length) html += '<p>' + leadParts.join(' ') + '</p>';
 		if (standoutLine)     html += '<p>' + standoutLine + '</p>';
-		// Preserve the existing 'coming up' paragraph (it's today-relative, not day-scoped)
-		var existingComingUp = document.querySelector('#wx-rundown-body p:last-child');
-		var preservedComingUp = '';
-		if (existingComingUp && existingComingUp.querySelector('a[href="#upcoming-events"]')) {
-			preservedComingUp = existingComingUp.outerHTML;
+		// "N events in the week ahead" — always relative to "now", shows on
+		// every day pill so users see upcoming event concerns regardless of
+		// which day they're inspecting.
+		if (window.WX_COMING_UP_HTML) {
+			html += window.WX_COMING_UP_HTML;
 		}
-		document.getElementById('wx-rundown-body').innerHTML = html + preservedComingUp;
+		document.getElementById('wx-rundown-body').innerHTML = html;
+	}
+
+	// Severity tier from the highest-severity badge — drives map marker color.
+	function rowTier(p) {
+		if (!p.forecast || p.forecast.hi_f == null) return 'none';
+		if (p.badges && p.badges.length) {
+			for (var i = 0; i < p.badges.length; i++) {
+				if (p.badges[i].severity === 'warning') return 'warning';
+			}
+			return 'caution';
+		}
+		return 'favorable';
+	}
+	var TIER_COLOR = { warning: '#e53e3e', caution: '#dd6b20', favorable: '#48bb78', none: '#a0aec0' };
+	var TIER_ORDER = { warning: 0, caution: 1, favorable: 2, none: 3 };
+	function statusText(s) {
+		if (s === 'dormant')     return 'no recent activity — weather not tracked';
+		if (s === 'no_coords')   return 'park location not set';
+		return 'forecast unavailable';
+	}
+
+	var wxMap = null, wxTileLayer = null, wxMarkers = [], wxMarkersByPark = {};
+	var wxTempMarker = null; // ephemeral marker for event-only venues (no park marker)
+	var wxBounds = null;    // last fitted bounds — Esc flies back to this
+	var wxZoomedIn = false; // true while user is zoomed into a specific park/event
+	var wxOpeningPopup = false; // true in the instant before openPopup fires, so
+	                            // popupclose can tell "replaced by another" vs "× clicked"
+	var wxFitting = false;  // true during programmatic flyToBounds/fitBounds — suppresses
+	                        // the zoomend listener so it doesn't re-show the button
+	function setZoomedIn(v) {
+		wxZoomedIn = v;
+		var btn = document.getElementById('wx-zoom-out');
+		if (btn) btn.classList.toggle('visible', !!v);
+	}
+	function fitWxMap() {
+		if (wxMap && wxBounds) {
+			wxFitting = true;
+			wxMap.flyToBounds(wxBounds, { padding: [30, 30], maxZoom: 9, duration: 0.6 });
+			wxMap.once('moveend', function() { wxFitting = false; });
+		}
+		setZoomedIn(false);
+	}
+	function isDarkTheme() { return document.documentElement.getAttribute('data-theme') === 'dark'; }
+	function wxApplyMapTheme() {
+		if (!wxMap) return;
+		var url = isDarkTheme()
+			? 'https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png'
+			: 'https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png';
+		if (wxTileLayer) wxMap.removeLayer(wxTileLayer);
+		wxTileLayer = L.tileLayer(url, { maxZoom: 19, subdomains: 'abcd' }).addTo(wxMap);
+	}
+	function ensureMap() {
+		if (wxMap || typeof L === 'undefined') return wxMap;
+		wxMap = L.map('wx-map', { zoomControl: true, attributionControl: false }).setView([39.5, -98.35], 4);
+		wxApplyMapTheme();
+		new MutationObserver(wxApplyMapTheme).observe(document.documentElement, { attributes: true, attributeFilter: ['data-theme'] });
+		onMapReady();
+		return wxMap;
+	}
+	function renderMap(rows, dayLabel) {
+		var shortDay = dayLabel === 'today' ? 'Today' : dayLabel.slice(0,1).toUpperCase() + dayLabel.slice(1,3);
+		document.getElementById('wx-map-title').textContent = '🗺️ Conditions Map — ' + shortDay;
+		if (!ensureMap()) return;
+		// Close any open popup and reset zoom state when the user switches dates.
+		wxMap.closePopup();
+		setZoomedIn(false);
+		// Clear old markers
+		wxMarkers.forEach(function(m) { wxMap.removeLayer(m); });
+		wxMarkers = [];
+		wxMarkersByPark = {};
+		if (wxTempMarker) { wxMap.removeLayer(wxTempMarker); wxTempMarker = null; }
+		// Place worst tiers on top by sorting ascending by TIER_ORDER then adding in order
+		// (Leaflet stacks later-added markers above earlier ones)
+		var plot = rows.filter(function(p) { return p.lat != null && p.lng != null; })
+			.slice()
+			.sort(function(a, b) { return TIER_ORDER[rowTier(b)] - TIER_ORDER[rowTier(a)]; });
+		var bounds = [];
+		plot.forEach(function(p) {
+			var tier = rowTier(p);
+			var color = TIER_COLOR[tier];
+			var marker = L.circleMarker([p.lat, p.lng], {
+				radius: tier === 'warning' ? 8 : (tier === 'caution' ? 7 : 6),
+				color: color, weight: 1, fillColor: color,
+				fillOpacity: tier === 'none' ? 0.4 : 0.8
+			}).addTo(wxMap);
+			var fc = p.forecast;
+			var wxLine = '';
+			if (fc && fc.hi_f != null) {
+				var loPart = fc.lo_f != null ? ' / L ' + tempPair(fc.lo_f) : '';
+				wxLine = '<div class="wx-pp-wx">' + wxIcon(fc.code) + ' ' + tempPair(fc.hi_f) + loPart + '</div>';
+				wxLine += renderBadgeChips(p.badges);
+			} else {
+				wxLine = '<div class="wx-pp-meta">' + esc(statusText(p.forecast_status)) + '</div>';
+			}
+			var k = shortKingdom(p.kingdom_name || '');
+			marker.bindPopup(
+				'<div class="wx-map-popup">' +
+					'<div class="wx-pp-name"><a href="' + UIR + 'Park/profile/' + p.park_id + '" target="_blank" rel="noopener">' + esc(p.park_name) + '</a></div>' +
+					(k ? '<div class="wx-pp-meta">' + esc(k) + '</div>' : '') +
+					wxLine +
+				'</div>'
+			);
+			var tip = p.park_name;
+			if (tier === 'none') tip += ' — ' + statusText(p.forecast_status);
+			marker.bindTooltip(tip, { direction: 'top', opacity: 0.9 });
+			wxMarkers.push(marker);
+			wxMarkersByPark[p.park_id] = marker;
+			bounds.push([p.lat, p.lng]);
+		});
+		if (bounds.length) {
+			wxBounds = bounds;
+			wxFitting = true;
+			wxMap.fitBounds(bounds, { padding: [30, 30], maxZoom: 9 });
+			wxMap.once('moveend', function() { wxFitting = false; });
+		}
+		setTimeout(function() { wxMap.invalidateSize(); }, 50);
 	}
 
 	function renderPlay(rows, dayLabel) {
-		var title = dayLabel === 'today' ? '🏕️ Play Today' : '🏕️ Play ' + dayLabel.replace(/\b\w/, function(c) { return c.toUpperCase(); });
-		document.getElementById('wx-play-title').textContent = title;
-		document.getElementById('wx-play-count').textContent = rows.length + (rows.length === 1 ? ' park' : ' parks');
+		var shortDay = dayLabel === 'today' ? 'Today' : dayLabel.slice(0,1).toUpperCase() + dayLabel.slice(1,3);
+		document.getElementById('wx-play-title').textContent = '🏕️ Play ' + shortDay;
 		var body = document.getElementById('wx-play-body');
 		if (!rows.length) {
 			body.innerHTML = '<div class="wx-empty">No in-person play scheduled.</div>';
+			document.getElementById('wx-play-count').textContent = '0 parks';
+			ensurePlayToggle(0, 0);
 			return;
 		}
+		var flaggedCount = 0;
+		rows.forEach(function(p) { if (p.badges && p.badges.length) flaggedCount++; });
+		// Reset the toggle to the default mode for the new day: flagged when
+		// any exist, otherwise all. Re-create the button via ensurePlayToggle.
+		var existingBtn = document.getElementById('wx-play-toggle');
+		if (existingBtn) existingBtn.remove();
 		var html = '';
-		rows.forEach(function(p) {
+		rows.forEach(function(p, i) {
 			var k = shortKingdom(p.kingdom_name || '');
 			var fc = p.forecast || null;
 			var scheds = (p.schedules || []).map(function(s) {
@@ -507,17 +823,176 @@ html[data-theme="dark"] .wx-event-badge-caution { background: #422006; color: #f
 						'</div>';
 				}
 			} else {
-				wx = '<div class="wx-play-empty">forecast unavailable</div>';
+				wx = '<div class="wx-play-empty">' + esc(statusText(p.forecast_status)) + '</div>';
 			}
-			html += '<div class="wx-play-row">' +
+			var coordAttrs = (p.lat != null && p.lng != null)
+				? ' data-lat="' + p.lat + '" data-lng="' + p.lng + '"' : '';
+			var sev = +p._score || 0;
+			var nameAttr = (p.park_name || '').toLowerCase();
+			var flag = (p.badges && p.badges.length) ? '1' : '0';
+			html += '<div class="wx-play-row" data-park-id="' + p.park_id + '"' +
+				' data-park-name="' + esc(nameAttr) + '" data-severity="' + sev + '"' +
+				' data-flagged="' + flag + '"' + coordAttrs + '>' +
 				'<div class="wx-play-main">' +
-					'<div class="wx-play-park"><a href="' + UIR + 'Park/profile/' + p.park_id + '">' + esc(p.park_name) + '</a></div>' +
+					'<div class="wx-play-park"><a href="' + UIR + 'Park/profile/' + p.park_id + '" class="wx-jump" target="_blank" rel="noopener">' + esc(p.park_name) + '</a></div>' +
 					'<div class="wx-play-meta">' + scheds.join(' &middot; ') + (k ? ' &middot; ' + esc(k) : '') + '</div>' +
 				'</div>' +
 				'<div class="wx-play-wx">' + wx + '</div>' +
 			'</div>';
 		});
 		body.innerHTML = html;
+		ensurePlayToggle(flaggedCount, rows.length);
+		applyPlayState();
+	}
+
+	// Label the toggle based on the current mode + whether toggling makes sense.
+	// Modes:
+	//   "flagged" → show only parks with badges, severity-sorted. Default when
+	//               any flagged parks exist.
+	//   "all"     → show every park, alphabetical. Default when nothing's flagged.
+	// Button only appears when both modes would show different content (i.e.
+	// at least one flagged AND at least one unflagged).
+	function labelToggle(btn, flaggedCount, total) {
+		if (!btn) return;
+		var mode = btn.dataset.mode || 'flagged';
+		var hasUnflagged = flaggedCount < total;
+		if (mode === 'flagged') {
+			// Toggle would either reveal unflagged rows OR just re-sort.
+			btn.textContent = hasUnflagged ? 'Show all ' + total : 'A–Z';
+		} else {
+			btn.textContent = hasUnflagged ? 'Show concerns only' : 'By severity';
+		}
+		btn.classList.toggle('active', mode === 'all');
+	}
+
+	function ensurePlayToggle(flaggedCount, total) {
+		var controls = document.querySelector('#wx-play .wx-play-controls');
+		if (!controls) return;
+		var existing = document.getElementById('wx-play-toggle');
+		// Hide toggle only when there's nothing flagged — in that case the
+		// flagged mode would be empty, so default 'all' (alphabetical) and
+		// drop the button.
+		if (flaggedCount <= 0) {
+			if (existing) existing.remove();
+			return;
+		}
+		if (!existing) {
+			existing = document.createElement('button');
+			existing.id = 'wx-play-toggle';
+			existing.className = 'wx-play-toggle';
+			existing.dataset.mode = 'flagged';
+			controls.appendChild(existing);
+			existing.addEventListener('click', function() {
+				existing.dataset.mode = existing.dataset.mode === 'flagged' ? 'all' : 'flagged';
+				var rows = document.querySelectorAll('#wx-play-body .wx-play-row');
+				var f = 0;
+				rows.forEach(function(r) { if (r.dataset.flagged === '1') f++; });
+				labelToggle(existing, f, rows.length);
+				applyPlayState();
+				var body = document.getElementById('wx-play-body');
+				if (body) body.scrollTop = 0;
+			});
+		}
+		labelToggle(existing, flaggedCount, total);
+	}
+
+	// Single source of truth for play-list visibility/order.
+	//   - "flagged" mode (no search): severity-sorted, only data-flagged="1" visible
+	//   - "all" mode OR any search: alphabetical, every matching row visible
+	function applyPlayState() {
+		var body = document.getElementById('wx-play-body');
+		if (!body) return;
+		var rows = Array.prototype.slice.call(body.querySelectorAll('.wx-play-row'));
+		if (!rows.length) return;
+		var searchEl = document.getElementById('wx-play-search');
+		var query = (searchEl && searchEl.value || '').trim().toLowerCase();
+		var toggle = document.getElementById('wx-play-toggle');
+		// Default to 'all' when no toggle present (nothing flagged), 'flagged' otherwise.
+		var mode = toggle ? toggle.dataset.mode : 'all';
+		// Search always shows everything matching, alphabetically — overrides mode.
+		var effectiveMode = query ? 'all' : mode;
+
+		rows.sort(function(a, b) {
+			if (effectiveMode === 'all') {
+				return (a.dataset.parkName || '').localeCompare(b.dataset.parkName || '');
+			}
+			var ds = (+b.dataset.severity || 0) - (+a.dataset.severity || 0);
+			if (ds !== 0) return ds;
+			return (a.dataset.parkName || '').localeCompare(b.dataset.parkName || '');
+		});
+		rows.forEach(function(r) { body.appendChild(r); });
+
+		var flaggedTotal = 0, shown = 0;
+		rows.forEach(function(r) {
+			if (r.dataset.flagged === '1') flaggedTotal++;
+			r.classList.remove('wx-hidden', 'wx-filtered');
+			var name = r.dataset.parkName || '';
+			var matchesQuery = !query || name.indexOf(query) !== -1;
+			if (!matchesQuery) { r.classList.add('wx-filtered'); return; }
+			if (effectiveMode === 'flagged' && r.dataset.flagged !== '1') {
+				r.classList.add('wx-hidden');
+				return;
+			}
+			shown++;
+		});
+
+		// Count: "5 of 162" when filtered, "162 parks" when all, "3 / 162" while searching.
+		var countEl = document.getElementById('wx-play-count');
+		if (countEl) {
+			if (query)                          countEl.textContent = shown + ' / ' + rows.length;
+			else if (effectiveMode === 'flagged') countEl.textContent = shown + ' of ' + rows.length;
+			else                                countEl.textContent = rows.length + (rows.length === 1 ? ' park' : ' parks');
+		}
+
+		// Banner: only visible in flagged mode (not while searching either —
+		// search results aren't a "weather concerns" filter).
+		var card = document.getElementById('wx-play');
+		if (card) card.classList.toggle('is-flagged-mode', effectiveMode === 'flagged');
+
+		// Toggle button: invisible (but space reserved) while searching. The
+		// search already shows "all matching parks" regardless of mode, so the
+		// button would either be a no-op or set stale state for when the
+		// search is cleared. Reserving space prevents header reflow.
+		if (toggle) toggle.classList.toggle('wx-invisible', !!query);
+	}
+
+	// Filter the events list to only show events that haven't ended before the
+	// selected date. Multi-day events remain visible as long as their end date
+	// is on or after the selected date.
+	function applyEventsFilter(date) {
+		var isToday = (date === WX_TODAY);
+		var rows = document.querySelectorAll('#upcoming-events .wx-event');
+		var shown = 0;
+		rows.forEach(function(r) {
+			var end = r.dataset.eventEnd || r.dataset.eventStart || '';
+			var visible = !end || end >= date;
+			r.classList.toggle('wx-hidden', !visible);
+			if (visible) shown++;
+		});
+		var title = document.getElementById('wx-events-title');
+		if (title) {
+			if (isToday) {
+				title.textContent = '📅 Upcoming Events — in the week ahead';
+			} else {
+				var d = new Date(date + 'T00:00:00');
+				var lbl = d.toLocaleDateString([], { weekday: 'short', month: 'short', day: 'numeric' });
+				title.textContent = '📅 Upcoming Events — from ' + lbl;
+			}
+		}
+		var body = document.querySelector('#upcoming-events .wx-events-body');
+		if (body) {
+			var emptyEl = body.querySelector('.wx-events-empty-state');
+			if (shown === 0 && rows.length > 0) {
+				if (!emptyEl) {
+					emptyEl = document.createElement('div');
+					emptyEl.className = 'wx-empty wx-events-empty-state';
+					body.appendChild(emptyEl);
+				}
+				emptyEl.textContent = 'No events on or after this date.';
+			} else if (emptyEl) {
+				emptyEl.remove();
+			}
+		}
 	}
 
 	function activatePill(date) {
@@ -537,6 +1012,7 @@ html[data-theme="dark"] .wx-event-badge-caution { background: #422006; color: #f
 					return;
 				}
 				renderRundown(d.rundown || {}, dayLabel);
+				renderMap(d.play || [], dayLabel);
 				renderPlay(d.play || [], dayLabel);
 			})
 			.catch(function() {
@@ -547,12 +1023,278 @@ html[data-theme="dark"] .wx-event-badge-caution { background: #422006; color: #f
 	document.querySelectorAll('.wx-pill').forEach(function(btn) {
 		btn.addEventListener('click', function() {
 			var date = this.dataset.date;
-			var today = new Date().toISOString().slice(0, 10);
-			var dayLabel = (date === today) ? 'today' :
+			var dayLabel = (date === WX_TODAY) ? 'today' :
 				new Date(date + 'T00:00:00').toLocaleDateString([], { weekday: 'long' });
 			activatePill(date);
+			applyEventsFilter(date);
 			fetchAndRender(date, dayLabel);
 		});
+	});
+
+	// Stash the server-rendered "coming up" paragraph so we can re-insert it
+	// when the user comes back to Today after viewing another day.
+	(function() {
+		var p = document.querySelector('#wx-rundown-body p:last-child');
+		if (p && p.querySelector('a[href="#upcoming-events"]')) {
+			window.WX_COMING_UP_HTML = p.outerHTML;
+		}
+	})();
+
+	// Wire the server-rendered header toggle (initial page load — today's data)
+	(function() {
+		var initialToggle = document.getElementById('wx-play-toggle');
+		if (initialToggle) {
+			initialToggle.addEventListener('click', function() {
+				initialToggle.dataset.mode = initialToggle.dataset.mode === 'flagged' ? 'all' : 'flagged';
+				var rows = document.querySelectorAll('#wx-play-body .wx-play-row');
+				var f = 0;
+				rows.forEach(function(r) { if (r.dataset.flagged === '1') f++; });
+				labelToggle(initialToggle, f, rows.length);
+				applyPlayState();
+				var body = document.getElementById('wx-play-body');
+				if (body) body.scrollTop = 0;
+			});
+		}
+		// Search input: debounced filter
+		var search = document.getElementById('wx-play-search');
+		if (search) {
+			var timer = null;
+			search.addEventListener('input', function() {
+				clearTimeout(timer);
+				timer = setTimeout(applyPlayState, 80);
+			});
+		}
+		// Banner "Show all parks" — delegates to the header toggle so a single
+		// state owns the mode.
+		var modeClear = document.getElementById('wx-play-mode-clear');
+		if (modeClear) {
+			modeClear.addEventListener('click', function() {
+				var t = document.getElementById('wx-play-toggle');
+				if (t) t.click();
+			});
+		}
+		// Normalize count text + banner visibility on first paint
+		applyPlayState();
+		// Apply event date filter for the initially selected date (today on first
+		// load, but correct if someone navigates back with a stale pill state).
+		applyEventsFilter(<?= json_encode($selected) ?>);
+	})();
+
+	// Esc: close any open popup and fly back to the full-map view.
+	document.addEventListener('keydown', function(e) {
+		if (e.key !== 'Escape') return;
+		if (e.target.closest('input, textarea, [contenteditable]')) return;
+		if (wxMap) wxMap.closePopup();
+		fitWxMap();
+	});
+
+	// "Zoom out" button in the map header — same as Esc.
+	document.getElementById('wx-zoom-out').addEventListener('click', function() {
+		if (wxMap) wxMap.closePopup();
+		fitWxMap();
+	});
+
+	// Closing a popup via its × button also zooms back out (only when we
+	// triggered the zoom — wxZoomedIn tracks this).
+	function onMapReady() {
+		// Clear the flag once the new popup is actually open.
+		wxMap.on('popupopen', function() { wxOpeningPopup = false; });
+		// Only zoom out when the popup was closed by the user (× or Esc), not
+		// when it was replaced by another popup (wxOpeningPopup is true then).
+		wxMap.on('popupclose', function() {
+			if (wxZoomedIn && !wxOpeningPopup) fitWxMap();
+		});
+		// Show the "zoom out" button whenever the user manually zooms or pans.
+		// wxFitting suppresses this during our own programmatic flyToBounds calls.
+		wxMap.on('zoomend dragend', function() {
+			if (!wxFitting && wxBounds) setZoomedIn(true);
+		});
+	}
+
+	// Make Leaflet recompute size after the flex layout settles, and on resize.
+	window.addEventListener('resize', function() {
+		if (wxMap) wxMap.invalidateSize();
+	});
+
+	// Render badges as the same colored chips used in the list rows — same
+	// emoji, label visible (since the popup has room), severity-tinted background.
+	function renderBadgeChips(badges) {
+		if (!badges || !badges.length) return '';
+		return '<div class="wx-pp-badges">' + badges.map(function(b) {
+			return '<span class="wx-event-badge wx-event-badge-' + b.severity + '">' + b.icon + ' ' + esc(b.label) + '</span>';
+		}).join('') + '</div>';
+	}
+
+	// Build the same popup body the map markers use, for an event jumped to
+	// without a corresponding park marker. Same .wx-map-popup classes →
+	// matches the styling, dark-mode rules, etc.
+	function buildEventPopup(ev) {
+		var fc = ev.forecast;
+		var wxLine = '';
+		if (fc && fc.hi_f != null) {
+			var loPart = fc.lo_f != null ? ' / L ' + tempPair(fc.lo_f) : '';
+			wxLine = '<div class="wx-pp-wx">' + wxIcon(fc.code) + ' ' + tempPair(fc.hi_f) + loPart + '</div>';
+			wxLine += renderBadgeChips(ev.badges);
+		} else {
+			wxLine = '<div class="wx-pp-meta">forecast unavailable</div>';
+		}
+		var parts = [];
+		if (ev.park_id && ev.park_name) {
+			parts.push('<a href="' + UIR + 'Park/profile/' + ev.park_id + '" target="_blank" rel="noopener">' + esc(ev.park_name) + '</a>');
+		}
+		var k = shortKingdom(ev.kingdom_name || '');
+		if (k) parts.push(esc(k));
+		var locLine = parts.length ? '<div class="wx-pp-meta">' + parts.join(' · ') + '</div>' : '';
+		var dateLine = '';
+		var startStr = ev.event_start ? ev.event_start.slice(0, 10) : '';
+		var endStr   = ev.event_end   ? ev.event_end.slice(0, 10)   : startStr;
+		if (startStr) {
+			var dtS = new Date(startStr + 'T00:00:00');
+			if (!isNaN(dtS)) {
+				var startLabel = dtS.toLocaleDateString([], { weekday: 'short', month: 'short', day: 'numeric' });
+				if (endStr && endStr > startStr) {
+					var dtE = new Date(endStr + 'T00:00:00');
+					var endLabel = !isNaN(dtE) ? dtE.toLocaleDateString([], { month: 'short', day: 'numeric' }) : '';
+					dateLine = '<div class="wx-pp-meta">' + esc(startLabel) + (endLabel ? ' – ' + esc(endLabel) : '') + '</div>';
+				} else {
+					dateLine = '<div class="wx-pp-meta">' + esc(startLabel) + '</div>';
+				}
+			}
+		}
+		return '<div class="wx-map-popup">' +
+			'<div class="wx-pp-name"><a href="' + UIR + 'Event/detail/' + ev.event_id + '/' + ev.event_calendardetail_id + '" target="_blank" rel="noopener">' + esc(ev.name) + '</a></div>' +
+			dateLine + locLine + wxLine +
+		'</div>';
+	}
+
+	// Map-jump: clicking a park/event row (or its link) zooms the map instead
+	// of navigating away. Modifier-key clicks still follow the link so users
+	// can open the profile in a new tab if they want.
+	function flyToPark(parkId) {
+		var pid = parseInt(parkId, 10);
+		var marker = pid ? wxMarkersByPark[pid] : null;
+		if (!marker || !wxMap) return false;
+		var ll = marker.getLatLng();
+		wxMap.flyTo([ll.lat, ll.lng], Math.max(wxMap.getZoom(), 9), { duration: 0.6 });
+		setZoomedIn(true);
+		setTimeout(function() { wxOpeningPopup = true; marker.openPopup(); }, 650);
+		return true;
+	}
+
+	function flyToEvent(ev) {
+		if (!wxMap || !ev) return false;
+		// Anchor the event popup to the host park's marker when that park is
+		// playing today (no duplicate pin), otherwise drop a blue marker at
+		// the event's own coords (cd.lat/lng or at_park).
+		var hostMarker = ev.park_id ? wxMarkersByPark[ev.park_id] : null;
+		var ll;
+		if (hostMarker) {
+			var p = hostMarker.getLatLng();
+			ll = [p.lat, p.lng];
+		} else if (ev.lat != null && ev.lng != null) {
+			ll = [+ev.lat, +ev.lng];
+		} else {
+			return false;
+		}
+		wxMap.flyTo(ll, Math.max(wxMap.getZoom(), 9), { duration: 0.6 });
+		setZoomedIn(true);
+		if (wxTempMarker) { wxMap.removeLayer(wxTempMarker); wxTempMarker = null; }
+		var popup = L.popup({ offset: hostMarker ? [0, -8] : [0, 0] })
+			.setLatLng(ll)
+			.setContent(buildEventPopup(ev));
+		if (!hostMarker) {
+			// Visual anchor for event-only venues
+			wxTempMarker = L.circleMarker(ll, {
+				radius: 9, color: '#3182ce', weight: 2, fillColor: '#3182ce', fillOpacity: 0.6
+			}).addTo(wxMap);
+		}
+		setTimeout(function() { wxOpeningPopup = true; popup.openOn(wxMap); }, 650);
+		return true;
+	}
+
+	function jumpClickHandler(e) {
+		// Let modifier-clicks fall through (open in new tab etc.)
+		if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey || e.button !== 0) return;
+
+		// Rundown park link (top-of-page summary)
+		var jumpLink = e.target.closest('.wx-jump-park');
+		if (jumpLink && jumpLink.dataset.parkId) {
+			if (flyToPark(jumpLink.dataset.parkId)) {
+				e.preventDefault();
+				e.stopPropagation();
+			}
+			return;
+		}
+
+		var row = e.target.closest('.wx-play-row, .wx-event');
+		if (!row || !row.closest('.wx-root')) return;
+		var handled = false;
+		if (row.classList.contains('wx-event')) {
+			var cd = parseInt(row.dataset.eventCdId || '0', 10);
+			var ev = cd && window.WX_EVENTS ? window.WX_EVENTS[cd] : null;
+			if (ev) handled = flyToEvent(ev);
+		} else {
+			handled = flyToPark(row.dataset.parkId);
+		}
+		if (handled) {
+			e.preventDefault();
+			e.stopPropagation();
+			var mapEl = document.getElementById('wx-map');
+			if (mapEl) {
+				var r = mapEl.getBoundingClientRect();
+				if (r.top < 0 || r.bottom > window.innerHeight) {
+					mapEl.scrollIntoView({ behavior: 'smooth', block: 'center' });
+				}
+			}
+		}
+	}
+	document.querySelector('.wx-root').addEventListener('click', jumpClickHandler);
+
+	// Render the map for the initial date using the server-supplied play list
+	function whenLeafletReady(cb) {
+		if (typeof L !== 'undefined') return cb();
+		var s = document.querySelector('script[src*="leaflet.js"]');
+		if (s) s.addEventListener('load', cb);
+		else window.addEventListener('load', cb);
+	}
+	// Events stay the same across date pills (always next-7-days from now), so
+	// dump them once for the click→map-popup flow. Keep as an array (avoids
+	// JSON_FORCE_OBJECT recursing into badges) and build the cd_id lookup in JS.
+	(function() {
+		var rows = <?= json_encode(array_map(function($ev) {
+			return array(
+				'event_id'                => (int)$ev['event_id'],
+				'event_calendardetail_id' => (int)$ev['event_calendardetail_id'],
+				'name'                    => $ev['name'],
+				'park_id'                 => (int)($ev['park_id'] ?? 0),
+				'park_name'               => $ev['park_name'],
+				'kingdom_name'            => $ev['kingdom_name'],
+				'event_start'             => $ev['event_start'],
+				'event_end'               => $ev['event_end'] ?? $ev['event_start'],
+				'lat'                     => $ev['lat'],
+				'lng'                     => $ev['lng'],
+				'forecast'                => $ev['forecast'],
+				'badges'                  => $ev['badges'],
+			);
+		}, $events), JSON_UNESCAPED_SLASHES) ?>;
+		window.WX_EVENTS = {};
+		rows.forEach(function(r) { window.WX_EVENTS[r.event_calendardetail_id] = r; });
+	})();
+
+	whenLeafletReady(function() {
+		var initialPlay = <?= json_encode(array_map(function($p) {
+			return array(
+				'park_id'         => (int)$p['park_id'],
+				'park_name'       => $p['park_name'],
+				'kingdom_name'    => $p['kingdom_name'],
+				'lat'             => $p['lat'],
+				'lng'             => $p['lng'],
+				'forecast'        => $p['forecast'],
+				'forecast_status' => $p['forecast_status'] ?? 'unavailable',
+				'badges'          => $p['badges'],
+			);
+		}, $playToday), JSON_UNESCAPED_SLASHES) ?>;
+		renderMap(initialPlay, 'today');
 	});
 })();
 </script>

--- a/orkui/template/revised-frontend/Weather_index.tpl
+++ b/orkui/template/revised-frontend/Weather_index.tpl
@@ -1,6 +1,9 @@
 <?php
-	$rundown = $Rundown ?? array();
-	$events  = $UpcomingEvents ?? array();
+	$rundown    = $Rundown ?? array();
+	$events     = $UpcomingEvents ?? array();
+	$dateStrip  = $DateStrip ?? array();
+	$playToday  = $PlayToday ?? array();
+	$selected   = $SelectedDate ?? date('Y-m-d');
 
 	// ─── Rundown sentence builder ──────────────────────────────────
 	// Pre-written slot templates; no LLM.
@@ -186,13 +189,41 @@ html[data-theme="dark"] .wx-event-badge-warning { background: #450a0a; color: #f
 html[data-theme="dark"] .wx-event-badge-caution { background: #422006; color: #fcd34d; border-color: #78350f; }
 
 .wx-empty { padding: 30px 12px; text-align: center; color: var(--ork-text-muted, #a0aec0); font-style: italic; }
+
+/* Date strip */
+.wx-strip { display: flex; gap: 6px; margin: 20px 0 14px; flex-wrap: wrap; }
+.wx-pill { flex: 1 1 0; min-width: 70px; padding: 8px 10px; border-radius: 8px; background: var(--ork-card-bg, #fff); border: 1px solid var(--ork-border, #e2e8f0); cursor: pointer; text-align: center; transition: background .12s, border-color .12s, transform .12s; }
+.wx-pill:hover { background: var(--ork-bg-secondary, #f7fafc); }
+.wx-pill.active { border-color: var(--ork-link-bright, #2b6cb0); background: var(--ork-link-bright, #2b6cb0); color: #fff; }
+.wx-pill.active .wx-pill-date { color: rgba(255,255,255,0.85); }
+.wx-pill-day { font-size: 11px; font-weight: 700; text-transform: uppercase; letter-spacing: .06em; }
+.wx-pill-date { font-size: 11px; color: var(--ork-text-muted, #718096); margin-top: 2px; }
+
+/* Play list */
+.wx-play { background: var(--ork-card-bg, #fff); border: 1px solid var(--ork-border, #e2e8f0); border-radius: 10px; padding: 14px 18px; margin-bottom: 20px; }
+.wx-play-header { display: flex; align-items: center; justify-content: space-between; margin-bottom: 12px; padding-bottom: 8px; border-bottom: 1px solid var(--ork-border, #e2e8f0); }
+.wx-play-header h2 { margin: 0; font-size: 14px; font-weight: 700; text-transform: uppercase; letter-spacing: .08em; color: var(--ork-text-muted, #718096); background: none; border: none; padding: 0; border-radius: 0; text-shadow: none; box-shadow: none; }
+.wx-play-count { font-size: 11px; color: var(--ork-text-muted, #a0aec0); }
+.wx-play-row { display: grid; grid-template-columns: 1fr auto; gap: 14px; padding: 9px 0; border-bottom: 1px solid var(--ork-border, #edf2f7); align-items: center; }
+.wx-play-row:last-child { border-bottom: 0; }
+.wx-play-main { min-width: 0; }
+.wx-play-park { font-size: 14px; font-weight: 600; color: var(--ork-text, #2d3748); }
+.wx-play-park a { color: inherit; text-decoration: none; }
+.wx-play-park a:hover { color: var(--ork-link-bright, #2b6cb0); }
+.wx-play-meta { font-size: 11.5px; color: var(--ork-text-muted, #718096); margin-top: 2px; }
+.wx-play-wx { text-align: right; font-size: 13px; min-width: 130px; }
+.wx-play-wx .wx-play-temps { font-weight: 600; color: var(--ork-text, #2d3748); }
+.wx-play-wx .wx-play-empty { font-size: 11px; color: var(--ork-text-muted, #a0aec0); font-style: italic; }
+
+.wx-loading { padding: 20px; text-align: center; color: var(--ork-text-muted, #a0aec0); font-style: italic; }
 </style>
 
-<div class="wx-root">
+<div class="wx-root" data-selected-date="<?= htmlspecialchars($selected) ?>">
 
 	<!-- ── Rundown ──────────────────────────────────────────── -->
-	<div class="wx-rundown">
+	<div class="wx-rundown" id="wx-rundown">
 		<h2>🌤️ Amtgard Weather This Week</h2>
+		<div id="wx-rundown-body">
 		<?php if (!empty($leadParts)): ?>
 			<p><?= implode(' ', $leadParts) ?></p>
 		<?php endif; ?>
@@ -202,6 +233,72 @@ html[data-theme="dark"] .wx-event-badge-caution { background: #422006; color: #f
 		<?php if ($comingUp): ?>
 			<p><?= $comingUp ?></p>
 		<?php endif; ?>
+		</div>
+	</div>
+
+	<!-- ── Date strip ─────────────────────────────────────── -->
+	<div class="wx-strip" id="wx-strip">
+		<?php foreach ($dateStrip as $pill): ?>
+			<button class="wx-pill<?= $pill['is_today'] ? ' active' : '' ?>"
+			        data-date="<?= htmlspecialchars($pill['date']) ?>">
+				<div class="wx-pill-day"><?= htmlspecialchars($pill['day_label']) ?></div>
+				<div class="wx-pill-date"><?= htmlspecialchars($pill['date_label']) ?></div>
+			</button>
+		<?php endforeach; ?>
+	</div>
+
+	<!-- ── Play list (for selected day) ───────────────────── -->
+	<div class="wx-play" id="wx-play">
+		<div class="wx-play-header">
+			<h2 id="wx-play-title">🏕️ Play Today</h2>
+			<span class="wx-play-count" id="wx-play-count"><?= count($playToday) ?> parks</span>
+		</div>
+		<div id="wx-play-body">
+			<?php if (empty($playToday)): ?>
+				<div class="wx-empty">No in-person play scheduled.</div>
+			<?php else: ?>
+				<?php foreach ($playToday as $p):
+					$fc = $p['forecast'] ?? null;
+					$kshort = Weather::short_kingdom($p['kingdom_name'] ?? '');
+					$scheds = array();
+					foreach ($p['schedules'] as $s) {
+						$t = $s['time'] ? date('g:i A', strtotime($s['time'])) : '';
+						$scheds[] = htmlspecialchars($s['purpose']) . ($t ? " at $t" : '');
+					}
+				?>
+				<div class="wx-play-row">
+					<div class="wx-play-main">
+						<div class="wx-play-park">
+							<a href="<?= UIR ?>Park/profile/<?= (int)$p['park_id'] ?>"><?= htmlspecialchars($p['park_name']) ?></a>
+						</div>
+						<div class="wx-play-meta">
+							<?= implode(' &middot; ', $scheds) ?><?php if ($kshort): ?> &middot; <?= htmlspecialchars($kshort) ?><?php endif; ?>
+						</div>
+					</div>
+					<div class="wx-play-wx">
+						<?php if ($fc && $fc['hi_f'] !== null):
+							$hiC = round(($fc['hi_f'] - 32) * 5 / 9);
+							$loC = $fc['lo_f'] !== null ? round(($fc['lo_f'] - 32) * 5 / 9) : null;
+						?>
+							<div class="wx-play-temps">
+								<?= $wxIcon($fc['code']) ?>
+								<?= round($fc['hi_f']) ?>/<?= $hiC ?>°<?php if ($fc['lo_f'] !== null): ?> · L <?= round($fc['lo_f']) ?>/<?= $loC ?>°<?php endif; ?>
+							</div>
+							<?php if (!empty($p['badges'])): ?>
+								<div class="wx-play-meta">
+									<?php foreach ($p['badges'] as $b): ?>
+										<span class="wx-event-badge wx-event-badge-<?= $b['severity'] ?>" title="<?= htmlspecialchars($b['label']) ?>"><?= $b['icon'] ?></span>
+									<?php endforeach; ?>
+								</div>
+							<?php endif; ?>
+						<?php else: ?>
+							<div class="wx-play-empty">forecast unavailable</div>
+						<?php endif; ?>
+					</div>
+				</div>
+				<?php endforeach; ?>
+			<?php endif; ?>
+		</div>
 	</div>
 
 	<!-- ── Upcoming Events ─────────────────────────────────── -->
@@ -275,16 +372,187 @@ html[data-theme="dark"] .wx-event-badge-caution { background: #422006; color: #f
 </div>
 
 <script>
-// Park link clicks: for v1, scroll to a future map placeholder. With no map
-// on the page yet, fall back to opening the park profile.
-document.querySelectorAll('.wx-jump-park').forEach(function(a) {
-	a.addEventListener('click', function(e) {
-		if (!document.getElementById('weather-map')) {
-			// No map yet — let the default # anchor jump do nothing, navigate to the park profile instead.
-			e.preventDefault();
-			var pid = this.dataset.parkId;
-			if (pid) window.location.href = '<?= UIR ?>Park/profile/' + pid;
+(function() {
+	var UIR = '<?= UIR ?>';
+	var wxIcon = function(c) {
+		c = +c;
+		if (c === 0)                  return '☀️';
+		if (c === 1)                  return '🌤️';
+		if (c === 2)                  return '⛅';
+		if (c === 3)                  return '☁️';
+		if (c === 45 || c === 48)     return '🌫️';
+		if (c >= 51 && c <= 57)       return '🌦️';
+		if (c >= 61 && c <= 67)       return '🌧️';
+		if (c >= 71 && c <= 77)       return '❄️';
+		if (c >= 80 && c <= 82)       return '🌦️';
+		if (c === 85 || c === 86)     return '🌨️';
+		if (c >= 95 && c <= 99)       return '⛈️';
+		return '🌡️';
+	};
+	function esc(s) { return String(s == null ? '' : s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;'); }
+	function tempPair(f) { var c = Math.round((f - 32) * 5 / 9); return Math.round(f) + '/' + c + '°'; }
+
+	// Kingdom-name shortener mirrors Weather::short_kingdom in PHP
+	function shortKingdom(name) {
+		if (!name) return '';
+		if (/Freeholds/i.test(name)) return '';
+		var m = name.match(/^The (.+ Kingdom)$/i);
+		if (m) return 'the ' + m[1];
+		return name.replace(/^The /i, '').replace(/^(Kingdom|Empire|Principality) of /i, '');
+	}
+
+	function rollupKingdoms(map, max) {
+		max = max || 5;
+		if (!map) return '';
+		var arr = Object.keys(map).map(function(k) { return [k, map[k]]; });
+		arr.sort(function(a, b) { return b[1] - a[1]; });
+		arr = arr.slice(0, max);
+		var names = arr.map(function(e) { return shortKingdom(e[0]); }).filter(function(s) { return s; });
+		if (names.length === 0) return '';
+		if (names.length === 1) return names[0];
+		if (names.length === 2) return names[0] + ' and ' + names[1];
+		return names.slice(0, -1).join(', ') + ', and ' + names[names.length - 1];
+	}
+
+	function renderRundown(r, dayLabel) {
+		var bc = r.badge_counts || {}, bk = r.badge_kingdoms || {};
+		var standout = r.standout_park || null;
+		var leadParts = [];
+		var noPlay = r.no_play_today;
+		var noFlags = Object.keys(bc).length === 0;
+		if (noPlay) {
+			leadParts.push('No parks have in-person play scheduled for ' + dayLabel + '.');
+		} else if (noFlags) {
+			leadParts.push('Of the parks playing ' + dayLabel + ', conditions look favorable across the board — no warnings flagged.');
+		} else {
+			if (bc['Thunderstorms']) {
+				var n = bc['Thunderstorms'], k = rollupKingdoms(bk['Thunderstorms']);
+				leadParts.push('Of parks playing ' + dayLabel + ', ' + n + ' ' + (n === 1 ? 'faces' : 'face') + ' thunderstorms' + (k ? ' — primarily in ' + k : '') + '.');
+			}
+			if (bc['Extreme heat']) {
+				var n = bc['Extreme heat'];
+				leadParts.push((n === 1 ? 'One park playing ' + dayLabel + ' is' : n + ' parks playing ' + dayLabel + ' are') + ' facing extreme heat.');
+			}
+			if (bc['Frostbite risk']) {
+				var n = bc['Frostbite risk'];
+				leadParts.push((n === 1 ? 'One park playing ' + dayLabel + ' is' : n + ' parks playing ' + dayLabel + ' are') + ' under frostbite-risk conditions.');
+			}
+			if (bc['Severe wind']) {
+				var n = bc['Severe wind'], k = rollupKingdoms(bk['Severe wind']);
+				leadParts.push('Severe wind gusts (40+ mph / 65+ km/h) at ' + n + ' ' + (n === 1 ? 'park' : 'parks') + ' playing ' + dayLabel + (k ? ', across ' + k : '') + '.');
+			}
+			if (bc['Very high UV']) {
+				var n = bc['Very high UV'], k = rollupKingdoms(bk['Very high UV']);
+				leadParts.push('Very high UV at ' + n + ' ' + (n === 1 ? 'park' : 'parks') + ' playing ' + dayLabel + (k ? ' in ' + k : '') + '.');
+			}
 		}
+
+		var standoutLine = '';
+		if (standout) {
+			var icons = { 'Extreme heat':'🥵', 'Frostbite risk':'🥶', 'Thunderstorms':'⛈️', 'Severe wind':'💨', 'Very high UV':'🌞' };
+			var pieces = (standout.flags || []).map(function(f) { return (icons[f] || '⚠️') + ' ' + esc(f); });
+			standoutLine = '<a href="' + UIR + 'Park/profile/' + standout.park_id + '" class="wx-jump-park" data-park-id="' + standout.park_id + '">' + esc(standout.name) + '</a> carries the worst forecast — ' + pieces.join(' · ');
+			if (standout.app_hi_f != null) {
+				standoutLine += ' (' + tempPair(standout.app_hi_f) + ' apparent).';
+			} else {
+				standoutLine += '.';
+			}
+		}
+
+		// Coming-up: ALWAYS today-relative — keep this constant even when pills shift.
+		// We don't have the event count in the per-day response (we only computed it
+		// for today on initial load), so leave the existing paragraph untouched.
+
+		var html = '';
+		if (leadParts.length) html += '<p>' + leadParts.join(' ') + '</p>';
+		if (standoutLine)     html += '<p>' + standoutLine + '</p>';
+		// Preserve the existing 'coming up' paragraph (it's today-relative, not day-scoped)
+		var existingComingUp = document.querySelector('#wx-rundown-body p:last-child');
+		var preservedComingUp = '';
+		if (existingComingUp && existingComingUp.querySelector('a[href="#upcoming-events"]')) {
+			preservedComingUp = existingComingUp.outerHTML;
+		}
+		document.getElementById('wx-rundown-body').innerHTML = html + preservedComingUp;
+	}
+
+	function renderPlay(rows, dayLabel) {
+		var title = dayLabel === 'today' ? '🏕️ Play Today' : '🏕️ Play ' + dayLabel.replace(/\b\w/, function(c) { return c.toUpperCase(); });
+		document.getElementById('wx-play-title').textContent = title;
+		document.getElementById('wx-play-count').textContent = rows.length + (rows.length === 1 ? ' park' : ' parks');
+		var body = document.getElementById('wx-play-body');
+		if (!rows.length) {
+			body.innerHTML = '<div class="wx-empty">No in-person play scheduled.</div>';
+			return;
+		}
+		var html = '';
+		rows.forEach(function(p) {
+			var k = shortKingdom(p.kingdom_name || '');
+			var fc = p.forecast || null;
+			var scheds = (p.schedules || []).map(function(s) {
+				var t = '';
+				if (s.time) {
+					var parts = s.time.split(':');
+					var d = new Date(); d.setHours(+parts[0], +parts[1] || 0, 0, 0);
+					t = d.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' });
+				}
+				return esc(s.purpose) + (t ? ' at ' + t : '');
+			});
+			var wx = '';
+			if (fc && fc.hi_f != null) {
+				var loPart = fc.lo_f != null ? ' · L ' + tempPair(fc.lo_f) : '';
+				wx = '<div class="wx-play-temps">' + wxIcon(fc.code) + ' ' + tempPair(fc.hi_f) + loPart + '</div>';
+				if (p.badges && p.badges.length) {
+					wx += '<div class="wx-play-meta">' +
+						p.badges.map(function(b) { return '<span class="wx-event-badge wx-event-badge-' + b.severity + '" title="' + esc(b.label) + '">' + b.icon + '</span>'; }).join(' ') +
+						'</div>';
+				}
+			} else {
+				wx = '<div class="wx-play-empty">forecast unavailable</div>';
+			}
+			html += '<div class="wx-play-row">' +
+				'<div class="wx-play-main">' +
+					'<div class="wx-play-park"><a href="' + UIR + 'Park/profile/' + p.park_id + '">' + esc(p.park_name) + '</a></div>' +
+					'<div class="wx-play-meta">' + scheds.join(' &middot; ') + (k ? ' &middot; ' + esc(k) : '') + '</div>' +
+				'</div>' +
+				'<div class="wx-play-wx">' + wx + '</div>' +
+			'</div>';
+		});
+		body.innerHTML = html;
+	}
+
+	function activatePill(date) {
+		document.querySelectorAll('.wx-pill').forEach(function(b) {
+			b.classList.toggle('active', b.dataset.date === date);
+		});
+		document.querySelector('.wx-root').dataset.selectedDate = date;
+	}
+
+	function fetchAndRender(date, dayLabel) {
+		document.getElementById('wx-play-body').innerHTML = '<div class="wx-loading">Loading…</div>';
+		fetch(UIR + 'Weather/day/' + date, { credentials: 'same-origin' })
+			.then(function(r) { return r.json(); })
+			.then(function(d) {
+				if (!d || d.status !== 0) {
+					document.getElementById('wx-play-body').innerHTML = '<div class="wx-empty">Could not load weather.</div>';
+					return;
+				}
+				renderRundown(d.rundown || {}, dayLabel);
+				renderPlay(d.play || [], dayLabel);
+			})
+			.catch(function() {
+				document.getElementById('wx-play-body').innerHTML = '<div class="wx-empty">Request failed.</div>';
+			});
+	}
+
+	document.querySelectorAll('.wx-pill').forEach(function(btn) {
+		btn.addEventListener('click', function() {
+			var date = this.dataset.date;
+			var today = new Date().toISOString().slice(0, 10);
+			var dayLabel = (date === today) ? 'today' :
+				new Date(date + 'T00:00:00').toLocaleDateString([], { weekday: 'long' });
+			activatePill(date);
+			fetchAndRender(date, dayLabel);
+		});
 	});
-});
+})();
 </script>

--- a/orkui/template/revised-frontend/Weather_index.tpl
+++ b/orkui/template/revised-frontend/Weather_index.tpl
@@ -1,0 +1,290 @@
+<?php
+	$rundown = $Rundown ?? array();
+	$events  = $UpcomingEvents ?? array();
+
+	// ─── Rundown sentence builder ──────────────────────────────────
+	// Pre-written slot templates; no LLM.
+	$parts = array();
+
+	$bc      = $rundown['badge_counts']   ?? array();
+	$bk      = $rundown['badge_kingdoms'] ?? array();
+	$standout = $rundown['standout_park'] ?? null;
+	$ec      = (int)($rundown['event_count']      ?? 0);
+	$econ    = (int)($rundown['event_concerning'] ?? 0);
+
+	// Helper: format a list of kingdom rollups (top N) for a badge label
+	$wxRollupKingdoms = function($map, $max = 5) {
+		if (!is_array($map)) return '';
+		arsort($map);
+		$top = array_slice($map, 0, $max, true);
+		$names = array();
+		foreach ($top as $k => $count) {
+			$short = Weather::short_kingdom($k);
+			if ($short !== '') $names[] = $short;
+		}
+		$n = count($names);
+		if ($n === 0) return '';
+		if ($n === 1) return $names[0];
+		if ($n === 2) return $names[0] . ' and ' . $names[1];
+		return implode(', ', array_slice($names, 0, -1)) . ', and ' . end($names);
+	};
+
+	// Helper: park name as a link, "the Kingdom of Foo" suffix only when kingdom is non-Freeholds
+	$wxParkLink = function($p) {
+		if (!$p) return '';
+		$name = htmlspecialchars($p['name'] ?? 'a park');
+		$pid  = (int)($p['park_id'] ?? 0);
+		if ($pid > 0) {
+			return '<a href="#weather-map" data-park-id="' . $pid . '" class="wx-jump-park">' . $name . '</a>';
+		}
+		return $name;
+	};
+
+	$wxTemp = function($f) {
+		if ($f === null) return '';
+		$c = round(($f - 32) * 5 / 9);
+		return round($f) . '°F / ' . $c . '°C';
+	};
+
+	// ─── Lead sentence(s). Counts here are scoped to parks with in-person play today —
+	//    so a 113°F forecast at a park with no scheduled play doesn't show up,
+	//    keeping the rundown actionable for "should I head out tonight?".
+	$leadParts = array();
+	$noPlayToday = !empty($rundown['no_play_today']);
+	$nothingFlagged = empty($bc);
+	if ($noPlayToday) {
+		$leadParts[] = 'No parks have in-person play scheduled for today.';
+	} elseif ($nothingFlagged) {
+		$leadParts[] = 'Of the parks playing today, conditions look favorable across the board — no warnings flagged.';
+	} else {
+		if (!empty($bc['Thunderstorms'])) {
+			$n = $bc['Thunderstorms'];
+			$kingdoms = $wxRollupKingdoms($bk['Thunderstorms'] ?? array());
+			$leadParts[] = "Of parks playing today, $n " . ($n === 1 ? 'faces' : 'face') . ' thunderstorms' .
+				($kingdoms ? " — primarily in $kingdoms" : '') . '.';
+		}
+		if (!empty($bc['Extreme heat'])) {
+			$n = $bc['Extreme heat'];
+			$leadParts[] = ($n === 1 ? 'One park playing today is' : "$n parks playing today are") . ' facing extreme heat.';
+		}
+		if (!empty($bc['Frostbite risk'])) {
+			$n = $bc['Frostbite risk'];
+			$leadParts[] = ($n === 1 ? 'One park playing today is' : "$n parks playing today are") . ' under frostbite-risk conditions.';
+		}
+		if (!empty($bc['Severe wind'])) {
+			$n = $bc['Severe wind'];
+			$kingdoms = $wxRollupKingdoms($bk['Severe wind'] ?? array());
+			$leadParts[] = "Severe wind gusts (40+ mph / 65+ km/h) at $n " . ($n === 1 ? 'park' : 'parks') . ' playing today' .
+				($kingdoms ? ", across $kingdoms" : '') . '.';
+		}
+		if (!empty($bc['Very high UV'])) {
+			$n = $bc['Very high UV'];
+			$kingdoms = $wxRollupKingdoms($bk['Very high UV'] ?? array());
+			$leadParts[] = "Very high UV at $n " . ($n === 1 ? 'park' : 'parks') . ' playing today' .
+				($kingdoms ? " in $kingdoms" : '') . '.';
+		}
+	}
+
+	// ─── Standout park callout (one line about the worst-hit park)
+	$standoutLine = '';
+	if ($standout) {
+		$flags = $standout['flags'] ?? array();
+		$icons = array(
+			'Extreme heat'   => '🥵',
+			'Frostbite risk' => '🥶',
+			'Thunderstorms'  => '⛈️',
+			'Severe wind'    => '💨',
+			'Very high UV'   => '🌞',
+		);
+		$pieces = array();
+		foreach ($flags as $f) {
+			$pieces[] = ($icons[$f] ?? '⚠️') . ' ' . htmlspecialchars($f);
+		}
+		$standoutLine = $wxParkLink($standout) . ' carries the worst forecast — ' . implode(' · ', $pieces);
+		if (!empty($standout['app_hi_f'])) {
+			$standoutLine .= ' (' . $wxTemp($standout['app_hi_f']) . ' apparent).';
+		} else {
+			$standoutLine .= '.';
+		}
+	}
+
+	// ─── Coming-up sentence
+	$comingUp = '';
+	if ($ec > 0) {
+		$comingUp = '<a href="#upcoming-events" class="wx-events-link">' . $ec . ' ' . ($ec === 1 ? 'event' : 'events') .
+			' scheduled in the next 7 days</a>.';
+		if ($econ > 0) {
+			$comingUp .= ' ' . $econ . ' ' . ($econ === 1 ? 'falls' : 'fall') . ' on days with concerning forecasts; the rest look favorable.';
+		} else {
+			$comingUp .= ' All look favorable.';
+		}
+	}
+
+	// ─── Fallback
+	if (empty($leadParts) && !$standoutLine && !$comingUp) {
+		$leadParts[] = 'Calm conditions across the realm today.';
+	}
+
+	// WMO code → emoji (used by the events list)
+	$wxIcon = function($c) {
+		$c = (int)$c;
+		if ($c === 0)                          return '☀️';
+		if ($c === 1)                          return '🌤️';
+		if ($c === 2)                          return '⛅';
+		if ($c === 3)                          return '☁️';
+		if ($c === 45 || $c === 48)            return '🌫️';
+		if ($c >= 51 && $c <= 57)              return '🌦️';
+		if ($c >= 61 && $c <= 67)              return '🌧️';
+		if ($c >= 71 && $c <= 77)              return '❄️';
+		if ($c >= 80 && $c <= 82)              return '🌦️';
+		if ($c === 85 || $c === 86)            return '🌨️';
+		if ($c >= 95 && $c <= 99)              return '⛈️';
+		return '🌡️';
+	};
+?>
+
+<style>
+.wx-root { max-width: 1100px; margin: 0 auto; padding: 16px 12px 40px; }
+.wx-rundown { background: var(--ork-card-bg, #fff); border: 1px solid var(--ork-border, #e2e8f0); border-radius: 10px; padding: 18px 22px; margin-bottom: 20px; box-shadow: 0 1px 3px rgba(0,0,0,0.04); }
+.wx-rundown h2 { margin: 0 0 10px; font-size: 14px; font-weight: 700; text-transform: uppercase; letter-spacing: .08em; color: var(--ork-text-muted, #718096); background: none; border: none; padding: 0; border-radius: 0; text-shadow: none; box-shadow: none; }
+.wx-rundown p { margin: 0 0 8px; font-size: 14.5px; line-height: 1.55; color: var(--ork-text, #2d3748); }
+.wx-rundown p:last-child { margin-bottom: 0; }
+.wx-rundown .wx-jump-park { color: var(--ork-link-bright, #2b6cb0); font-weight: 600; text-decoration: none; border-bottom: 1px dotted currentColor; cursor: pointer; }
+.wx-rundown .wx-jump-park:hover { border-bottom-style: solid; }
+.wx-rundown .wx-events-link { color: var(--ork-link-bright, #2b6cb0); text-decoration: none; border-bottom: 1px dotted currentColor; }
+.wx-rundown .wx-events-link::after { content: ' ↓'; opacity: .6; }
+.wx-rundown .wx-events-link:hover { border-bottom-style: solid; }
+
+.wx-events { background: var(--ork-card-bg, #fff); border: 1px solid var(--ork-border, #e2e8f0); border-radius: 10px; padding: 14px 18px; }
+.wx-events-header { display: flex; align-items: center; justify-content: space-between; margin-bottom: 12px; padding-bottom: 8px; border-bottom: 1px solid var(--ork-border, #e2e8f0); }
+.wx-events-header h2 { margin: 0; font-size: 14px; font-weight: 700; text-transform: uppercase; letter-spacing: .08em; color: var(--ork-text-muted, #718096); background: none; border: none; padding: 0; border-radius: 0; text-shadow: none; box-shadow: none; }
+.wx-events-header .wx-events-attr { font-size: 11px; color: var(--ork-text-muted, #a0aec0); }
+.wx-events-header .wx-events-attr a { color: inherit; text-decoration: none; }
+.wx-events-header .wx-events-attr a:hover { color: var(--ork-link); }
+
+.wx-event { display: grid; grid-template-columns: 70px 1fr auto; gap: 14px; padding: 10px 0; border-bottom: 1px solid var(--ork-border, #edf2f7); align-items: center; }
+.wx-event:last-child { border-bottom: 0; }
+.wx-event-date { font-size: 12px; color: var(--ork-text-muted, #718096); font-variant-numeric: tabular-nums; text-align: center; }
+.wx-event-date .wx-event-month { display: block; font-size: 10px; text-transform: uppercase; letter-spacing: .08em; }
+.wx-event-date .wx-event-day   { display: block; font-size: 20px; font-weight: 700; color: var(--ork-text, #2d3748); line-height: 1.1; }
+.wx-event-date .wx-event-dow   { display: block; font-size: 10px; }
+.wx-event-main { min-width: 0; }
+.wx-event-name { font-size: 14.5px; font-weight: 600; color: var(--ork-text, #2d3748); }
+.wx-event-name a { color: inherit; text-decoration: none; }
+.wx-event-name a:hover { color: var(--ork-link-bright, #2b6cb0); }
+.wx-event-loc { font-size: 12px; color: var(--ork-text-muted, #718096); margin-top: 2px; }
+.wx-event-loc a { color: inherit; text-decoration: none; }
+.wx-event-loc a:hover { text-decoration: underline; }
+.wx-event-wx { text-align: right; font-size: 13px; min-width: 130px; }
+.wx-event-wx .wx-event-temps { font-weight: 600; color: var(--ork-text, #2d3748); }
+.wx-event-wx .wx-event-meta { font-size: 11px; color: var(--ork-text-muted, #718096); margin-top: 1px; }
+.wx-event-wx .wx-event-empty { font-size: 11px; color: var(--ork-text-muted, #a0aec0); font-style: italic; }
+.wx-event-badge { display: inline-block; padding: 1px 6px; border-radius: 10px; font-size: 10px; font-weight: 600; margin-left: 4px; vertical-align: middle; }
+.wx-event-badge-warning { background: #fee2e2; color: #991b1b; border: 1px solid #fca5a5; }
+.wx-event-badge-caution { background: #fef3c7; color: #92400e; border: 1px solid #fcd34d; }
+html[data-theme="dark"] .wx-event-badge-warning { background: #450a0a; color: #fca5a5; border-color: #7f1d1d; }
+html[data-theme="dark"] .wx-event-badge-caution { background: #422006; color: #fcd34d; border-color: #78350f; }
+
+.wx-empty { padding: 30px 12px; text-align: center; color: var(--ork-text-muted, #a0aec0); font-style: italic; }
+</style>
+
+<div class="wx-root">
+
+	<!-- ── Rundown ──────────────────────────────────────────── -->
+	<div class="wx-rundown">
+		<h2>🌤️ Amtgard Weather This Week</h2>
+		<?php if (!empty($leadParts)): ?>
+			<p><?= implode(' ', $leadParts) ?></p>
+		<?php endif; ?>
+		<?php if ($standoutLine): ?>
+			<p><?= $standoutLine ?></p>
+		<?php endif; ?>
+		<?php if ($comingUp): ?>
+			<p><?= $comingUp ?></p>
+		<?php endif; ?>
+	</div>
+
+	<!-- ── Upcoming Events ─────────────────────────────────── -->
+	<div class="wx-events" id="upcoming-events">
+		<div class="wx-events-header">
+			<h2>📅 Upcoming Events — next 7 days</h2>
+			<span class="wx-events-attr">Weather by <a href="https://open-meteo.com/" target="_blank" rel="noopener">Open-Meteo</a></span>
+		</div>
+
+		<?php if (empty($events)): ?>
+			<div class="wx-empty">No events scheduled in the next 7 days.</div>
+		<?php else: ?>
+			<?php foreach ($events as $ev):
+				$ts = strtotime($ev['event_start']);
+				$dayDate = substr($ev['event_start'], 0, 10);
+				$today = date('Y-m-d');
+				$isToday = ($dayDate === $today);
+			?>
+			<div class="wx-event">
+				<div class="wx-event-date">
+					<span class="wx-event-month"><?= date('M', $ts) ?></span>
+					<span class="wx-event-day"><?= date('j', $ts) ?></span>
+					<span class="wx-event-dow"><?= $isToday ? 'Today' : date('D', $ts) ?></span>
+				</div>
+				<div class="wx-event-main">
+					<div class="wx-event-name">
+						<a href="<?= UIR ?>Event/detail/<?= (int)$ev['event_id'] ?>/<?= (int)$ev['event_calendardetail_id'] ?>">
+							<?= htmlspecialchars($ev['name']) ?>
+						</a>
+					</div>
+					<div class="wx-event-loc">
+						<?php $kingdomShort = Weather::short_kingdom($ev['kingdom_name'] ?? '');
+						      $parts = array();
+						      if (!empty($ev['park_id']) && !empty($ev['park_name'])) {
+						          $parts[] = '<a href="' . UIR . 'Park/profile/' . (int)$ev['park_id'] . '">' . htmlspecialchars($ev['park_name']) . '</a>';
+						      }
+						      if ($kingdomShort !== '') $parts[] = htmlspecialchars($kingdomShort);
+						      echo implode(' · ', $parts);
+						?>
+					</div>
+				</div>
+				<div class="wx-event-wx">
+					<?php $fc = $ev['forecast'] ?? null;
+					      if ($fc && $fc['hi_f'] !== null):
+					          $hiC = round(($fc['hi_f'] - 32) * 5 / 9);
+					          $loC = $fc['lo_f'] !== null ? round(($fc['lo_f'] - 32) * 5 / 9) : null;
+					?>
+						<div class="wx-event-temps">
+							<?= $wxIcon($fc['code']) ?>
+							<?= round($fc['hi_f']) ?>/<?= $hiC ?>°<?php if ($fc['lo_f'] !== null): ?> · L <?= round($fc['lo_f']) ?>/<?= $loC ?>°<?php endif; ?>
+						</div>
+						<?php if (!empty($fc['precip_pct']) && $fc['precip_pct'] >= 20): ?>
+							<div class="wx-event-meta"><?= (int)$fc['precip_pct'] ?>% rain</div>
+						<?php endif; ?>
+						<?php if (!empty($ev['badges'])): ?>
+							<div class="wx-event-meta">
+								<?php foreach ($ev['badges'] as $b): ?>
+									<span class="wx-event-badge wx-event-badge-<?= $b['severity'] ?>" title="<?= htmlspecialchars($b['label']) ?>"><?= $b['icon'] ?></span>
+								<?php endforeach; ?>
+							</div>
+						<?php endif; ?>
+					<?php else: ?>
+						<div class="wx-event-empty">forecast unavailable</div>
+					<?php endif; ?>
+				</div>
+			</div>
+			<?php endforeach; ?>
+		<?php endif; ?>
+	</div>
+
+</div>
+
+<script>
+// Park link clicks: for v1, scroll to a future map placeholder. With no map
+// on the page yet, fall back to opening the park profile.
+document.querySelectorAll('.wx-jump-park').forEach(function(a) {
+	a.addEventListener('click', function(e) {
+		if (!document.getElementById('weather-map')) {
+			// No map yet — let the default # anchor jump do nothing, navigate to the park profile instead.
+			e.preventDefault();
+			var pid = this.dataset.parkId;
+			if (pid) window.location.href = '<?= UIR ?>Park/profile/' + pid;
+		}
+	});
+});
+</script>

--- a/orkui/template/revised-frontend/style/revised.css
+++ b/orkui/template/revised-frontend/style/revised.css
@@ -7161,6 +7161,9 @@ html[data-theme="dark"] .kn-ac-item.kn-ac-focused {
 html[data-theme="dark"] .pk-stat-value {
   color: hsl(var(--pk-hue), var(--pk-sat), var(--ork-accent-lightness, 65%));
 }
+html[data-theme="dark"] .pk-stat-sub {
+  color: var(--ork-text-muted);
+}
 html[data-theme="dark"] #theme_container .pk-link-list a,
 html[data-theme="dark"] #theme_container .pk-officer-name a,
 html[data-theme="dark"] #theme_container .pk-about-text a,

--- a/system/lib/ork3/class.Live.php
+++ b/system/lib/ork3/class.Live.php
@@ -125,6 +125,22 @@ class Live extends Ork3 {
 					$response['parks'][$pid]['lng']        = (float)$rs->longitude;
 				}
 			}
+
+			// Per-park weather (compact). One DB read; at most one upstream
+			// fetch shared across all parks if the cache is stale.
+			$wx_rows = Ork3::$Lib->weather->for_parks($park_ids);
+			foreach ($wx_rows as $pid => $wx) {
+				if (!isset($response['parks'][$pid])) continue;
+				$response['parks'][$pid]['weather'] = array(
+					'temp_f'     => $wx['current_temp_f'],
+					'code'       => $wx['current_code'],
+					'is_day'     => $wx['current_is_day'],
+					'wind_mph'   => $wx['current_wind_mph'],
+					'hi_f'       => $wx['today_high_f'],
+					'lo_f'       => $wx['today_low_f'],
+					'precip_pct' => $wx['today_precip_pct'],
+				);
+			}
 		}
 
 		// Hydrate event metadata + resolve coords (own → at_park → none)

--- a/system/lib/ork3/class.Weather.php
+++ b/system/lib/ork3/class.Weather.php
@@ -26,6 +26,17 @@ class Weather extends Ork3 {
 
 	// Open-Meteo endpoints (no API key required)
 	const URL_FORECAST = 'https://api.open-meteo.com/v1/forecast';
+	const URL_ARCHIVE  = 'https://archive-api.open-meteo.com/v1/archive';
+
+	// Open-Meteo's archive (ERA5) has roughly a 5-day lag — dates closer than
+	// this to today don't have archive data yet. We refuse to query for them.
+	const ARCHIVE_LAG_DAYS = 5;
+
+	// Past weather is immutable, but memcached caps TTL at 30 days before
+	// it interprets the value as a Unix timestamp. 30 days is fine: cold
+	// re-fetches cost essentially nothing and the API is unlimited at our
+	// scale (a few thousand calls/year).
+	const ARCHIVE_TTL_SEC = 2592000; // 30 days
 
 	/**
 	 * Read the cached weather row for a park. Triggers an inline refresh of
@@ -133,13 +144,125 @@ class Weather extends Ork3 {
 				return $vals ? array_sum($vals) / count($vals) : null;
 			};
 			$avgHi  = $avg('apparent_temperature_max');
-			$avgLo  = $avg('apparent_temperature_min');
 			$avgGus = $avg('wind_gusts_10m_max');
-			if ($ah !== null && $avgHi  !== null && ($ah - $avgHi) >=  10)   { $out[] = array('icon'=>'🔥','label'=>'Hot for the week','severity'=>'caution'); }
-			if ($al !== null && $avgLo  !== null && ($avgLo - $al) >=  10)   { $out[] = array('icon'=>'❄️','label'=>'Cold for the week','severity'=>'caution'); }
-			if ($g  !== null && $avgGus !== null && ($g  - $avgGus) >= 15)   { $out[] = array('icon'=>'💨','label'=>'Windy day',       'severity'=>'caution'); }
+			// Combine a *relative* deviation with an *absolute* floor so the
+			// caution only fires when the day is BOTH unusual for the week AND
+			// objectively notable. Use apparent HIGH for both warm/cool — park
+			// days happen during daytime, so the overnight low isn't the
+			// signal that matters.
+			if ($ah !== null && $avgHi  !== null && ($ah - $avgHi) >=  10 && $ah >= 75)   { $out[] = array('icon'=>'🔥','label'=>'Warm day','severity'=>'caution'); }
+			if ($ah !== null && $avgHi  !== null && ($avgHi - $ah) >=  10 && $ah <= 60)   { $out[] = array('icon'=>'❄️','label'=>'Cool day','severity'=>'caution'); }
+			if ($g  !== null && $avgGus !== null && ($g  - $avgGus) >= 15)               { $out[] = array('icon'=>'💨','label'=>'Windy day','severity'=>'caution'); }
 		}
 		return $out;
+	}
+
+	/**
+	 * Forecast for an arbitrary lat/lng. Used by callers whose location isn't
+	 * a park (e.g., kingdom-level events with their own venue coords). Cached
+	 * in GhettoCache for 30 minutes — matches the cron refresh cadence for
+	 * the park-based forecast cache, so coord-based one-offs stay roughly as
+	 * fresh as the park ones. Returns the same shape as forecast_for_date.
+	 */
+	public function forecast_for_coords($lat, $lng, $date) {
+		if (!is_numeric($lat) || !is_numeric($lng)) return null;
+		if (!preg_match('/^\d{4}-\d{2}-\d{2}$/', $date)) return null;
+		$lat = number_format((float)$lat, 4, '.', '');
+		$lng = number_format((float)$lng, 4, '.', '');
+
+		$key = Ork3::$Lib->ghettocache->key(array($lat, $lng));
+		$cached = Ork3::$Lib->ghettocache->get(__CLASS__ . '.forecast_for_coords', $key, 30 * 60);
+		if ($cached === false) {
+			$url = self::URL_FORECAST . '?latitude=' . $lat . '&longitude=' . $lng
+				. '&daily=temperature_2m_max,temperature_2m_min,apparent_temperature_max,apparent_temperature_min,'
+					. 'precipitation_probability_max,weather_code,uv_index_max,wind_gusts_10m_max'
+				. '&temperature_unit=fahrenheit&wind_speed_unit=mph&precipitation_unit=inch&timezone=auto&forecast_days=14';
+			$json = $this->http_get($url);
+			if ($json === false) return null;
+			$cached = @json_decode($json, true);
+			if (!is_array($cached)) return null;
+			Ork3::$Lib->ghettocache->cache(__CLASS__ . '.forecast_for_coords', $key, $cached);
+		}
+		if (empty($cached['daily']['time'])) return null;
+		$idx = array_search($date, $cached['daily']['time'], true);
+		if ($idx === false) return null;
+		return array(
+			'date'         => $date,
+			'code'         => isset($cached['daily']['weather_code'][$idx])              ? (int)$cached['daily']['weather_code'][$idx]              : null,
+			'hi_f'         => isset($cached['daily']['temperature_2m_max'][$idx])        ? (float)$cached['daily']['temperature_2m_max'][$idx]      : null,
+			'lo_f'         => isset($cached['daily']['temperature_2m_min'][$idx])        ? (float)$cached['daily']['temperature_2m_min'][$idx]      : null,
+			'app_hi_f'     => isset($cached['daily']['apparent_temperature_max'][$idx])  ? (float)$cached['daily']['apparent_temperature_max'][$idx]: null,
+			'app_lo_f'     => isset($cached['daily']['apparent_temperature_min'][$idx])  ? (float)$cached['daily']['apparent_temperature_min'][$idx]: null,
+			'uv_max'       => isset($cached['daily']['uv_index_max'][$idx])              ? (float)$cached['daily']['uv_index_max'][$idx]            : null,
+			'gusts_max'    => isset($cached['daily']['wind_gusts_10m_max'][$idx])        ? (float)$cached['daily']['wind_gusts_10m_max'][$idx]      : null,
+			'precip_pct'   => isset($cached['daily']['precipitation_probability_max'][$idx]) ? (int)$cached['daily']['precipitation_probability_max'][$idx] : null,
+		);
+	}
+
+	/**
+	 * Historic weather for a past date at a park. No DB row; just GhettoCache.
+	 *
+	 *  - Refuses dates inside the ARCHIVE_LAG_DAYS window (Open-Meteo's
+	 *    ERA5 reanalysis isn't published until ~5 days after the fact).
+	 *  - Refuses future dates (use forecast_for_date for those).
+	 *  - Refuses bad input — invalid date or non-existent park.
+	 *  - Cached for ARCHIVE_TTL_SEC (30 days) — past weather is immutable,
+	 *    re-fetch cost is negligible.
+	 *
+	 * Returns the same shape as forecast_for_date() plus null fields where
+	 * the archive endpoint doesn't expose data (e.g., precip_pct — that's
+	 * a forecast concept, not an archive one; we substitute precip_inches).
+	 */
+	public function archive_for_date($park_id, $date) {
+		$coords = $this->coords_for_park($park_id);
+		if ($coords === null) return null;
+		return $this->archive_for_coords($coords[0], $coords[1], $date);
+	}
+
+	/**
+	 * Coord-based variant. Used when a caller has lat/lng directly (e.g., an
+	 * event venue that isn't a park). Same caching, same shape as
+	 * archive_for_date.
+	 */
+	public function archive_for_coords($lat, $lng, $date) {
+		if (!is_numeric($lat) || !is_numeric($lng)) return null;
+		if (!preg_match('/^\d{4}-\d{2}-\d{2}$/', $date)) return null;
+		if ($date >= date('Y-m-d', time() - self::ARCHIVE_LAG_DAYS * 86400)) return null;
+		if ($date < '1940-01-01') return null;
+
+		// Round coords to 4 decimal places (~11m precision) for cache hit rate;
+		// raw values would key cache uniquely per micro-jitter.
+		$lat = number_format((float)$lat, 4, '.', '');
+		$lng = number_format((float)$lng, 4, '.', '');
+
+		$key = Ork3::$Lib->ghettocache->key(array($lat, $lng, $date));
+		$cached = Ork3::$Lib->ghettocache->get(__CLASS__ . '.archive_for_coords', $key, self::ARCHIVE_TTL_SEC);
+		if ($cached !== false) return $cached;
+
+		$url = self::URL_ARCHIVE . '?latitude=' . $lat . '&longitude=' . $lng
+			. '&start_date=' . $date . '&end_date=' . $date
+			. '&daily=temperature_2m_max,temperature_2m_min,apparent_temperature_max,apparent_temperature_min,'
+				. 'precipitation_sum,weather_code,wind_gusts_10m_max'
+			. '&temperature_unit=fahrenheit&wind_speed_unit=mph&precipitation_unit=inch&timezone=auto';
+
+		$json = $this->http_get($url);
+		if ($json === false) return null;  // do NOT cache a transient failure
+		$d = @json_decode($json, true);
+		if (!is_array($d) || empty($d['daily']['time'])) {
+			return Ork3::$Lib->ghettocache->cache(__CLASS__ . '.archive_for_coords', $key, null);
+		}
+
+		$result = array(
+			'date'           => $date,
+			'code'           => isset($d['daily']['weather_code'][0])              ? (int)$d['daily']['weather_code'][0]              : null,
+			'hi_f'           => isset($d['daily']['temperature_2m_max'][0])        ? (float)$d['daily']['temperature_2m_max'][0]      : null,
+			'lo_f'           => isset($d['daily']['temperature_2m_min'][0])        ? (float)$d['daily']['temperature_2m_min'][0]      : null,
+			'app_hi_f'       => isset($d['daily']['apparent_temperature_max'][0]) ? (float)$d['daily']['apparent_temperature_max'][0] : null,
+			'app_lo_f'       => isset($d['daily']['apparent_temperature_min'][0]) ? (float)$d['daily']['apparent_temperature_min'][0] : null,
+			'precip_inches'  => isset($d['daily']['precipitation_sum'][0])        ? (float)$d['daily']['precipitation_sum'][0]        : null,
+			'gusts_max'      => isset($d['daily']['wind_gusts_10m_max'][0])       ? (float)$d['daily']['wind_gusts_10m_max'][0]       : null,
+		);
+		return Ork3::$Lib->ghettocache->cache(__CLASS__ . '.archive_for_coords', $key, $result);
 	}
 
 	/**
@@ -189,6 +312,272 @@ class Weather extends Ork3 {
 	}
 
 	/**
+	 * Resolve a park's coordinates with fallback: prefer the scalar lat/lng
+	 * columns, then parse the `location` blob (Google geocode response, same
+	 * source the park map uses). A surprising number of high-traffic parks
+	 * have populated `location` but zero scalars — this read-time fallback
+	 * brings them into the weather feature without backfilling.
+	 *
+	 * Note: the `location` column is stored backslash-escaped (e.g.
+	 * `{\"bounds\":{...}}`) so SQL JSON_VALUE returns NULL. We do the
+	 * parsing in PHP after stripslashes() to recover the real JSON.
+	 *
+	 * Returns [lat, lng] or null if no usable coords.
+	 */
+	public function coords_for_park($park_id) {
+		$park_id = (int)$park_id;
+		if ($park_id <= 0) return null;
+		$rs = $this->db->query("SELECT latitude, longitude, location FROM " . DB_PREFIX . "park WHERE park_id = $park_id LIMIT 1");
+		if (!$rs || $rs->size() === 0) return null;
+		$rs->next();
+		$lat = (float)$rs->latitude;
+		$lng = (float)$rs->longitude;
+		if ($lat != 0.0 && $lng != 0.0) return array($lat, $lng);
+		return $this->parse_location_blob($rs->location);
+	}
+
+	/**
+	 * Park IDs that have an in-person park day on the given date.
+	 * Evaluates all three recurrence flavors (weekly, week-of-month, monthly).
+	 * Excludes online-marked entries — only in-field play counts.
+	 */
+	public function parks_playing_on($date) {
+		$ts        = strtotime($date);
+		if ($ts === false) return array();
+		$dow_name  = date('l', $ts);          // e.g., "Sunday" — matches ork_parkday.week_day enum
+		$dom       = (int)date('j', $ts);     // day-of-month for monthly recurrence
+		$wom       = (int)ceil($dom / 7);     // 1..5 — which Nth-weekday of the month today is
+
+		$sql = "SELECT DISTINCT park_id FROM " . DB_PREFIX . "parkday WHERE online = 0 AND (
+			(recurrence = 'weekly'        AND week_day = '$dow_name') OR
+			(recurrence = 'week-of-month' AND week_day = '$dow_name' AND week_of_month = $wom) OR
+			(recurrence = 'monthly'       AND month_day = $dom)
+		)";
+		$rs = $this->db->query($sql);
+		$out = array();
+		if ($rs && $rs->size() > 0) {
+			while ($rs->next()) $out[] = (int)$rs->park_id;
+		}
+		return $out;
+	}
+
+	/**
+	 * Build the structured data the Weather-page rundown renders from.
+	 * Returns a single associative array with:
+	 *   - badge_counts:    [label => count]   total parks flagged per badge type today
+	 *   - badge_kingdoms:  [label => [kingdom_name => count]]   distribution
+	 *   - standout_park:   ['park_id','name','kingdom','flags' => [...]]  worst-hit park
+	 *   - total_parks:     int                covered active parks
+	 *   - event_count:     int                events scheduled in next 7 days
+	 *   - event_concerning:int                events whose start day has a warning
+	 *   - date:            'YYYY-MM-DD'
+	 *
+	 * No external calls — reads ork_park_weather + ork_event.
+	 */
+	public function daily_summary($date) {
+		if (!preg_match('/^\d{4}-\d{2}-\d{2}$/', $date)) $date = date('Y-m-d');
+
+		// Scope the rundown to parks with an in-person park day on $date.
+		// The whole point of the Rundown is to answer "where will weather
+		// matter today" — a 113°F forecast at a park with no scheduled play
+		// is not decision-relevant for anyone reading.
+		$playing_ids = $this->parks_playing_on($date);
+		if (empty($playing_ids)) {
+			return array(
+				'date' => $date, 'total_parks' => 0,
+				'badge_counts' => array(), 'badge_kingdoms' => array(),
+				'standout_park' => null, 'event_count' => 0, 'event_concerning' => 0,
+				'no_play_today' => true,
+			);
+		}
+		$ids_sql = implode(',', array_map('intval', $playing_ids));
+		$rs = $this->db->query("SELECT pw.park_id, pw.forecast_json, p.name AS park_name, k.name AS kingdom_name
+			FROM " . DB_PREFIX . "park_weather pw
+			JOIN " . DB_PREFIX . "park p ON p.park_id = pw.park_id
+			LEFT JOIN " . DB_PREFIX . "kingdom k ON k.kingdom_id = p.kingdom_id
+			WHERE pw.park_id IN ($ids_sql)");
+
+		$out = array(
+			'date'              => $date,
+			'badge_counts'      => array(),
+			'badge_kingdoms'    => array(),
+			'standout_park'     => null,
+			'total_parks'       => 0,
+			'event_count'       => 0,
+			'event_concerning'  => 0,
+		);
+		$standoutScore = -1;
+		// Severity score for "worst-hit" picking — picks the park with the
+		// nastiest single warning, breaks ties by total flag count.
+		$severity = array(
+			'Extreme heat'    => 100,
+			'Frostbite risk'  => 100,
+			'Thunderstorms'   =>  80,
+			'Severe wind'     =>  60,
+			'Very high UV'    =>  40,
+			'Warm day'        =>  10,
+			'Cool day'        =>  10,
+			'Windy day'       =>   5,
+		);
+
+		if ($rs && $rs->size() > 0) {
+			while ($rs->next()) {
+				$out['total_parks']++;
+				if (empty($rs->forecast_json)) continue;
+				$wx = json_decode($rs->forecast_json, true);
+				if (!is_array($wx) || empty($wx['daily']['time'])) continue;
+				$idx = array_search($date, $wx['daily']['time'], true);
+				if ($idx === false) continue;
+				$f = array(
+					'code'         => isset($wx['daily']['weather_code'][$idx])              ? (int)$wx['daily']['weather_code'][$idx]              : null,
+					'hi_f'         => isset($wx['daily']['temperature_2m_max'][$idx])        ? (float)$wx['daily']['temperature_2m_max'][$idx]      : null,
+					'app_hi_f'     => isset($wx['daily']['apparent_temperature_max'][$idx])  ? (float)$wx['daily']['apparent_temperature_max'][$idx]: null,
+					'app_lo_f'     => isset($wx['daily']['apparent_temperature_min'][$idx])  ? (float)$wx['daily']['apparent_temperature_min'][$idx]: null,
+					'uv_max'       => isset($wx['daily']['uv_index_max'][$idx])              ? (float)$wx['daily']['uv_index_max'][$idx]            : null,
+					'gusts_max'    => isset($wx['daily']['wind_gusts_10m_max'][$idx])        ? (float)$wx['daily']['wind_gusts_10m_max'][$idx]      : null,
+				);
+				// Compute warning-tier badges only (skip relative cautions for the rundown — they're noisy in aggregate).
+				$badges = self::safety_badges($f, null, $date);
+				$badges = array_filter($badges, function($b) { return $b['severity'] === 'warning'; });
+				if (empty($badges)) continue;
+
+				$score = 0;
+				$labels = array();
+				foreach ($badges as $b) {
+					$lbl = $b['label'];
+					$labels[] = $lbl;
+					$score   += isset($severity[$lbl]) ? $severity[$lbl] : 0;
+					$out['badge_counts'][$lbl] = ($out['badge_counts'][$lbl] ?? 0) + 1;
+					if (!empty($rs->kingdom_name)) {
+						$k = $rs->kingdom_name;
+						$out['badge_kingdoms'][$lbl][$k] = ($out['badge_kingdoms'][$lbl][$k] ?? 0) + 1;
+					}
+				}
+				if ($score > $standoutScore) {
+					$standoutScore = $score;
+					$out['standout_park'] = array(
+						'park_id' => (int)$rs->park_id,
+						'name'    => $rs->park_name,
+						'kingdom' => $rs->kingdom_name,
+						'flags'   => array_values(array_unique($labels)),
+						'app_hi_f'=> $f['app_hi_f'],
+					);
+				}
+			}
+		}
+
+		// Event counts. Concerning = event's start day forecast carries any warning badge.
+		$cutoff = date('Y-m-d', time() + 7 * 86400);
+		$today  = date('Y-m-d');
+		$er = $this->db->query("SELECT e.event_id, e.park_id, cd.event_start, cd.event_calendardetail_id
+			FROM " . DB_PREFIX . "event e
+			JOIN " . DB_PREFIX . "event_calendardetail cd ON cd.event_id = e.event_id
+			WHERE DATE(cd.event_start) >= '$today' AND DATE(cd.event_start) <= '$cutoff'");
+		if ($er && $er->size() > 0) {
+			while ($er->next()) {
+				$out['event_count']++;
+				$d = substr($er->event_start, 0, 10);
+				$evFC = $this->forecast_for_date((int)$er->park_id, $d);
+				if (!$evFC) continue;
+				$bs = self::safety_badges($evFC, null, $d);
+				$warn = array_filter($bs, function($b) { return $b['severity'] === 'warning'; });
+				if (!empty($warn)) $out['event_concerning']++;
+			}
+		}
+		return $out;
+	}
+
+	/**
+	 * Upcoming events in the next $days, each enriched with the start-day
+	 * forecast (or null if outside the cache window). Sorted by start date.
+	 */
+	public function upcoming_events_with_forecast($days = 7) {
+		$today  = date('Y-m-d');
+		$cutoff = date('Y-m-d', time() + (int)$days * 86400);
+		$rs = $this->db->query("SELECT e.event_id, e.name AS event_name, e.park_id, e.kingdom_id,
+		         cd.event_start, cd.event_end, cd.event_calendardetail_id, cd.at_park_id,
+		         cd.latitude AS ev_lat, cd.longitude AS ev_lng,
+		         p.name AS park_name, k.name AS kingdom_name
+			FROM " . DB_PREFIX . "event e
+			JOIN " . DB_PREFIX . "event_calendardetail cd ON cd.event_id = e.event_id
+			LEFT JOIN " . DB_PREFIX . "park p ON p.park_id = e.park_id
+			LEFT JOIN " . DB_PREFIX . "kingdom k ON k.kingdom_id = e.kingdom_id
+			WHERE DATE(cd.event_start) >= '$today' AND DATE(cd.event_start) <= '$cutoff'
+			ORDER BY cd.event_start ASC");
+		$out = array();
+		if ($rs && $rs->size() > 0) {
+			while ($rs->next()) {
+				$d = substr($rs->event_start, 0, 10);
+				// Coord priority for forecast:
+				//   1. event_calendardetail's own coords (event-only venue)
+				//   2. at_park (host park)
+				//   3. owning park
+				$fc = null;
+				$evLat = (float)$rs->ev_lat;
+				$evLng = (float)$rs->ev_lng;
+				if ($evLat != 0.0 && $evLng != 0.0) {
+					$fc = $this->forecast_for_coords($evLat, $evLng, $d);
+				}
+				$pid = (int)$rs->at_park_id ?: (int)$rs->park_id;
+				if (!$fc && $pid > 0) {
+					$fc = $this->forecast_for_date($pid, $d);
+				}
+				$badges = $fc ? self::safety_badges($fc, null, $d) : array();
+				$out[] = array(
+					'event_id'                => (int)$rs->event_id,
+					'name'                    => $rs->event_name,
+					'park_id'                 => $pid,
+					'park_name'               => $rs->park_name,
+					'kingdom_name'            => $rs->kingdom_name,
+					'event_start'             => $rs->event_start,
+					'event_end'               => $rs->event_end,
+					'event_calendardetail_id' => (int)$rs->event_calendardetail_id,
+					'forecast'                => $fc,
+					'badges'                  => $badges,
+				);
+			}
+		}
+		return $out;
+	}
+
+	/**
+	 * Convert "The Kingdom of X" / "The Empire of X" etc. to a short form
+	 * suitable for the rundown narrative — see the design notes in
+	 * follow_ups.md. Excludes "Freeholds of Amtgard" entirely (scatter, not
+	 * a region).
+	 */
+	public static function short_kingdom($name) {
+		if (!$name) return '';
+		if (stripos($name, 'Freeholds') !== false) return '';  // not a region
+		// "The Celestial Kingdom" — special case (no "X of Y" structure)
+		if (preg_match('/^The (.+ Kingdom)$/i', $name, $m)) return 'the ' . $m[1];
+		// Strip leading "The " then any rank-of[-the] prefix
+		$n = preg_replace('/^The /i', '', $name);
+		$n = preg_replace('/^(Kingdom|Empire|Principality) of /i', '', $n);
+		return $n;
+	}
+
+	private function parse_location_blob($loc) {
+		if (!$loc) return null;
+		$d = @json_decode($loc, true);
+		if (!is_array($d)) $d = @json_decode(stripslashes($loc), true);
+		if (!is_array($d)) return null;
+		$lat = $d['location']['lat'] ?? null;
+		$lng = $d['location']['lng'] ?? null;
+		if (!is_numeric($lat) || !is_numeric($lng)) return null;
+		$lat = (float)$lat; $lng = (float)$lng;
+		if ($lat == 0.0 || $lng == 0.0) return null;
+		return array($lat, $lng);
+	}
+
+	/**
+	 * Cheap boolean version of coords_for_park() for template eligibility checks.
+	 */
+	public function park_has_coords($park_id) {
+		return $this->coords_for_park($park_id) !== null;
+	}
+
+	/**
 	 * Bulk refresh: one HTTP call to Open-Meteo for every active park's
 	 * coords, then upsert each park's row. Safe to call from cron OR from a
 	 * lazy fallback (callers shouldn't notice the difference beyond latency).
@@ -213,7 +602,7 @@ class Weather extends Ork3 {
 			. 'daily=temperature_2m_max,temperature_2m_min,apparent_temperature_max,apparent_temperature_min,'
 				. 'precipitation_probability_max,weather_code,uv_index_max,wind_gusts_10m_max&'
 			. 'temperature_unit=fahrenheit&wind_speed_unit=mph&precipitation_unit=inch&'
-			. 'timezone=auto&forecast_days=7';
+			. 'timezone=auto&forecast_days=14';
 
 		$json = $this->http_get($url);
 		if ($json === false) return 0;
@@ -266,11 +655,13 @@ class Weather extends Ork3 {
 
 	private function active_parks_with_coords() {
 		$cutoff = date('Y-m-d', time() - self::ACTIVE_DAYS * 86400);
-		$sql = "SELECT p.park_id, p.latitude, p.longitude
+		// Pull all active parks with recent attendance, resolve coords in PHP
+		// (scalar first, then the location-JSON blob — same source the park
+		// map uses). Done in PHP because the blob is stored backslash-escaped
+		// so SQL JSON_VALUE returns NULL on it.
+		$sql = "SELECT p.park_id, p.latitude, p.longitude, p.location
 		        FROM " . DB_PREFIX . "park p
-		        WHERE p.latitude IS NOT NULL AND p.longitude IS NOT NULL
-		          AND p.latitude != 0 AND p.longitude != 0
-		          AND p.active = 'Active'
+		        WHERE p.active = 'Active'
 		          AND EXISTS (
 		              SELECT 1 FROM " . DB_PREFIX . "attendance a
 		              WHERE a.park_id = p.park_id AND a.date >= '$cutoff'
@@ -280,10 +671,17 @@ class Weather extends Ork3 {
 		$out = array();
 		if ($rs && $rs->size() > 0) {
 			while ($rs->next()) {
+				$lat = (float)$rs->latitude;
+				$lng = (float)$rs->longitude;
+				if ($lat == 0.0 || $lng == 0.0) {
+					$parsed = $this->parse_location_blob($rs->location);
+					if ($parsed === null) continue;
+					list($lat, $lng) = $parsed;
+				}
 				$out[] = array(
 					'park_id'   => (int)$rs->park_id,
-					'latitude'  => (float)$rs->latitude,
-					'longitude' => (float)$rs->longitude,
+					'latitude'  => $lat,
+					'longitude' => $lng,
 				);
 			}
 		}

--- a/system/lib/ork3/class.Weather.php
+++ b/system/lib/ork3/class.Weather.php
@@ -75,6 +75,15 @@ class Weather extends Ork3 {
 	 */
 	public function forecast_for_date($park_id, $date) {
 		$row = $this->for_park($park_id);
+		return self::forecast_from_row($row, $date);
+	}
+
+	/**
+	 * Decode a pre-fetched park_weather row into a single-day forecast array.
+	 * Used to avoid the N+1 of forecast_for_date() when iterating many parks —
+	 * callers do one read_rows() then ask this helper per-park.
+	 */
+	public static function forecast_from_row($row, $date) {
 		if (!$row || empty($row['forecast_json'])) return null;
 		$wx = json_decode($row['forecast_json'], true);
 		if (!is_array($wx) || empty($wx['daily']['time'])) return null;
@@ -164,7 +173,7 @@ class Weather extends Ork3 {
 	 * the park-based forecast cache, so coord-based one-offs stay roughly as
 	 * fresh as the park ones. Returns the same shape as forecast_for_date.
 	 */
-	public function forecast_for_coords($lat, $lng, $date) {
+	public function forecast_for_coords($lat, $lng, $date, $fetch_if_missing = true) {
 		if (!is_numeric($lat) || !is_numeric($lng)) return null;
 		if (!preg_match('/^\d{4}-\d{2}-\d{2}$/', $date)) return null;
 		$lat = number_format((float)$lat, 4, '.', '');
@@ -173,6 +182,10 @@ class Weather extends Ork3 {
 		$key = Ork3::$Lib->ghettocache->key(array($lat, $lng));
 		$cached = Ork3::$Lib->ghettocache->get(__CLASS__ . '.forecast_for_coords', $key, 30 * 60);
 		if ($cached === false) {
+			// Caller opted out of synchronous HTTP — return null and let the
+			// cron-driven warm-up fill the cache for next time. Keeps hot
+			// page-render paths from blocking on Open-Meteo.
+			if (!$fetch_if_missing) return null;
 			$url = self::URL_FORECAST . '?latitude=' . $lat . '&longitude=' . $lng
 				. '&daily=temperature_2m_max,temperature_2m_min,apparent_temperature_max,apparent_temperature_min,'
 					. 'precipitation_probability_max,weather_code,uv_index_max,wind_gusts_10m_max'
@@ -348,10 +361,15 @@ class Weather extends Ork3 {
 		$dom       = (int)date('j', $ts);     // day-of-month for monthly recurrence
 		$wom       = (int)ceil($dom / 7);     // 1..5 — which Nth-weekday of the month today is
 
-		$sql = "SELECT DISTINCT park_id FROM " . DB_PREFIX . "parkday WHERE online = 0 AND (
-			(recurrence = 'weekly'        AND week_day = '$dow_name') OR
-			(recurrence = 'week-of-month' AND week_day = '$dow_name' AND week_of_month = $wom) OR
-			(recurrence = 'monthly'       AND month_day = $dom)
+		// Filter retired/inactive parks at the source — they may still have
+		// parkday rows from when they were active, but we don't want them on
+		// the weather page (map markers, play list, rundown counts).
+		$sql = "SELECT DISTINCT pd.park_id FROM " . DB_PREFIX . "parkday pd
+			JOIN " . DB_PREFIX . "park p ON p.park_id = pd.park_id
+			WHERE pd.online = 0 AND p.active = 'Active' AND (
+			(pd.recurrence = 'weekly'        AND pd.week_day = '$dow_name') OR
+			(pd.recurrence = 'week-of-month' AND pd.week_day = '$dow_name' AND pd.week_of_month = $wom) OR
+			(pd.recurrence = 'monthly'       AND pd.month_day = $dom)
 		)";
 		$rs = $this->db->query($sql);
 		$out = array();
@@ -467,21 +485,35 @@ class Weather extends Ork3 {
 		}
 
 		// Event counts. Concerning = event's start day forecast carries any warning badge.
+		// Two-pass: buffer rows, batch-read host-park weather, then judge.
+		// (Original code did forecast_for_date per event → N+1 SQL plus a real
+		// risk of triggering refresh_all_active_parks() synchronously.)
 		$cutoff = date('Y-m-d', time() + 7 * 86400);
 		$today  = date('Y-m-d');
 		$er = $this->db->query("SELECT e.event_id, e.park_id, cd.event_start, cd.event_calendardetail_id
 			FROM " . DB_PREFIX . "event e
 			JOIN " . DB_PREFIX . "event_calendardetail cd ON cd.event_id = e.event_id
 			WHERE DATE(cd.event_start) >= '$today' AND DATE(cd.event_start) <= '$cutoff'");
+		$ev_buf = array();
+		$ev_park_ids = array();
 		if ($er && $er->size() > 0) {
 			while ($er->next()) {
 				$out['event_count']++;
-				$d = substr($er->event_start, 0, 10);
-				$evFC = $this->forecast_for_date((int)$er->park_id, $d);
-				if (!$evFC) continue;
-				$bs = self::safety_badges($evFC, null, $d);
-				$warn = array_filter($bs, function($b) { return $b['severity'] === 'warning'; });
-				if (!empty($warn)) $out['event_concerning']++;
+				$ev_buf[] = array(
+					'park_id'     => (int)$er->park_id,
+					'event_start' => $er->event_start,
+				);
+				if ((int)$er->park_id > 0) $ev_park_ids[(int)$er->park_id] = true;
+			}
+		}
+		$ev_weather = !empty($ev_park_ids) ? $this->read_rows(array_keys($ev_park_ids)) : array();
+		foreach ($ev_buf as $ev) {
+			$d = substr($ev['event_start'], 0, 10);
+			$evFC = self::forecast_from_row($ev_weather[$ev['park_id']] ?? null, $d);
+			if (!$evFC) continue;
+			$bs = self::safety_badges($evFC, null, $d);
+			foreach ($bs as $b) {
+				if ($b['severity'] === 'warning') { $out['event_concerning']++; break; }
 			}
 		}
 		return $out;
@@ -505,11 +537,11 @@ class Weather extends Ork3 {
 		$wom = (int)ceil($dom / 7);
 
 		$rs = $this->db->query("SELECT pd.park_id, pd.parkday_id, pd.purpose, pd.time, pd.description,
-		         p.name AS park_name, k.name AS kingdom_name
+		         p.name AS park_name, p.latitude, p.longitude, p.location, k.name AS kingdom_name
 			FROM " . DB_PREFIX . "parkday pd
 			JOIN " . DB_PREFIX . "park p ON p.park_id = pd.park_id
 			LEFT JOIN " . DB_PREFIX . "kingdom k ON k.kingdom_id = p.kingdom_id
-			WHERE pd.online = 0 AND pd.park_id IN ($ids_sql)
+			WHERE pd.online = 0 AND p.active = 'Active' AND pd.park_id IN ($ids_sql)
 			  AND (
 				(pd.recurrence = 'weekly'        AND pd.week_day = '$dow_name') OR
 				(pd.recurrence = 'week-of-month' AND pd.week_day = '$dow_name' AND pd.week_of_month = $wom) OR
@@ -517,6 +549,7 @@ class Weather extends Ork3 {
 			  )
 			ORDER BY p.name");
 		$by_park = array();
+		$park_coords = array();
 		if ($rs && $rs->size() > 0) {
 			while ($rs->next()) {
 				$pid = (int)$rs->park_id;
@@ -534,6 +567,15 @@ class Weather extends Ork3 {
 					'time'        => $rs->time,
 					'description' => $rs->description,
 				);
+				if (!isset($park_coords[$pid])) {
+					$lat = (float)$rs->latitude;
+					$lng = (float)$rs->longitude;
+					if ($lat != 0.0 && $lng != 0.0) {
+						$park_coords[$pid] = array($lat, $lng);
+					} else {
+						$park_coords[$pid] = $this->parse_location_blob($rs->location);
+					}
+				}
 			}
 		}
 
@@ -549,21 +591,65 @@ class Weather extends Ork3 {
 			'Windy day'       =>   5,
 		);
 
+		// Bulk-classify which parks are "active" (recent attendance) so we can
+		// label gray markers / unavailable rows with a reason. One query for the
+		// whole playing set instead of N is_active_park() calls.
+		$active_set = array();
+		if (!empty($by_park)) {
+			$cutoff = date('Y-m-d', time() - self::ACTIVE_DAYS * 86400);
+			$ids_in = implode(',', array_map('intval', array_keys($by_park)));
+			$ar = $this->db->query("SELECT DISTINCT park_id FROM " . DB_PREFIX . "attendance
+				WHERE park_id IN ($ids_in) AND date >= '$cutoff'");
+			if ($ar && $ar->size() > 0) {
+				while ($ar->next()) $active_set[(int)$ar->park_id] = true;
+			}
+		}
+
+		// Batch-read every park's weather row in ONE query — replaces the N+1
+		// where each forecast_for_date() did its own SELECT. The cron is the
+		// source of truth; we don't lazy-refresh from this hot path.
+		$weather_rows = !empty($by_park) ? $this->read_rows(array_keys($by_park)) : array();
+		$stale_threshold = time() - self::STALE_MIN * 60;
+
 		$out = array();
 		foreach ($by_park as $pid => $schedules) {
 			$first = $schedules[0];
-			$fc     = $this->forecast_for_date($pid, $date);
+			// Treat stale rows for now-dormant parks as "no forecast" so we
+			// don't surface months-old data. Cron-fresh rows fall through.
+			$row = $weather_rows[$pid] ?? null;
+			if ($row && strtotime($row['fetched_at']) < $stale_threshold && empty($active_set[$pid])) {
+				$row = null;
+			}
+			$fc     = self::forecast_from_row($row, $date);
 			$badges = $fc ? self::safety_badges($fc, null, $date) : array();
 			$score  = 0;
 			foreach ($badges as $b) $score += $severity[$b['label']] ?? 0;
+			$coords = $park_coords[$pid] ?? null;
+
+			// Reason classification for missing forecasts — surfaced in the UI
+			// so users understand "why no forecast?" without us having to make
+			// a support ticket out of it.
+			if ($fc) {
+				$status = 'ok';
+			} elseif ($coords === null) {
+				$status = 'no_coords';
+			} elseif (empty($active_set[$pid])) {
+				$status = 'dormant';
+			} else {
+				$status = 'unavailable';
+			}
+
 			$out[] = array(
-				'park_id'      => $pid,
-				'park_name'    => $first['park_name'],
-				'kingdom_name' => $first['kingdom'],
-				'schedules'    => $schedules,
-				'forecast'     => $fc,
-				'badges'       => $badges,
-				'_score'       => $score,
+				'park_id'         => $pid,
+				'park_name'       => $first['park_name'],
+				'kingdom_name'    => $first['kingdom'],
+				'lat'             => $coords ? $coords[0] : null,
+				'lng'             => $coords ? $coords[1] : null,
+				'schedules'       => $schedules,
+				'forecast'        => $fc,
+				'forecast_status' => $status,
+				'badges'          => $badges,
+				'_score'          => $score,
 			);
 		}
 		usort($out, function($a, $b) {
@@ -583,7 +669,8 @@ class Weather extends Ork3 {
 		$rs = $this->db->query("SELECT e.event_id, e.name AS event_name, e.park_id, e.kingdom_id,
 		         cd.event_start, cd.event_end, cd.event_calendardetail_id, cd.at_park_id,
 		         cd.latitude AS ev_lat, cd.longitude AS ev_lng,
-		         p.name AS park_name, k.name AS kingdom_name
+		         p.name AS park_name, p.latitude AS p_lat, p.longitude AS p_lng, p.location AS p_loc,
+		         k.name AS kingdom_name
 			FROM " . DB_PREFIX . "event e
 			JOIN " . DB_PREFIX . "event_calendardetail cd ON cd.event_id = e.event_id
 			LEFT JOIN " . DB_PREFIX . "park p ON p.park_id = e.park_id
@@ -591,22 +678,78 @@ class Weather extends Ork3 {
 			WHERE DATE(cd.event_start) >= '$today' AND DATE(cd.event_start) <= '$cutoff'
 			ORDER BY cd.event_start ASC");
 		$out = array();
+		// Two-pass: buffer rows, collect park_ids that need a forecast, do ONE
+		// read_rows() for all of them, then build the output. Saves N+1 SELECTs.
+		$buf = array();
+		$park_ids_needed = array();
 		if ($rs && $rs->size() > 0) {
 			while ($rs->next()) {
+				$row = array(
+					'event_id'                => (int)$rs->event_id,
+					'event_name'              => $rs->event_name,
+					'park_id'                 => (int)$rs->park_id,
+					'at_park_id'              => (int)$rs->at_park_id,
+					'event_calendardetail_id' => (int)$rs->event_calendardetail_id,
+					'event_start'             => $rs->event_start,
+					'event_end'               => $rs->event_end,
+					'ev_lat'                  => (float)$rs->ev_lat,
+					'ev_lng'                  => (float)$rs->ev_lng,
+					'p_lat'                   => (float)$rs->p_lat,
+					'p_lng'                   => (float)$rs->p_lng,
+					'p_loc'                   => $rs->p_loc,
+					'park_name'               => $rs->park_name,
+					'kingdom_name'            => $rs->kingdom_name,
+				);
+				$pid = $row['at_park_id'] ?: $row['park_id'];
+				if ($pid > 0) $park_ids_needed[$pid] = true;
+				$buf[] = $row;
+			}
+		}
+		$park_weather_rows = !empty($park_ids_needed)
+			? $this->read_rows(array_keys($park_ids_needed))
+			: array();
+		foreach ($buf as $rs) {
+			$rs = (object)$rs;
 				$d = substr($rs->event_start, 0, 10);
 				// Coord priority for forecast:
-				//   1. event_calendardetail's own coords (event-only venue)
-				//   2. at_park (host park)
-				//   3. owning park
+				//   1. event_calendardetail's own coords IF already cached (no HTTP)
+				//   2. host/owning park (cron-warmed, always cheap)
+				//   3. event_calendardetail's own coords WITH HTTP fallback —
+				//      last resort, only if no park forecast available. Cron
+				//      can later warm this; we accept slightly stale data
+				//      rather than block 19 HTTP roundtrips per page render.
 				$fc = null;
 				$evLat = (float)$rs->ev_lat;
 				$evLng = (float)$rs->ev_lng;
 				if ($evLat != 0.0 && $evLng != 0.0) {
-					$fc = $this->forecast_for_coords($evLat, $evLng, $d);
+					$fc = $this->forecast_for_coords($evLat, $evLng, $d, /*fetch_if_missing*/ false);
 				}
 				$pid = (int)$rs->at_park_id ?: (int)$rs->park_id;
 				if (!$fc && $pid > 0) {
-					$fc = $this->forecast_for_date($pid, $d);
+					$fc = self::forecast_from_row($park_weather_rows[$pid] ?? null, $d);
+				}
+				// Note: we never synchronously fetch from page render — even
+				// for event-only venues. warm_event_venue_coords() (run by
+				// the cron) keeps those coord caches populated. If the cron
+				// hasn't run yet for a new event, the row just shows
+				// "forecast unavailable" until next refresh.
+				// Coords for map-jump (same priority as the forecast lookup):
+				// 1. event_calendardetail's own coords, 2. at_park, 3. owning park
+				$lat = null; $lng = null;
+				if ($evLat != 0.0 && $evLng != 0.0) {
+					$lat = $evLat; $lng = $evLng;
+				} elseif ((int)$rs->at_park_id > 0) {
+					$c = $this->coords_for_park((int)$rs->at_park_id);
+					if ($c) { $lat = $c[0]; $lng = $c[1]; }
+				}
+				if ($lat === null) {
+					$plat = (float)$rs->p_lat; $plng = (float)$rs->p_lng;
+					if ($plat != 0.0 && $plng != 0.0) {
+						$lat = $plat; $lng = $plng;
+					} else {
+						$c = $this->parse_location_blob($rs->p_loc);
+						if ($c) { $lat = $c[0]; $lng = $c[1]; }
+					}
 				}
 				$badges = $fc ? self::safety_badges($fc, null, $d) : array();
 				$out[] = array(
@@ -615,13 +758,48 @@ class Weather extends Ork3 {
 					'park_id'                 => $pid,
 					'park_name'               => $rs->park_name,
 					'kingdom_name'            => $rs->kingdom_name,
+					'lat'                     => $lat,
+					'lng'                     => $lng,
 					'event_start'             => $rs->event_start,
 					'event_end'               => $rs->event_end,
 					'event_calendardetail_id' => (int)$rs->event_calendardetail_id,
 					'forecast'                => $fc,
 					'badges'                  => $badges,
 				);
+		}
+		return $out;
+	}
+
+	/**
+	 * Severity signal for each date in $dates — used to render warning dots on
+	 * the date-strip pills. Returns ['YYYY-MM-DD' => 'warning'|'ok'|'none'].
+	 * 'none' = no parks playing; 'ok' = parks playing but no flags.
+	 *
+	 * Costs 7 parkday queries + 1 batch read_rows for all parks across all dates.
+	 */
+	public function strip_severities(array $dates) {
+		$per_date = array();
+		$all_ids  = array();
+		foreach ($dates as $date) {
+			$ids = $this->parks_playing_on($date);
+			$per_date[$date] = $ids;
+			foreach ($ids as $id) $all_ids[$id] = true;
+		}
+		$rows = !empty($all_ids) ? $this->read_rows(array_keys($all_ids)) : array();
+		$out = array();
+		foreach ($dates as $date) {
+			$ids = $per_date[$date] ?? array();
+			if (empty($ids)) { $out[$date] = 'none'; continue; }
+			$max = 'ok';
+			foreach ($ids as $pid) {
+				$fc = self::forecast_from_row($rows[$pid] ?? null, $date);
+				if (!$fc) continue;
+				foreach (self::safety_badges($fc, null, $date) as $b) {
+					if ($b['severity'] === 'warning') { $max = 'warning'; break 2; }
+					$max = 'caution';
+				}
 			}
+			$out[$date] = $max;
 		}
 		return $out;
 	}
@@ -735,6 +913,38 @@ class Weather extends Ork3 {
 			$updated++;
 		}
 		return $updated;
+	}
+
+	/**
+	 * Warm the coord-based forecast cache for upcoming-event venues whose
+	 * cd.latitude/longitude is set. Without this, the /Weather page's events
+	 * list pays a synchronous Open-Meteo call per event with its own coords
+	 * (typically ~250ms each) on every cold-cache request. Called by the cron
+	 * alongside refresh_all_active_parks().
+	 *
+	 * Returns the number of venues warmed.
+	 */
+	public function warm_event_venue_coords($days = 14) {
+		$today  = date('Y-m-d');
+		$cutoff = date('Y-m-d', time() + (int)$days * 86400);
+		$rs = $this->db->query("SELECT DISTINCT cd.latitude, cd.longitude
+			FROM " . DB_PREFIX . "event_calendardetail cd
+			WHERE cd.latitude IS NOT NULL AND cd.longitude IS NOT NULL
+			  AND cd.latitude != 0 AND cd.longitude != 0
+			  AND DATE(cd.event_start) >= '$today' AND DATE(cd.event_start) <= '$cutoff'");
+		$warmed = 0;
+		if ($rs && $rs->size() > 0) {
+			while ($rs->next()) {
+				$lat = (float)$rs->latitude;
+				$lng = (float)$rs->longitude;
+				if ($lat == 0.0 || $lng == 0.0) continue;
+				// Use the existing single-coord path — it caches as a side
+				// effect. We don't care about the return value here.
+				$got = $this->forecast_for_coords($lat, $lng, $today, true);
+				if ($got !== null) $warmed++;
+			}
+		}
+		return $warmed;
 	}
 
 	// ---- internals --------------------------------------------------------

--- a/system/lib/ork3/class.Weather.php
+++ b/system/lib/ork3/class.Weather.php
@@ -46,6 +46,30 @@ class Weather extends Ork3 {
 	}
 
 	/**
+	 * Batch variant — one query for a list of park IDs. Returns an assoc
+	 * keyed by park_id. If any returned row is missing or older than
+	 * STALE_MIN, triggers ONE refresh and re-reads. Caller pays at most one
+	 * Open-Meteo round trip regardless of how many parks they ask about.
+	 */
+	public function for_parks(array $park_ids) {
+		$ids = array_filter(array_map('intval', $park_ids), function($i) { return $i > 0; });
+		if (empty($ids)) return array();
+		$rows = $this->read_rows($ids);
+		$threshold = time() - self::STALE_MIN * 60;
+		$stale = (count($rows) !== count($ids));
+		if (!$stale) {
+			foreach ($rows as $r) {
+				if (strtotime($r['fetched_at']) < $threshold) { $stale = true; break; }
+			}
+		}
+		if ($stale) {
+			$this->refresh_all_active_parks();
+			$rows = $this->read_rows($ids);
+		}
+		return $rows;
+	}
+
+	/**
 	 * Bulk refresh: one HTTP call to Open-Meteo for every active park's
 	 * coords, then upsert each park's row. Safe to call from cron OR from a
 	 * lazy fallback (callers shouldn't notice the difference beyond latency).
@@ -147,21 +171,32 @@ class Weather extends Ork3 {
 	}
 
 	private function read_row($park_id) {
-		$rs = $this->db->query("SELECT * FROM " . DB_PREFIX . "park_weather WHERE park_id = " . (int)$park_id . " LIMIT 1");
-		if (!$rs || $rs->size() === 0) return null;
-		$rs->next();
-		return array(
-			'park_id'          => (int)$rs->park_id,
-			'fetched_at'       => $rs->fetched_at,
-			'current_temp_f'   => $rs->current_temp_f   !== null ? (float)$rs->current_temp_f : null,
-			'current_code'     => $rs->current_code     !== null ? (int)$rs->current_code     : null,
-			'current_is_day'   => $rs->current_is_day   !== null ? (int)$rs->current_is_day   : null,
-			'current_wind_mph' => $rs->current_wind_mph !== null ? (float)$rs->current_wind_mph : null,
-			'today_high_f'     => $rs->today_high_f     !== null ? (float)$rs->today_high_f   : null,
-			'today_low_f'      => $rs->today_low_f      !== null ? (float)$rs->today_low_f    : null,
-			'today_precip_pct' => $rs->today_precip_pct !== null ? (int)$rs->today_precip_pct : null,
-			'forecast_json'    => $rs->forecast_json,
-		);
+		$rows = $this->read_rows(array((int)$park_id));
+		return $rows[(int)$park_id] ?? null;
+	}
+
+	private function read_rows(array $park_ids) {
+		$ids_sql = implode(',', array_map('intval', $park_ids));
+		if ($ids_sql === '') return array();
+		$rs = $this->db->query("SELECT * FROM " . DB_PREFIX . "park_weather WHERE park_id IN ($ids_sql)");
+		$out = array();
+		if ($rs && $rs->size() > 0) {
+			while ($rs->next()) {
+				$out[(int)$rs->park_id] = array(
+					'park_id'          => (int)$rs->park_id,
+					'fetched_at'       => $rs->fetched_at,
+					'current_temp_f'   => $rs->current_temp_f   !== null ? (float)$rs->current_temp_f : null,
+					'current_code'     => $rs->current_code     !== null ? (int)$rs->current_code     : null,
+					'current_is_day'   => $rs->current_is_day   !== null ? (int)$rs->current_is_day   : null,
+					'current_wind_mph' => $rs->current_wind_mph !== null ? (float)$rs->current_wind_mph : null,
+					'today_high_f'     => $rs->today_high_f     !== null ? (float)$rs->today_high_f   : null,
+					'today_low_f'      => $rs->today_low_f      !== null ? (float)$rs->today_low_f    : null,
+					'today_precip_pct' => $rs->today_precip_pct !== null ? (int)$rs->today_precip_pct : null,
+					'forecast_json'    => $rs->forecast_json,
+				);
+			}
+		}
+		return $out;
 	}
 
 	private function upsert_row($park_id, $fetched_at, $fields) {

--- a/system/lib/ork3/class.Weather.php
+++ b/system/lib/ork3/class.Weather.php
@@ -46,6 +46,108 @@ class Weather extends Ork3 {
 	}
 
 	/**
+	 * Pull a single day's forecast out of the cached forecast_json for a
+	 * park. Returns null if the date is outside the 7-day window we cached,
+	 * or if the park has no weather row at all.
+	 *
+	 * Returned shape: ['date'=>'YYYY-MM-DD','code'=>int,'hi_f'=>float,'lo_f'=>float,'precip_pct'=>int]
+	 */
+	public function forecast_for_date($park_id, $date) {
+		$row = $this->for_park($park_id);
+		if (!$row || empty($row['forecast_json'])) return null;
+		$wx = json_decode($row['forecast_json'], true);
+		if (!is_array($wx) || empty($wx['daily']['time'])) return null;
+		$idx = array_search($date, $wx['daily']['time'], true);
+		if ($idx === false) return null;
+		return array(
+			'date'         => $date,
+			'code'         => isset($wx['daily']['weather_code'][$idx])                  ? (int)$wx['daily']['weather_code'][$idx]                  : null,
+			'hi_f'         => isset($wx['daily']['temperature_2m_max'][$idx])            ? (float)$wx['daily']['temperature_2m_max'][$idx]          : null,
+			'lo_f'         => isset($wx['daily']['temperature_2m_min'][$idx])            ? (float)$wx['daily']['temperature_2m_min'][$idx]          : null,
+			'app_hi_f'     => isset($wx['daily']['apparent_temperature_max'][$idx])      ? (float)$wx['daily']['apparent_temperature_max'][$idx]    : null,
+			'app_lo_f'     => isset($wx['daily']['apparent_temperature_min'][$idx])      ? (float)$wx['daily']['apparent_temperature_min'][$idx]    : null,
+			'uv_max'       => isset($wx['daily']['uv_index_max'][$idx])                  ? (float)$wx['daily']['uv_index_max'][$idx]                : null,
+			'gusts_max'    => isset($wx['daily']['wind_gusts_10m_max'][$idx])            ? (float)$wx['daily']['wind_gusts_10m_max'][$idx]          : null,
+			'precip_pct'   => isset($wx['daily']['precipitation_probability_max'][$idx]) ? (int)$wx['daily']['precipitation_probability_max'][$idx] : null,
+		);
+	}
+
+	/**
+	 * Derive safety badges for a single forecast row.
+	 *
+	 * Two tiers:
+	 *  - WARNINGS (absolute, universal): things that are biologically dangerous
+	 *    no matter where you live — heat stroke territory, frostbite territory,
+	 *    lightning, severe wind, extreme UV. Same thresholds for Texas as
+	 *    Ottawa as Florida.
+	 *  - CAUTIONS (relative): "this day is notably hotter/colder/windier than
+	 *    the surrounding week here." Solves the Texas-vs-Ottawa problem
+	 *    without per-park config — a steady-cold Ottawa Sunday is normal and
+	 *    flagless; a cold snap below the local week's average lights up.
+	 *
+	 * @param array      $f         Single-day forecast (from forecast_for_date)
+	 * @param array|null $allDaily  Optional: the 'daily' block from forecast_json
+	 *                              for week-relative comparisons. Without it,
+	 *                              only the absolute warnings fire.
+	 * @param string|null $forDate  Optional: the date string for $f (skips it
+	 *                              when computing the week's average so we're
+	 *                              comparing today against the other days).
+	 */
+	public static function safety_badges($f, $allDaily = null, $forDate = null) {
+		$out = array();
+		$code = isset($f['code'])      ? (int)$f['code']        : null;
+		$ah   = isset($f['app_hi_f'])  ? (float)$f['app_hi_f']  : null;
+		$al   = isset($f['app_lo_f'])  ? (float)$f['app_lo_f']  : null;
+		$uv   = isset($f['uv_max'])    ? (float)$f['uv_max']    : null;
+		$g    = isset($f['gusts_max']) ? (float)$f['gusts_max'] : null;
+
+		// ---- WARNINGS — absolute, biologically dangerous everywhere ----
+		if ($ah !== null && $ah >= 103)                   { $out[] = array('icon'=>'🥵','label'=>'Extreme heat',   'severity'=>'warning'); }
+		if ($al !== null && $al <=   0)                   { $out[] = array('icon'=>'🥶','label'=>'Frostbite risk', 'severity'=>'warning'); }
+		if ($code !== null && $code >= 95 && $code <= 99) { $out[] = array('icon'=>'⛈️','label'=>'Thunderstorms',  'severity'=>'warning'); }
+		if ($g  !== null && $g  >= 40)                    { $out[] = array('icon'=>'💨','label'=>'Severe wind',    'severity'=>'warning'); }
+		if ($uv !== null && $uv >= 10)                    { $out[] = array('icon'=>'🌞','label'=>'Very high UV',   'severity'=>'warning'); }
+
+		// ---- CAUTIONS — relative to the local 7-day forecast ----
+		if (is_array($allDaily) && !empty($allDaily['time'])) {
+			$idxToday = $forDate !== null ? array_search($forDate, $allDaily['time'], true) : false;
+			$peers = array_keys($allDaily['time']);
+			if ($idxToday !== false) {
+				$peers = array_values(array_diff($peers, array($idxToday)));
+			}
+			$avg = function($key) use ($allDaily, $peers) {
+				$vals = array();
+				foreach ($peers as $i) {
+					if (isset($allDaily[$key][$i]) && is_numeric($allDaily[$key][$i])) $vals[] = (float)$allDaily[$key][$i];
+				}
+				return $vals ? array_sum($vals) / count($vals) : null;
+			};
+			$avgHi  = $avg('apparent_temperature_max');
+			$avgLo  = $avg('apparent_temperature_min');
+			$avgGus = $avg('wind_gusts_10m_max');
+			if ($ah !== null && $avgHi  !== null && ($ah - $avgHi) >=  10)   { $out[] = array('icon'=>'🔥','label'=>'Hot for the week','severity'=>'caution'); }
+			if ($al !== null && $avgLo  !== null && ($avgLo - $al) >=  10)   { $out[] = array('icon'=>'❄️','label'=>'Cold for the week','severity'=>'caution'); }
+			if ($g  !== null && $avgGus !== null && ($g  - $avgGus) >= 15)   { $out[] = array('icon'=>'💨','label'=>'Windy day',       'severity'=>'caution'); }
+		}
+		return $out;
+	}
+
+	/**
+	 * Convenience: look up a park's forecast for a date AND its 7-day daily
+	 * block in one call, return the badges for that date with week-relative
+	 * cautions enabled. Returns [] if no data.
+	 */
+	public function badges_for_date($park_id, $date) {
+		$row = $this->for_park($park_id);
+		if (!$row || empty($row['forecast_json'])) return array();
+		$wx = json_decode($row['forecast_json'], true);
+		if (!is_array($wx) || empty($wx['daily']['time'])) return array();
+		$f = $this->forecast_for_date($park_id, $date);
+		if (!$f) return array();
+		return self::safety_badges($f, $wx['daily'], $date);
+	}
+
+	/**
 	 * Batch variant — one query for a list of park IDs. Returns an assoc
 	 * keyed by park_id. If any returned row is missing or older than
 	 * STALE_MIN, triggers ONE refresh and re-reads. Caller pays at most one
@@ -90,8 +192,9 @@ class Weather extends Ork3 {
 		$url = self::URL_FORECAST . '?'
 			. 'latitude='  . implode(',', $lats) . '&'
 			. 'longitude=' . implode(',', $lngs) . '&'
-			. 'current=temperature_2m,weather_code,is_day,wind_speed_10m&'
-			. 'daily=temperature_2m_max,temperature_2m_min,precipitation_probability_max,weather_code&'
+			. 'current=temperature_2m,apparent_temperature,weather_code,is_day,wind_speed_10m&'
+			. 'daily=temperature_2m_max,temperature_2m_min,apparent_temperature_max,apparent_temperature_min,'
+				. 'precipitation_probability_max,weather_code,uv_index_max,wind_gusts_10m_max&'
 			. 'temperature_unit=fahrenheit&wind_speed_unit=mph&precipitation_unit=inch&'
 			. 'timezone=auto&forecast_days=7';
 

--- a/system/lib/ork3/class.Weather.php
+++ b/system/lib/ork3/class.Weather.php
@@ -38,9 +38,19 @@ class Weather extends Ork3 {
 
 		$row = $this->read_row($park_id);
 		$stale = !$row || strtotime($row['fetched_at']) < (time() - self::STALE_MIN * 60);
-		if ($stale) {
+		if ($stale && $this->is_active_park($park_id)) {
+			// Only refresh for parks in the active set. Pages for dormant parks
+			// stay fast (no Open-Meteo round trip); they just don't show weather.
+			// When a dormant park gets a fresh signin, the active filter picks
+			// it up automatically on the next refresh — no code change needed.
 			$this->refresh_all_active_parks();
 			$row = $this->read_row($park_id);
+		} elseif ($stale) {
+			// Dormant park with a stale row from when it was active. Don't
+			// surface months-old data to the UI; just show nothing. The row
+			// stays in the table (cheap) and will get overwritten if the park
+			// reactivates and the next refresh picks it up.
+			return null;
 		}
 		return $row;
 	}
@@ -169,6 +179,13 @@ class Weather extends Ork3 {
 			$rows = $this->read_rows($ids);
 		}
 		return $rows;
+	}
+
+	private function is_active_park($park_id) {
+		$cutoff = date('Y-m-d', time() - self::ACTIVE_DAYS * 86400);
+		$rs = $this->db->query("SELECT 1 FROM " . DB_PREFIX . "attendance
+			WHERE park_id = " . (int)$park_id . " AND date >= '$cutoff' LIMIT 1");
+		return ($rs && $rs->size() > 0);
 	}
 
 	/**

--- a/system/lib/ork3/class.Weather.php
+++ b/system/lib/ork3/class.Weather.php
@@ -488,6 +488,92 @@ class Weather extends Ork3 {
 	}
 
 	/**
+	 * Parks playing in-person on a given date, each enriched with that day's
+	 * forecast + badges. Sorted by severity (worst weather first) so users
+	 * see the biggest concerns at the top of the list.
+	 */
+	public function play_for_date($date) {
+		if (!preg_match('/^\d{4}-\d{2}-\d{2}$/', $date)) $date = date('Y-m-d');
+		$ids = $this->parks_playing_on($date);
+		if (empty($ids)) return array();
+		$ids_sql = implode(',', array_map('intval', $ids));
+
+		// Pull schedule + park metadata for the playing set
+		$ts = strtotime($date);
+		$dow_name = date('l', $ts);
+		$dom = (int)date('j', $ts);
+		$wom = (int)ceil($dom / 7);
+
+		$rs = $this->db->query("SELECT pd.park_id, pd.parkday_id, pd.purpose, pd.time, pd.description,
+		         p.name AS park_name, k.name AS kingdom_name
+			FROM " . DB_PREFIX . "parkday pd
+			JOIN " . DB_PREFIX . "park p ON p.park_id = pd.park_id
+			LEFT JOIN " . DB_PREFIX . "kingdom k ON k.kingdom_id = p.kingdom_id
+			WHERE pd.online = 0 AND pd.park_id IN ($ids_sql)
+			  AND (
+				(pd.recurrence = 'weekly'        AND pd.week_day = '$dow_name') OR
+				(pd.recurrence = 'week-of-month' AND pd.week_day = '$dow_name' AND pd.week_of_month = $wom) OR
+				(pd.recurrence = 'monthly'       AND pd.month_day = $dom)
+			  )
+			ORDER BY p.name");
+		$by_park = array();
+		if ($rs && $rs->size() > 0) {
+			while ($rs->next()) {
+				$pid = (int)$rs->park_id;
+				$purpose_labels = array(
+					'park-day'         => 'Park Day',
+					'fighter-practice' => 'Fighter Practice',
+					'arts-day'         => 'A&S Day',
+					'other'            => 'Other',
+				);
+				$by_park[$pid][] = array(
+					'parkday_id'  => (int)$rs->parkday_id,
+					'park_name'   => $rs->park_name,
+					'kingdom'     => $rs->kingdom_name,
+					'purpose'     => $purpose_labels[$rs->purpose] ?? ucfirst($rs->purpose),
+					'time'        => $rs->time,
+					'description' => $rs->description,
+				);
+			}
+		}
+
+		// Severity scoring — same scale used in daily_summary's standout pick
+		$severity = array(
+			'Extreme heat'    => 100,
+			'Frostbite risk'  => 100,
+			'Thunderstorms'   =>  80,
+			'Severe wind'     =>  60,
+			'Very high UV'    =>  40,
+			'Warm day'        =>  10,
+			'Cool day'        =>  10,
+			'Windy day'       =>   5,
+		);
+
+		$out = array();
+		foreach ($by_park as $pid => $schedules) {
+			$first = $schedules[0];
+			$fc     = $this->forecast_for_date($pid, $date);
+			$badges = $fc ? self::safety_badges($fc, null, $date) : array();
+			$score  = 0;
+			foreach ($badges as $b) $score += $severity[$b['label']] ?? 0;
+			$out[] = array(
+				'park_id'      => $pid,
+				'park_name'    => $first['park_name'],
+				'kingdom_name' => $first['kingdom'],
+				'schedules'    => $schedules,
+				'forecast'     => $fc,
+				'badges'       => $badges,
+				'_score'       => $score,
+			);
+		}
+		usort($out, function($a, $b) {
+			if ($a['_score'] !== $b['_score']) return $b['_score'] - $a['_score'];
+			return strcmp($a['park_name'], $b['park_name']);
+		});
+		return $out;
+	}
+
+	/**
 	 * Upcoming events in the next $days, each enriched with the start-day
 	 * forecast (or null if outside the cache window). Sorted by start date.
 	 */

--- a/system/lib/ork3/class.Weather.php
+++ b/system/lib/ork3/class.Weather.php
@@ -1,0 +1,206 @@
+<?php
+
+/**
+ * Park weather cache backed by Open-Meteo (https://open-meteo.com/).
+ *
+ * Strategy:
+ *   - One row per park in ork_park_weather.
+ *   - refresh_all_active_parks() batches every active park's coords into a
+ *     single multi-coord Open-Meteo request (one HTTP call total). Intended
+ *     to be invoked from cron every ~30 minutes.
+ *   - for_park($id) reads the cached row. If absent or stale (>STALE_MIN),
+ *     it triggers a refresh inline so any caller can be lazy without needing
+ *     cron in the loop.
+ *
+ * Attribution: Open-Meteo licenses data under CC-BY 4.0. Templates rendering
+ * weather data must include a link to https://open-meteo.com/ next to the
+ * displayed values (see the small "ⓘ" attribution link in the UI partials).
+ */
+class Weather extends Ork3 {
+
+	// Considered "active" if any signin happened in the past N days
+	const ACTIVE_DAYS = 60;
+
+	// Cache row age (minutes) after which we'll re-fetch on a read
+	const STALE_MIN = 90;
+
+	// Open-Meteo endpoints (no API key required)
+	const URL_FORECAST = 'https://api.open-meteo.com/v1/forecast';
+
+	/**
+	 * Read the cached weather row for a park. Triggers an inline refresh of
+	 * ALL active parks if this park's row is missing or older than STALE_MIN.
+	 * Returns null if the park has no coords or weather couldn't be fetched.
+	 */
+	public function for_park($park_id) {
+		$park_id = (int)$park_id;
+		if ($park_id <= 0) return null;
+
+		$row = $this->read_row($park_id);
+		$stale = !$row || strtotime($row['fetched_at']) < (time() - self::STALE_MIN * 60);
+		if ($stale) {
+			$this->refresh_all_active_parks();
+			$row = $this->read_row($park_id);
+		}
+		return $row;
+	}
+
+	/**
+	 * Bulk refresh: one HTTP call to Open-Meteo for every active park's
+	 * coords, then upsert each park's row. Safe to call from cron OR from a
+	 * lazy fallback (callers shouldn't notice the difference beyond latency).
+	 *
+	 * Returns the number of parks refreshed, or 0 on any failure.
+	 */
+	public function refresh_all_active_parks() {
+		$parks = $this->active_parks_with_coords();
+		if (empty($parks)) return 0;
+
+		$lats = array();
+		$lngs = array();
+		foreach ($parks as $p) {
+			$lats[] = number_format((float)$p['latitude'],  4, '.', '');
+			$lngs[] = number_format((float)$p['longitude'], 4, '.', '');
+		}
+
+		$url = self::URL_FORECAST . '?'
+			. 'latitude='  . implode(',', $lats) . '&'
+			. 'longitude=' . implode(',', $lngs) . '&'
+			. 'current=temperature_2m,weather_code,is_day,wind_speed_10m&'
+			. 'daily=temperature_2m_max,temperature_2m_min,precipitation_probability_max,weather_code&'
+			. 'temperature_unit=fahrenheit&wind_speed_unit=mph&precipitation_unit=inch&'
+			. 'timezone=auto&forecast_days=7';
+
+		$json = $this->http_get($url);
+		if ($json === false) return 0;
+
+		$decoded = json_decode($json, true);
+		if (!is_array($decoded)) return 0;
+
+		// Open-Meteo returns either a single object (one coord) or an array of
+		// objects (multi-coord). Normalize to array.
+		$results = isset($decoded[0]) ? $decoded : array($decoded);
+		if (count($results) !== count($parks)) {
+			// Mismatched response — refuse to write partial rows.
+			return 0;
+		}
+
+		$now = date('Y-m-d H:i:s');
+		$updated = 0;
+		foreach ($parks as $i => $p) {
+			$wx = $results[$i] ?? null;
+			if (!is_array($wx)) continue;
+
+			$current = $wx['current'] ?? array();
+			$daily   = $wx['daily']   ?? array();
+
+			$today_high = isset($daily['temperature_2m_max'][0])      ? (float)$daily['temperature_2m_max'][0]      : null;
+			$today_low  = isset($daily['temperature_2m_min'][0])      ? (float)$daily['temperature_2m_min'][0]      : null;
+			$today_pp   = isset($daily['precipitation_probability_max'][0]) ? (int)$daily['precipitation_probability_max'][0] : null;
+
+			$cur_temp = isset($current['temperature_2m']) ? (float)$current['temperature_2m'] : null;
+			$cur_code = isset($current['weather_code'])   ? (int)$current['weather_code']     : null;
+			$cur_day  = isset($current['is_day'])         ? (int)(bool)$current['is_day']     : null;
+			$cur_wind = isset($current['wind_speed_10m']) ? (float)$current['wind_speed_10m'] : null;
+
+			$this->upsert_row($p['park_id'], $now, array(
+				'current_temp_f'   => $cur_temp,
+				'current_code'     => $cur_code,
+				'current_is_day'   => $cur_day,
+				'current_wind_mph' => $cur_wind,
+				'today_high_f'     => $today_high,
+				'today_low_f'      => $today_low,
+				'today_precip_pct' => $today_pp,
+				'forecast_json'    => json_encode($wx),
+			));
+			$updated++;
+		}
+		return $updated;
+	}
+
+	// ---- internals --------------------------------------------------------
+
+	private function active_parks_with_coords() {
+		$cutoff = date('Y-m-d', time() - self::ACTIVE_DAYS * 86400);
+		$sql = "SELECT p.park_id, p.latitude, p.longitude
+		        FROM " . DB_PREFIX . "park p
+		        WHERE p.latitude IS NOT NULL AND p.longitude IS NOT NULL
+		          AND p.latitude != 0 AND p.longitude != 0
+		          AND p.active = 'Active'
+		          AND EXISTS (
+		              SELECT 1 FROM " . DB_PREFIX . "attendance a
+		              WHERE a.park_id = p.park_id AND a.date >= '$cutoff'
+		          )
+		        ORDER BY p.park_id";
+		$rs = $this->db->query($sql);
+		$out = array();
+		if ($rs && $rs->size() > 0) {
+			while ($rs->next()) {
+				$out[] = array(
+					'park_id'   => (int)$rs->park_id,
+					'latitude'  => (float)$rs->latitude,
+					'longitude' => (float)$rs->longitude,
+				);
+			}
+		}
+		return $out;
+	}
+
+	private function read_row($park_id) {
+		$rs = $this->db->query("SELECT * FROM " . DB_PREFIX . "park_weather WHERE park_id = " . (int)$park_id . " LIMIT 1");
+		if (!$rs || $rs->size() === 0) return null;
+		$rs->next();
+		return array(
+			'park_id'          => (int)$rs->park_id,
+			'fetched_at'       => $rs->fetched_at,
+			'current_temp_f'   => $rs->current_temp_f   !== null ? (float)$rs->current_temp_f : null,
+			'current_code'     => $rs->current_code     !== null ? (int)$rs->current_code     : null,
+			'current_is_day'   => $rs->current_is_day   !== null ? (int)$rs->current_is_day   : null,
+			'current_wind_mph' => $rs->current_wind_mph !== null ? (float)$rs->current_wind_mph : null,
+			'today_high_f'     => $rs->today_high_f     !== null ? (float)$rs->today_high_f   : null,
+			'today_low_f'      => $rs->today_low_f      !== null ? (float)$rs->today_low_f    : null,
+			'today_precip_pct' => $rs->today_precip_pct !== null ? (int)$rs->today_precip_pct : null,
+			'forecast_json'    => $rs->forecast_json,
+		);
+	}
+
+	private function upsert_row($park_id, $fetched_at, $fields) {
+		$sets = array();
+		$cols = array('park_id', 'fetched_at');
+		$vals = array((int)$park_id, "'" . mysql_real_escape_string($fetched_at) . "'");
+		foreach ($fields as $col => $val) {
+			$cols[] = $col;
+			if ($val === null) {
+				$vals[] = 'NULL';
+				$sets[] = "`$col` = NULL";
+			} elseif (is_string($val)) {
+				$esc = "'" . mysql_real_escape_string($val) . "'";
+				$vals[] = $esc;
+				$sets[] = "`$col` = $esc";
+			} else {
+				$vals[] = $val;
+				$sets[] = "`$col` = $val";
+			}
+		}
+		$sets[] = "`fetched_at` = '" . mysql_real_escape_string($fetched_at) . "'";
+		$sql = "INSERT INTO " . DB_PREFIX . "park_weather (`" . implode('`,`', $cols) . "`) VALUES (" . implode(',', $vals) . ") "
+		     . "ON DUPLICATE KEY UPDATE " . implode(', ', $sets);
+		$this->db->query($sql);
+	}
+
+	private function http_get($url) {
+		if (function_exists('curl_init')) {
+			$ch = curl_init($url);
+			curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+			curl_setopt($ch, CURLOPT_TIMEOUT, 15);
+			curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 5);
+			curl_setopt($ch, CURLOPT_USERAGENT, 'ORK3 weather refresh (https://ork.amtgard.com)');
+			$body = curl_exec($ch);
+			$http = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+			curl_close($ch);
+			if ($http !== 200) return false;
+			return $body;
+		}
+		return @file_get_contents($url);
+	}
+}


### PR DESCRIPTION
## Summary

- Adds a new `/Weather` page (auth-required) giving a realm-wide weather overview for the week ahead
- **Conditions map**: Leaflet map with colour-coded markers (red = warning, orange = caution, green = favorable, grey = no forecast); click any park or event row to fly to its marker and open a rich popup; Esc / "Esc — Reset Zoom" button returns to the full view
- **7-day date pill strip**: switch between days to see the play list and rundown for each day; pills show red/orange warning dots where parks have weather concerns
- **Play list**: defaults to "weather concerns only" mode (severity-sorted) with a toggle to show all parks alphabetically; search filter; "no recent activity" / "no location set" reasons for missing forecasts
- **Upcoming events**: filtered by selected date pill (multi-day events stay visible while they span the date); date ranges shown on event rows and map popups
- **Rundown summary**: natural-language conditions summary for the selected day, always showing the week-ahead events blurb
- **Performance**: batch `read_rows()` replaces N+1 SELECT pattern throughout; `forecast_for_coords` never blocks on HTTP from the page render path; `warm_event_venue_coords()` cron step pre-warms coord cache for event venues; `strip_severities()` computes pill dots with 7 parkday queries + 1 batch read
- **Data quality**: retired/inactive parks filtered from map and play list; `WX_TODAY` uses server-computed date to avoid UTC/local timezone mismatch in pill labels
- **Dark mode**: date pills, Leaflet zoom controls, popups, and tooltips all styled for dark theme

## Schema

`db-migrations/2026-05-17-park-weather.sql` — creates the `ork_park_weather` table (one row per park, stores current conditions + 7-day `forecast_json` blob). **Run this migration before deploying.**

## Cron

Add to crontab (or update existing entry):

```
0,30 * * * * www-data /usr/bin/php /var/www/ORK3/bin/refresh-weather.php >> /var/log/ork-weather.log 2>&1
```

The cron is not strictly required — the lazy fallback in `Weather::for_park()` keeps data fresh — but it keeps the cache warm so users never pay the ~500ms Open-Meteo round trip. The script now also warms coord-based forecasts for upcoming event venues.

## Test plan

- [ ] Run migration — `DESC ork_park_weather` matches schema
- [ ] Load `/Weather` — rundown, map, play list, and events render without errors; page loads in < 1s (cached data)
- [ ] Click each date pill — play list and map update; events filter to that date or later; pill title updates
- [ ] Click a park row — map flies to marker, popup opens; Esc / Reset Zoom / popup × all return to full view
- [ ] Click an event row — map flies to venue, popup shows date range for multi-day events
- [ ] Toggle "Show all" / "Show concerns only" on play list; search filter narrows correctly
- [ ] Dark mode — pills, map controls, popups all readable
- [ ] Confirm retired parks do not appear on map or play list
- [ ] Run `bin/refresh-weather.php` — log line includes warmed event venue count

🤖 Generated with [Claude Code](https://claude.com/claude-code)