### PR TITLE
Feature/Amtpride Banners

### DIFF
--- a/db-migrations/2026-05-19-mundane-design-hero-gradient.sql
+++ b/db-migrations/2026-05-19-mundane-design-hero-gradient.sql
@@ -1,0 +1,11 @@
+-- Amtpride Nameplate: stores a preset key (e.g. 'pride6', 'progress', 'trans')
+-- that the player template renders into a horizontal multi-stop gradient on
+-- the hero. When set, takes precedence over color_primary/color_secondary.
+-- Key validation lives in class.Player.php::UpdatePlayer against the keys
+-- defined in system/lib/ork3/pride_gradients.php.
+
+ALTER TABLE `ork_mundane_design`
+  ADD COLUMN IF NOT EXISTS `hero_gradient` varchar(32)
+  CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci
+  DEFAULT NULL
+  AFTER `color_secondary`;

--- a/db-migrations/2026-05-21-widen-parkday-description.sql
+++ b/db-migrations/2026-05-21-widen-parkday-description.sql
@@ -1,0 +1,9 @@
+-- Widen ork_parkday.description from varchar(50) to varchar(200).
+-- The park-day edit modal (Parknew_index.tpl) allows maxlength=200, but the
+-- column was varchar(50). With sql_mode empty, longer descriptions were
+-- silently truncated to 50 chars on save, so edits appeared to "do nothing".
+-- This was the sibling missed by 2026-03-29-markdown-description-columns.sql,
+-- which widened the description columns on ork_park / ork_unit / ork_event_calendardetail.
+ALTER TABLE `ork_parkday`
+  MODIFY COLUMN `description` varchar(200)
+  CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '';

--- a/docs/superpowers/specs/2026-05-21-heraldry-overlay-preview-design.md
+++ b/docs/superpowers/specs/2026-05-21-heraldry-overlay-preview-design.md
@@ -1,0 +1,96 @@
+# Live Heraldry-Overlay Preview in the Design modal
+
+**Date:** 2026-05-21
+**Surface:** Playernew "Design My Profile" modal → Colors tab
+**Type:** Enhancement (frontend only)
+
+## Problem
+
+The Design modal's hero preview (`#pn-color-hero-preview`) live-updates for color
+and gradient choices, but the **Heraldry Overlay Strength** buttons (Low / Medium /
+High / Vignette) have no visible effect there. They only set the `pn-hero-overlay`
+hidden field. The preview box also never renders the player's heraldry, so all four
+strengths look identical. Users cannot tell how their heraldry will bleed through the
+hero until they save and reload the profile.
+
+## Goal
+
+Make the overlay-strength buttons (and the modal's initial state) update the preview
+in real time, compositing the player's heraldry over the chosen color/gradient exactly
+as the saved profile hero will render it.
+
+## Constraints
+
+- Frontend only, confined to `orkui/template/revised-frontend/Playernew_index.tpl`.
+- No DB or controller changes — `HeroOverlay` already persists and round-trips.
+- Must match production hero compositing so the preview is truthful.
+- Must not alter the real hero's rendering or its `--pn-overlay-opacity` variable.
+
+## How production composites the hero (reference)
+
+`revised.css:166-202` + `Playernew_index.tpl:951-956`:
+
+- `.pn-hero` paints the base color/gradient (`--pn-hero-bg`).
+- `.pn-hero-bg` is an absolutely-positioned heraldry layer, `background-size:cover`,
+  `filter:blur(6px)`, `opacity: var(--pn-overlay-opacity)`.
+- Opacity map: `low 0.06`, `med 0.12`, `high 0.22`.
+- Vignette mode uses two layers — `.pn-hero-bg-vignette-base` (heavy blur, masked OFF
+  at center) + `.pn-hero-bg-vignette-sharp` (light blur, 0.30 opacity, masked ON at
+  center) — for a sharp center fading to a soft, low-opacity edge.
+- Heraldry layers render regardless of pride-gradient mode (they sit on top of the
+  pride background too).
+- Heraldry URL is already available server-side as `$heraldryUrl`; players with no
+  custom heraldry get the `000000.jpg` placeholder (same as production).
+
+## Design
+
+### 1. Preview markup
+Add heraldry layers as the first children of `#pn-color-hero-preview`, mirroring the
+real hero structure, using `$heraldryUrl`:
+- `.pn-hero-bg pn-preview-bg pn-preview-bg-vignette-base`
+- `.pn-preview-bg-vignette-sharp`
+
+Both vignette layers stay in the DOM; a `pn-preview-vignette` class on the preview box
+controls whether normal or vignette compositing is active. The preview content
+(name + subline) keeps `position:relative; z-index:1` so it stays above the layers
+(the `.pn-hero-preview` rule already sets `position:relative; overflow:hidden`).
+
+### 2. Preview-local opacity variable
+The preview reuses the production layer CSS (blur, masks) but is driven by its **own**
+opacity variable so the real hero is untouched. The preview-scoped `.pn-preview-bg`
+rule reads `var(--pn-preview-overlay-opacity, 0.12)`, set inline on the preview box by
+JS. Vignette base/sharp layers use preview-scoped selectors so their opacity/blur/mask
+match production (base uses the preview opacity var; sharp is fixed at 0.30 like prod).
+
+### 3. Wire-up (existing handlers)
+- **Overlay buttons** (`tpl:3941`): on click, in addition to the existing active-class
+  + hidden-field update, set the preview's `--pn-preview-overlay-opacity` from the
+  same map, toggle `pn-preview-vignette` for the vignette button, then call
+  `applyOverlayPreview()` / `updateColorPreview()`.
+- **`updateColorPreview()`**: unchanged base behavior (color or gradient as
+  `background`). Heraldry layers sit on top via CSS, including under pride gradients.
+- **Reset** (`tpl:3917`): already resets overlay to `med`; ensure it re-applies the
+  preview overlay state.
+- **Init**: call the overlay-preview applier once on modal setup so the preview opens
+  reflecting the saved `HeroOverlay`.
+
+### 4. Helper
+A small `applyOverlayPreview(level)` function centralizes: set opacity var, toggle
+vignette class. Called from button clicks, reset, and init. Keeps the logic in one
+place rather than duplicated.
+
+## Edge cases
+- **No custom heraldry:** placeholder `000000.jpg` renders faintly — matches prod, stays
+  truthful.
+- **Pride flag active:** heraldry overlays the pride gradient, same as production.
+- **Dark mode:** preview hero is always rendered on the light modal surface; no special
+  handling needed.
+
+## Out of scope
+- Changing the real hero rendering, the opacity map, or persisted values.
+- Restyling the preview box dimensions.
+
+## Verification
+Load a player **with** heraldry in Chrome, open the Design modal, and click
+Low → Med → High → Vignette. Confirm the heraldry bleed-through changes live and that,
+after submitting, the saved profile hero matches the previewed strength.

--- a/orkui/controller/controller.Kingdom.php
+++ b/orkui/controller/controller.Kingdom.php
@@ -395,6 +395,7 @@ class Controller_Kingdom extends Controller {
 
 		$this->data['AwardOptions']        = $this->Award->fetch_award_option_list($kingdom_id, 'Awards');
 		$this->data['OfficerOptions']      = $this->Award->fetch_award_option_list($kingdom_id, 'Officers');
+		$this->data['CustomTitleAliasOptions'] = $this->Award->fetch_custom_title_alias_options();
 		$preloadOfficers = [];
 		foreach ($this->data['kingdom_officers']['Officers'] ?? [] as $o) {
 			if (in_array($o['OfficerRole'], ['Monarch', 'Regent']) && (int)$o['MundaneId'] > 0)

--- a/orkui/controller/controller.Park.php
+++ b/orkui/controller/controller.Park.php
@@ -83,6 +83,7 @@ class Controller_Park extends Controller
 
 		$this->data['AwardOptions']   = $this->Award->fetch_award_option_list($this->session->kingdom_id, 'Awards');
 		$this->data['OfficerOptions'] = $this->Award->fetch_award_option_list($this->session->kingdom_id, 'Officers');
+		$this->data['CustomTitleAliasOptions'] = $this->Award->fetch_custom_title_alias_options();
 		$preloadOfficers = [];
 		foreach ($this->data['park_officers']['Officers'] ?? [] as $o) {
 			if (in_array($o['OfficerRole'], ['Monarch', 'Regent']) && (int)$o['MundaneId'] > 0)

--- a/orkui/controller/controller.Player.php
+++ b/orkui/controller/controller.Player.php
@@ -369,35 +369,7 @@ class Controller_Player extends Controller {
 		$_ctid = 0;
 		if ($_ctSentinel && $_ctSentinel->Size() > 0) { $_ctSentinel->Next(); $_ctid = (int)$_ctSentinel->award_id; }
 		$this->data['CustomTitleAwardId'] = $_ctid;
-		$DB->Clear();
-		$_ctAliasSql = "SELECT award_id, name, peerage, is_title
-			FROM " . DB_PREFIX . "award
-			WHERE officer_role = 'none'
-			  AND name <> 'Custom Title'
-			  AND name <> 'Custom Award'
-			  AND (peerage IN ('Page','Lords-Page','Squire','Man-At-Arms','Master','Knight') OR is_title = 1)
-			ORDER BY FIELD(peerage,'Knight','Master','Squire','Man-At-Arms','Lords-Page','Page') DESC, is_title DESC, name ASC";
-		$_ctAliasRes = $DB->DataSet($_ctAliasSql);
-		$_peerageLadder = []; $_otherTitles = [];
-		if ($_ctAliasRes && $_ctAliasRes->Size() > 0) {
-			while ($_ctAliasRes->Next()) {
-				$row = [
-					'AwardId' => (int)$_ctAliasRes->award_id,
-					'Name'    => $_ctAliasRes->name,
-					'Peerage' => $_ctAliasRes->peerage,
-				];
-				if (in_array($_ctAliasRes->peerage, ['Page','Lords-Page','Squire','Man-At-Arms','Master','Knight'], true)) {
-					$_peerageLadder[] = $row;
-				} elseif ((int)$_ctAliasRes->is_title === 1) {
-					$_otherTitles[] = $row;
-				}
-			}
-		}
-		$DB->Clear();
-		$this->data['CustomTitleAliasOptions'] = [
-			'Peerage' => $_peerageLadder,
-			'Titles'  => $_otherTitles,
-		];
+		$this->data['CustomTitleAliasOptions'] = $this->Award->fetch_custom_title_alias_options();
 		$this->data['PronounOptions'] = $this->Pronoun->fetch_pronoun_option_list($this->data['Player']['PronounId']);
 		$this->data['PronounList']    = $this->Pronoun->fetch_pronoun_list();
 		$this->data['Details']       = $this->Player->fetch_player_details($id);

--- a/orkui/controller/controller.PlayerAjax.php
+++ b/orkui/controller/controller.PlayerAjax.php
@@ -380,6 +380,7 @@ class Controller_PlayerAjax extends Controller {
 				'ColorPrimary'  => (isset($_POST['ColorPrimary']) && preg_match('/^#[0-9a-fA-F]{6}$/', $_POST['ColorPrimary'])) ? $_POST['ColorPrimary'] : null,
 				'ColorAccent'   => (isset($_POST['ColorAccent']) && preg_match('/^#[0-9a-fA-F]{6}$/', $_POST['ColorAccent'])) ? $_POST['ColorAccent'] : null,
 					'ColorSecondary'=> isset($_POST['ColorSecondary']) ? (preg_match('/^#[0-9a-fA-F]{6}$/', $_POST['ColorSecondary']) ? $_POST['ColorSecondary'] : '') : null,
+					'HeroGradient'  => isset($_POST['HeroGradient'])   ? substr(trim((string)$_POST['HeroGradient']), 0, 32) : null,
 					'HeroOverlay'   => isset($_POST['HeroOverlay'])     ? $_POST['HeroOverlay']    : null,
 				'NamePrefix'    => isset($_POST['NamePrefix'])    ? trim($_POST['NamePrefix'])  : null,
 				'NameSuffix'    => isset($_POST['NameSuffix'])    ? trim($_POST['NameSuffix'])  : null,

--- a/orkui/controller/controller.SearchAjax.php
+++ b/orkui/controller/controller.SearchAjax.php
@@ -40,6 +40,27 @@ class Controller_SearchAjax extends Controller {
 			$searchQ = trim($m[3]);
 		}
 
+		// Typographic punctuation/whitespace variants the DB collation does NOT treat as equal
+		// to their ASCII forms, so a normal-keyboard search misses names that store them (e.g.
+		// "Wolf’s Run" with U+2019). Accented letters are already matched by utf8mb4_unicode_ci.
+		$punctFolds = [
+			"\u{2019}" => "'", "\u{2018}" => "'",   // ’ ‘ → '
+			"\u{201C}" => '"', "\u{201D}" => '"',   // “ ” → "
+			"\u{2014}" => '-', "\u{2013}" => '-',   // — – → -
+			"\u{00A0}" => ' ',                       // no-break space → space
+			"\u{02DC}" => '~',                       // ˜ → ~
+		];
+		// Normalize the user's typed/pasted query, then provide a SQL expression that folds a
+		// column the same way so both sides of every LIKE compare in normalized ASCII form.
+		$searchQ  = strtr($searchQ, $punctFolds);
+		$sqlLit   = fn($s) => "'" . str_replace("'", "''", $s) . "'";
+		$foldText = function ($col) use ($punctFolds, $sqlLit) {
+			foreach ($punctFolds as $from => $to) {
+				$col = "REPLACE({$col}, " . $sqlLit($from) . ", " . $sqlLit($to) . ")";
+			}
+			return $col;
+		};
+
 		$term = str_replace(["'", '%', '_', '\\'], ["''", '\\%', '\\_', '\\\\'], $searchQ);
 
 		// Per-category budgets; unused slots from each category roll to players
@@ -51,7 +72,7 @@ class Controller_SearchAjax extends Controller {
 		$unitBudget    = $focus === 'unit'    ? 10 : ($focus ? 0 : 3);
 
 		// Parks — prioritize user's kingdom first; narrow by abbreviation prefix if provided
-		$parkWhere = "p.active = 'Active' AND (p.name LIKE '%{$term}%' OR p.abbreviation LIKE '%{$term}%')";
+		$parkWhere = "p.active = 'Active' AND (" . $foldText('p.name') . " LIKE '%{$term}%' OR p.abbreviation LIKE '%{$term}%')";
 		if ($filterPid > 0)           { $parkWhere .= " AND p.park_id = {$filterPid}"; }
 		elseif ($filterKid > 0)       { $parkWhere .= " AND p.kingdom_id = {$filterKid}"; }
 		$parkOrder = valid_id($pid)
@@ -73,10 +94,11 @@ class Controller_SearchAjax extends Controller {
 		// Kingdoms — skip if scoped to a specific kingdom/park by abbreviation prefix
 		$kingdoms = [];
 		if ($filterKid === 0) {
+			$kingdomWhere = $foldText('k.name') . " LIKE '%{$term}%' OR k.abbreviation LIKE '%{$term}%'";
 			$rs = $DB->DataSet("
 				SELECT k.kingdom_id, k.name, k.abbreviation
 				FROM ork_kingdom k
-				WHERE k.name LIKE '%{$term}%' OR k.abbreviation LIKE '%{$term}%'
+				WHERE {$kingdomWhere}
 				ORDER BY k.name
 				LIMIT {$kingdomBudget}");
 			while ($rs->Next()) {
@@ -86,10 +108,11 @@ class Controller_SearchAjax extends Controller {
 		$playerBudget += $kingdomBudget - count($kingdoms);
 
 		// Units
+		$unitWhere = $foldText('name') . " LIKE '%{$term}%'";
 		$rs = $DB->DataSet("
 			SELECT unit_id, name, type
 			FROM ork_unit
-			WHERE name LIKE '%{$term}%'
+			WHERE {$unitWhere}
 			ORDER BY name
 			LIMIT {$unitBudget}");
 		$units = [];
@@ -111,10 +134,10 @@ class Controller_SearchAjax extends Controller {
 		$isOrkAdmin     = $_searchUid > 0 && Ork3::$Lib->authorization->HasAuthority($_searchUid, AUTH_ADMIN, null, null);
 		$DB->Clear();
 		$mundaneClause  = $isOrkAdmin
-			? "OR m.given_name LIKE '%{$term}%' OR m.surname LIKE '%{$term}%'"
-			: "OR (m.restricted = 0 AND (m.given_name LIKE '%{$term}%' OR m.surname LIKE '%{$term}%'))";
+			? "OR " . $foldText('m.given_name') . " LIKE '%{$term}%' OR " . $foldText('m.surname') . " LIKE '%{$term}%'"
+			: "OR (m.restricted = 0 AND (" . $foldText('m.given_name') . " LIKE '%{$term}%' OR " . $foldText('m.surname') . " LIKE '%{$term}%'))";
 		$playerWhere = "{$suspendedClause} AND {$activeClause} AND LENGTH(m.persona) > 0
-			  AND (m.persona LIKE '%{$term}%'
+			  AND (" . $foldText('m.persona') . " LIKE '%{$term}%'
 			    OR m.username LIKE '%{$term}%'
 			    {$mundaneClause})";
 		if ($filterPid > 0)           { $playerWhere .= " AND m.park_id = {$filterPid}"; }

--- a/orkui/model/model.Award.php
+++ b/orkui/model/model.Award.php
@@ -116,43 +116,6 @@ class Model_Award extends Model {
         }
     }
 
-    /**
-     * Awards a "Custom Title" may be aliased to: peerage-ladder rungs and other titles.
-     * Drives the Add Award modal's "Alias of" dropdown on the player, kingdom, and park
-     * profiles. The list is global (not kingdom-specific), so it is shared across all three.
-     *
-     * @return array ['Peerage' => [...], 'Titles' => [...]] of ['AwardId','Name','Peerage'] rows
-     */
-    function fetch_custom_title_alias_options() {
-        global $DB;
-        $DB->Clear();
-        $sql = "SELECT award_id, name, peerage, is_title
-            FROM " . DB_PREFIX . "award
-            WHERE officer_role = 'none'
-              AND name <> 'Custom Title'
-              AND name <> 'Custom Award'
-              AND (peerage IN ('Page','Lords-Page','Squire','Man-At-Arms','Master','Knight') OR is_title = 1)
-            ORDER BY FIELD(peerage,'Knight','Master','Squire','Man-At-Arms','Lords-Page','Page') DESC, is_title DESC, name ASC";
-        $res = $DB->DataSet($sql);
-        $peerage = []; $titles = [];
-        if ($res && $res->Size() > 0) {
-            while ($res->Next()) {
-                $row = [
-                    'AwardId' => (int)$res->award_id,
-                    'Name'    => $res->name,
-                    'Peerage' => $res->peerage,
-                ];
-                if (in_array($res->peerage, ['Page','Lords-Page','Squire','Man-At-Arms','Master','Knight'], true)) {
-                    $peerage[] = $row;
-                } elseif ((int)$res->is_title === 1) {
-                    $titles[] = $row;
-                }
-            }
-        }
-        $DB->Clear();
-        return ['Peerage' => $peerage, 'Titles' => $titles];
-    }
-
 
 }
 

--- a/orkui/model/model.Award.php
+++ b/orkui/model/model.Award.php
@@ -116,6 +116,43 @@ class Model_Award extends Model {
         }
     }
 
+    /**
+     * Awards a "Custom Title" may be aliased to: peerage-ladder rungs and other titles.
+     * Drives the Add Award modal's "Alias of" dropdown on the player, kingdom, and park
+     * profiles. The list is global (not kingdom-specific), so it is shared across all three.
+     *
+     * @return array ['Peerage' => [...], 'Titles' => [...]] of ['AwardId','Name','Peerage'] rows
+     */
+    function fetch_custom_title_alias_options() {
+        global $DB;
+        $DB->Clear();
+        $sql = "SELECT award_id, name, peerage, is_title
+            FROM " . DB_PREFIX . "award
+            WHERE officer_role = 'none'
+              AND name <> 'Custom Title'
+              AND name <> 'Custom Award'
+              AND (peerage IN ('Page','Lords-Page','Squire','Man-At-Arms','Master','Knight') OR is_title = 1)
+            ORDER BY FIELD(peerage,'Knight','Master','Squire','Man-At-Arms','Lords-Page','Page') DESC, is_title DESC, name ASC";
+        $res = $DB->DataSet($sql);
+        $peerage = []; $titles = [];
+        if ($res && $res->Size() > 0) {
+            while ($res->Next()) {
+                $row = [
+                    'AwardId' => (int)$res->award_id,
+                    'Name'    => $res->name,
+                    'Peerage' => $res->peerage,
+                ];
+                if (in_array($res->peerage, ['Page','Lords-Page','Squire','Man-At-Arms','Master','Knight'], true)) {
+                    $peerage[] = $row;
+                } elseif ((int)$res->is_title === 1) {
+                    $titles[] = $row;
+                }
+            }
+        }
+        $DB->Clear();
+        return ['Peerage' => $peerage, 'Titles' => $titles];
+    }
+
 
 }
 

--- a/orkui/template/default/Award_addawards.tpl
+++ b/orkui/template/default/Award_addawards.tpl
@@ -112,8 +112,11 @@
 						Action: 'Search/Player',
 						type: 'all',
 						search: request.term,
-						kingdom_id: <?=$KingdomId ?>,
-						limit: 6
+						// Given By is cross-kingdom: an award can be presented by someone from
+						// any kingdom, so do NOT scope to the page's kingdom. The (KAbbr:PAbbr)
+						// suffix below disambiguates same-named personas across kingdoms.
+						kingdom_id: 0,
+						limit: 12
 					},
 					function( data ) {
 						var suggestions = [];

--- a/orkui/template/default/Unit_index.tpl
+++ b/orkui/template/default/Unit_index.tpl
@@ -1023,7 +1023,7 @@ document.querySelectorAll('.pn-overlay').forEach(function (overlay) {
 });
 
 /* ── Player search factory ──────────────────────────────── */
-var UN_SEARCH_URL = '<?=HTTP_SERVICE?>Search/SearchService.php';
+var UN_PSEARCH_BASE = '<?=UIR?>KingdomAjax/playersearch/';
 var UN_SCOPE_KID  = <?=(int)($ScopeKingdomId ?? 0)?>;
 var UN_SCOPE_PID  = <?=(int)($ScopeParkId ?? 0)?>;
 
@@ -1032,7 +1032,7 @@ function initPlayerSearch(cfg) {
 	var $input   = document.getElementById(cfg.inputId);
 	var $results = document.getElementById(cfg.resultsId);
 	var $hidden  = document.getElementById(cfg.hiddenId);
-	var debounce, focusIdx = -1;
+	var debounce, focusIdx = -1, searchSeq = 0;
 	var seen = {};
 
 	function closeResults() {
@@ -1055,8 +1055,15 @@ function initPlayerSearch(cfg) {
 		el.className   = 'un-ac-item' + (groupClass ? ' ' + groupClass : '');
 		el.dataset.id  = id;
 		el.dataset.lbl = label;
-		el.innerHTML   = '<span>' + label + '</span>'
-			+ (scope ? '<span class="un-ac-scope">' + scope + '</span>' : '');
+		var nameSpan = document.createElement('span');
+		nameSpan.textContent = label;
+		el.appendChild(nameSpan);
+		if (scope) {
+			var scopeSpan = document.createElement('span');
+			scopeSpan.className   = 'un-ac-scope';
+			scopeSpan.textContent = scope;
+			el.appendChild(scopeSpan);
+		}
 		el.addEventListener('mousedown', function (e) {
 			e.preventDefault();
 			selectPlayer(id, label + (scope ? ' (' + scope + ')' : ''));
@@ -1065,49 +1072,58 @@ function initPlayerSearch(cfg) {
 	}
 
 	function addGroup(label, players) {
-		if (!players.length) return;
+		var unseen = (players || []).filter(function (p) { return !seen[p.MundaneId]; });
+		if (!unseen.length) return;
 		var hdr = document.createElement('div');
 		hdr.className   = 'un-ac-group-label';
 		hdr.textContent = label;
 		$results.appendChild(hdr);
-		players.forEach(function (p) {
-			if (seen[p.MundaneId]) return;
+		unseen.forEach(function (p) {
 			seen[p.MundaneId] = true;
 			$results.appendChild(buildItem(p, ''));
 		});
 	}
 
 	function runSearch(term) {
-		seen = {};
-		$results.innerHTML = '';
-		$hidden.value = '';
-		var base = { Action: 'Search/Player', type: 'all', search: term, limit: 8 };
-		var calls = [];
-		/* Three-tier: park → kingdom → global */
-		if (cfg.parkId)    calls.push($.getJSON(UN_SEARCH_URL, $.extend({}, base, { park_id:    cfg.parkId })));
-		if (cfg.kingdomId) calls.push($.getJSON(UN_SEARCH_URL, $.extend({}, base, { kingdom_id: cfg.kingdomId })));
-		calls.push($.getJSON(UN_SEARCH_URL, base));
-
-		$.when.apply($, calls).done(function () {
-			var args = calls.length === 1 ? [arguments] : Array.prototype.slice.call(arguments);
-			var parkRes    = (cfg.parkId    && args[0]) ? (args[0][0] || []) : [];
-			var kingRes    = (cfg.kingdomId && args[cfg.parkId ? 1 : 0]) ? (args[cfg.parkId ? 1 : 0][0] || []) : [];
-			var allRes     = (args[args.length - 1]  ? args[args.length - 1][0] : null) || [];
-
-			var hasPark    = cfg.parkId    && parkRes.length;
-			var hasKing    = cfg.kingdomId && kingRes.length;
-
-			if (!hasPark && !hasKing && !allRes.length) {
+		/* Canonical playersearch endpoint: LIKE-based filtering, own-kingdom-first
+		   ordering, robust scope handling. Mirrors the Event RSVP modal's tiers. */
+		var kid  = cfg.kingdomId || 0;
+		var pid  = cfg.parkId || 0;
+		var base = UN_PSEARCH_BASE + kid;
+		var q    = '&include_inactive=1&include_suspended=1&q=' + encodeURIComponent(term);
+		var groups;
+		// An abbreviation prefix ("nb:ff wolf") makes the server filter by abbreviation
+		// and ignore scope/park_id — show one group so results aren't mislabelled.
+		if (/^[a-z0-9]{2,3}:[a-z0-9*]{0,3}\s+\S/i.test(term)) {
+			groups = [ { label: 'All Players', url: base + '&scope=all' + q } ];
+		} else if (pid > 0 && kid > 0) {
+			groups = [
+				{ label: 'In Park',     url: base + '&scope=own&park_id=' + pid + q },
+				{ label: 'In Kingdom',  url: base + '&scope=own' + q },
+				{ label: 'All Players', url: base + '&scope=exclude' + q }
+			];
+		} else if (kid > 0) {
+			groups = [
+				{ label: 'In Kingdom',  url: base + '&scope=own' + q },
+				{ label: 'All Players', url: base + '&scope=exclude' + q }
+			];
+		} else {
+			groups = [ { label: 'All Players', url: base + '&scope=all' + q } ];
+		}
+		var mySeq = ++searchSeq;
+		Promise.all(groups.map(function (g) {
+			return fetch(g.url).then(function (r) { return r.json(); }).catch(function () { return []; });
+		})).then(function (resArr) {
+			if (mySeq !== searchSeq) return; // a newer keystroke superseded this response
+			seen = {};
+			$results.innerHTML = '';
+			$hidden.value = '';
+			groups.forEach(function (g, i) { addGroup(g.label, resArr[i] || []); });
+			if (!$results.children.length) {
 				var empty = document.createElement('div');
 				empty.className   = 'un-ac-empty';
 				empty.textContent = 'No players found.';
 				$results.appendChild(empty);
-			} else {
-				if (hasPark)  addGroup('In Park',    parkRes);
-				if (hasKing)  addGroup('In Kingdom', kingRes);
-				/* global results not already shown */
-				var rest = allRes.filter(function (p) { return !seen[p.MundaneId]; });
-				if (rest.length) addGroup('All Players', rest);
 			}
 			focusIdx = -1;
 			$results.classList.add('un-ac-open');

--- a/orkui/template/default/style/orkui.css
+++ b/orkui/template/default/style/orkui.css
@@ -6605,6 +6605,15 @@ button.ui-button::-moz-focus-inner { border: 0; padding: 0; } /* reset extra pad
 
 html, body {
     height: 100%;
+    /* Guard against horizontal overflow from any descendant. Without this, an
+       element wider than the viewport makes the page scroll sideways, and on
+       Android Chrome a position:fixed; width:100% bar (#newmenu) then spans the
+       full scrollable width — pushing its right-side controls (Login / View
+       Profile / theme toggle) off the right edge. iOS clamps fixed elements to
+       the visual viewport so it doesn't show there. Clamping here keeps the
+       fixed nav pinned to the device width on every platform. */
+    overflow-x: hidden;
+    max-width: 100%;
 }
 body {
 	/*

--- a/orkui/template/revised-frontend/Kingdomnew_index.tpl
+++ b/orkui/template/revised-frontend/Kingdomnew_index.tpl
@@ -998,8 +998,8 @@ var KnConfig = {
 
 			<!-- Alias dropdown (shown only for "Custom Title") -->
 			<div class="kn-acct-field" id="kn-award-alias-row" style="display:none">
-				<label for="kn-award-alias">Alias of <span style="color:#a0aec0;font-weight:400;font-size:11px">(optional)</span></label>
-				<select id="kn-award-alias">
+				<label for="kn-award-alias">Alias of <span style="color:var(--ork-text-lighter);font-weight:400;font-size:11px">(optional)</span></label>
+				<select name="AliasAwardId" id="kn-award-alias">
 					<option value="0">— None —</option>
 					<?php if (!empty($CustomTitleAliasOptions['Peerage'])): ?>
 					<optgroup label="Peerage Ladder">
@@ -1016,7 +1016,7 @@ var KnConfig = {
 					</optgroup>
 					<?php endif; ?>
 				</select>
-				<div style="font-size:11px;color:#718096;margin-top:4px">Aliasing makes this title count as the selected core award for belt relationships and reports.</div>
+				<div style="font-size:11px;color:var(--ork-text-muted);margin-top:4px">Aliasing makes this title count as the selected core award for belt relationships and reports.</div>
 			</div>
 
 			<!-- Rank Picker -->
@@ -1114,7 +1114,7 @@ var KnConfig = {
 			</div>
 			<div class="pk-acct-field" id="kn-rec-rank-row" style="display:none">
 				<label>Rank <span id="kn-rec-rank-hint" style="color:#a0aec0;font-weight:400;font-size:11px">(optional)</span></label>
-				<div class="pk-rank-pills-wrap" id="kn-rec-rank-pills"></div>
+				<div class="kn-rank-pills-wrap" id="kn-rec-rank-pills"></div>
 				<input type="hidden" id="kn-rec-rank-val" value="" />
 			</div>
 			<div class="pk-acct-field">

--- a/orkui/template/revised-frontend/Kingdomnew_index.tpl
+++ b/orkui/template/revised-frontend/Kingdomnew_index.tpl
@@ -1021,7 +1021,7 @@ var KnConfig = {
 
 			<!-- Rank Picker -->
 			<div class="kn-acct-field" id="kn-award-rank-row" style="display:none">
-				<label>Rank <span id="kn-rank-hint" style="color:#a0aec0;font-weight:400;font-size:11px">— click to select; blue = already held, green border = suggested next</span></label>
+				<label>Rank <span id="kn-rank-hint" style="color:#a0aec0;font-weight:400;font-size:11px">— Select a rank of the award to recommend. Green ranks have already been awarded. You can suggest a rank higher than their next if you believe they have achieved it.</span></label>
 				<div class="kn-rank-pills-wrap" id="kn-rank-pills"></div>
 				<input type="hidden" id="kn-award-rank-val" value="" />
 			</div>

--- a/orkui/template/revised-frontend/Kingdomnew_index.tpl
+++ b/orkui/template/revised-frontend/Kingdomnew_index.tpl
@@ -992,8 +992,31 @@ var KnConfig = {
 
 			<!-- Custom Award Name -->
 			<div class="kn-acct-field" id="kn-award-custom-row" style="display:none">
-				<label for="kn-award-custom-name">Custom Award Name</label>
+				<label for="kn-award-custom-name" id="kn-award-custom-label">Custom Award Name</label>
 				<input type="text" id="kn-award-custom-name" maxlength="64" placeholder="Enter custom award name..." />
+			</div>
+
+			<!-- Alias dropdown (shown only for "Custom Title") -->
+			<div class="kn-acct-field" id="kn-award-alias-row" style="display:none">
+				<label for="kn-award-alias">Alias of <span style="color:#a0aec0;font-weight:400;font-size:11px">(optional)</span></label>
+				<select id="kn-award-alias">
+					<option value="0">— None —</option>
+					<?php if (!empty($CustomTitleAliasOptions['Peerage'])): ?>
+					<optgroup label="Peerage Ladder">
+						<?php foreach ($CustomTitleAliasOptions['Peerage'] as $_opt): ?>
+						<option value="<?= (int)$_opt['AwardId'] ?>"><?= htmlspecialchars($_opt['Name']) ?> (<?= htmlspecialchars($_opt['Peerage']) ?>)</option>
+						<?php endforeach; ?>
+					</optgroup>
+					<?php endif; ?>
+					<?php if (!empty($CustomTitleAliasOptions['Titles'])): ?>
+					<optgroup label="Other Titles">
+						<?php foreach ($CustomTitleAliasOptions['Titles'] as $_opt): ?>
+						<option value="<?= (int)$_opt['AwardId'] ?>"><?= htmlspecialchars($_opt['Name']) ?></option>
+						<?php endforeach; ?>
+					</optgroup>
+					<?php endif; ?>
+				</select>
+				<div style="font-size:11px;color:#718096;margin-top:4px">Aliasing makes this title count as the selected core award for belt relationships and reports.</div>
 			</div>
 
 			<!-- Rank Picker -->

--- a/orkui/template/revised-frontend/Parknew_index.tpl
+++ b/orkui/template/revised-frontend/Parknew_index.tpl
@@ -1274,7 +1274,7 @@ var PkConfig = {
 
 			<!-- Rank Picker -->
 			<div class="pk-acct-field" id="pk-award-rank-row" style="display:none">
-				<label>Rank <span id="pk-rank-hint" style="color:#a0aec0;font-weight:400;font-size:11px">— click to select; blue = already held, green border = suggested next</span></label>
+				<label>Rank <span id="pk-rank-hint" style="color:#a0aec0;font-weight:400;font-size:11px">— Select a rank of the award to recommend. Green ranks have already been awarded. You can suggest a rank higher than their next if you believe they have achieved it.</span></label>
 				<div class="pk-rank-pills-wrap" id="pk-rank-pills"></div>
 				<input type="hidden" id="pk-award-rank-val" value="" />
 			</div>

--- a/orkui/template/revised-frontend/Parknew_index.tpl
+++ b/orkui/template/revised-frontend/Parknew_index.tpl
@@ -1245,8 +1245,31 @@ var PkConfig = {
 
 			<!-- Custom Award Name -->
 			<div class="pk-acct-field" id="pk-award-custom-row" style="display:none">
-				<label for="pk-award-custom-name">Custom Award Name</label>
+				<label for="pk-award-custom-name" id="pk-award-custom-label">Custom Award Name</label>
 				<input type="text" id="pk-award-custom-name" maxlength="64" placeholder="Enter custom award name..." />
+			</div>
+
+			<!-- Alias dropdown (shown only for "Custom Title") -->
+			<div class="pk-acct-field" id="pk-award-alias-row" style="display:none">
+				<label for="pk-award-alias">Alias of <span style="color:#a0aec0;font-weight:400;font-size:11px">(optional)</span></label>
+				<select id="pk-award-alias">
+					<option value="0">— None —</option>
+					<?php if (!empty($CustomTitleAliasOptions['Peerage'])): ?>
+					<optgroup label="Peerage Ladder">
+						<?php foreach ($CustomTitleAliasOptions['Peerage'] as $_opt): ?>
+						<option value="<?= (int)$_opt['AwardId'] ?>"><?= htmlspecialchars($_opt['Name']) ?> (<?= htmlspecialchars($_opt['Peerage']) ?>)</option>
+						<?php endforeach; ?>
+					</optgroup>
+					<?php endif; ?>
+					<?php if (!empty($CustomTitleAliasOptions['Titles'])): ?>
+					<optgroup label="Other Titles">
+						<?php foreach ($CustomTitleAliasOptions['Titles'] as $_opt): ?>
+						<option value="<?= (int)$_opt['AwardId'] ?>"><?= htmlspecialchars($_opt['Name']) ?></option>
+						<?php endforeach; ?>
+					</optgroup>
+					<?php endif; ?>
+				</select>
+				<div style="font-size:11px;color:#718096;margin-top:4px">Aliasing makes this title count as the selected core award for belt relationships and reports.</div>
 			</div>
 
 			<!-- Rank Picker -->

--- a/orkui/template/revised-frontend/Parknew_index.tpl
+++ b/orkui/template/revised-frontend/Parknew_index.tpl
@@ -1251,8 +1251,8 @@ var PkConfig = {
 
 			<!-- Alias dropdown (shown only for "Custom Title") -->
 			<div class="pk-acct-field" id="pk-award-alias-row" style="display:none">
-				<label for="pk-award-alias">Alias of <span style="color:#a0aec0;font-weight:400;font-size:11px">(optional)</span></label>
-				<select id="pk-award-alias">
+				<label for="pk-award-alias">Alias of <span style="color:var(--ork-text-lighter);font-weight:400;font-size:11px">(optional)</span></label>
+				<select name="AliasAwardId" id="pk-award-alias">
 					<option value="0">— None —</option>
 					<?php if (!empty($CustomTitleAliasOptions['Peerage'])): ?>
 					<optgroup label="Peerage Ladder">
@@ -1269,7 +1269,7 @@ var PkConfig = {
 					</optgroup>
 					<?php endif; ?>
 				</select>
-				<div style="font-size:11px;color:#718096;margin-top:4px">Aliasing makes this title count as the selected core award for belt relationships and reports.</div>
+				<div style="font-size:11px;color:var(--ork-text-muted);margin-top:4px">Aliasing makes this title count as the selected core award for belt relationships and reports.</div>
 			</div>
 
 			<!-- Rank Picker -->

--- a/orkui/template/revised-frontend/Playernew_index.tpl
+++ b/orkui/template/revised-frontend/Playernew_index.tpl
@@ -215,21 +215,30 @@
 	}
 	$_pnAccent = (!empty($Player['ColorAccent']) && preg_match('/^#[0-9a-fA-F]{6}$/', $Player['ColorAccent'])) ? $Player['ColorAccent'] : '#4299e1';
 	$_pnColorSecondary = (!empty($Player['ColorSecondary']) && preg_match('/^#[0-9a-fA-F]{6}$/', $Player['ColorSecondary'])) ? $Player['ColorSecondary'] : '';
+	// Amtpride Nameplate: when set, this preset key takes precedence over
+	// color_primary/color_secondary on the hero background. Suspended state
+	// still wins (red signal), as does dark mode for the rest of the page.
+	$_pnPrideGradients = require __DIR__ . '/../../../system/lib/ork3/pride_gradients.php';
+	$_pnHeroGradientKey = (!$isSuspended && !empty($Player['HeroGradient']) && isset($_pnPrideGradients[$Player['HeroGradient']])) ? $Player['HeroGradient'] : '';
+	$_pnHeroGradientCss = $_pnHeroGradientKey ? ('linear-gradient(90deg, ' . implode(', ', $_pnPrideGradients[$_pnHeroGradientKey]['colors']) . ')') : '';
 	$_pnOverlay = in_array($Player['HeroOverlay'] ?? 'med', ['low','med','high','vignette']) ? ($Player['HeroOverlay'] ?? 'med') : 'med';
 	// Opacity for the flat-blur layer. Unused in vignette mode (which renders
 	// its own two-layer composition with per-layer opacities).
 	$_pnOverlayOpacity = ['low' => '0.06', 'med' => '0.12', 'high' => '0.22', 'vignette' => '0.12'][$_pnOverlay];
 	$_pnOverlayIsVignette = ($_pnOverlay === 'vignette');
-	// Single `background` shorthand value (color OR gradient).
-	$_pnHeroBgValue = !empty($_pnColorSecondary)
-		? "linear-gradient(135deg, $_pnHeroBg, $_pnColorSecondary)"
-		: $_pnHeroBg;
+	// Single `background` shorthand value (color OR gradient). Pride gradient
+	// wins over the legacy 135deg two-color gradient when active.
+	$_pnHeroBgValue = $_pnHeroGradientCss
+		?: (!empty($_pnColorSecondary)
+			? "linear-gradient(135deg, $_pnHeroBg, $_pnColorSecondary)"
+			: $_pnHeroBg);
 	// In dark mode, respect user customization (primary color and/or gradient) so
 	// the value the player picked in the design modal preview is what they see on
 	// the rendered hero. Fall back to --ork-bg-secondary only when the player has
 	// not customized, so default uncustomized heroes still auto-darken. Suspended
-	// state forces the red signal in both modes.
-	$_pnHeroBgValueDark = ($isSuspended || $_pnIsCustomPrimary || !empty($_pnColorSecondary))
+	// state forces the red signal in both modes. Amtpride flags render as-is in
+	// both themes — the colors are identity-bearing and shouldn't be tinted.
+	$_pnHeroBgValueDark = ($isSuspended || $_pnIsCustomPrimary || !empty($_pnColorSecondary) || $_pnHeroGradientCss)
 		? $_pnHeroBgValue
 		: 'var(--ork-bg-secondary)';
 	$_pnFocusX = (int)($Player['PhotoFocusX'] ?? 50);
@@ -720,6 +729,30 @@ html[data-theme="dark"] .pn-about-edit-btn:hover,html[data-theme="dark"] .pn-abo
 .pn-gradient-toggle-col{display:flex;flex-direction:column;justify-content:flex-end}
 .pn-gradient-toggle-label{display:flex;align-items:center;gap:8px;cursor:pointer;font-size:12px;font-weight:600;color:#4a5568}
 .pn-gradient-toggle-label input[type="checkbox"]{width:16px;height:16px;accent-color:var(--pn-accent,#4299e1)}
+/* Amtpride Nameplate subsection */
+.pn-amtpride-section{margin-top:14px;border:1px solid #e2e8f0;border-radius:8px;background:#fafbfc}
+.pn-amtpride-toggle{width:100%;display:flex;align-items:center;gap:8px;padding:10px 12px;background:transparent;border:0;border-radius:7px;cursor:pointer;font-size:12px;font-weight:700;color:#4a5568;text-transform:uppercase;letter-spacing:.04em}
+.pn-amtpride-section.pn-amtpride-open .pn-amtpride-toggle{border-radius:7px 7px 0 0}
+.pn-amtpride-toggle:hover{background:rgba(66,153,225,0.06)}
+.pn-amtpride-chev{transition:transform .2s ease;font-size:11px;color:#a0aec0}
+.pn-amtpride-section.pn-amtpride-open .pn-amtpride-chev{transform:rotate(90deg)}
+.pn-amtpride-active-badge{margin-left:auto;font-size:10px;font-weight:700;padding:2px 8px;border-radius:10px;background:linear-gradient(90deg,#e40303,#ff8c00,#ffed00,#008026,#004dff,#750787);color:#fff;text-shadow:0 1px 1px rgba(0,0,0,0.5);letter-spacing:.03em}
+.pn-amtpride-body{display:none;padding:4px 12px 12px}
+.pn-amtpride-section.pn-amtpride-open .pn-amtpride-body{display:block}
+.pn-amtpride-presets{display:flex;flex-wrap:wrap;gap:6px;margin-bottom:4px}
+.pn-amtpride-swatch{width:42px;height:24px;border-radius:4px;border:2px solid transparent;cursor:pointer;position:relative;transition:transform .15s,border-color .15s;box-shadow:0 1px 2px rgba(0,0,0,0.08)}
+.pn-amtpride-swatch:hover{transform:scale(1.08)}
+.pn-amtpride-swatch.pn-selected{border-color:#2d3748;box-shadow:0 0 0 2px #fff,0 0 0 3px #2d3748}
+.pn-amtpride-swatch[data-tip]:hover::after{content:attr(data-tip);position:absolute;bottom:calc(100% + 6px);left:50%;transform:translateX(-50%);background:#2d3748;color:#fff;padding:4px 8px;border-radius:4px;font-size:11px;font-weight:600;white-space:nowrap;pointer-events:none;z-index:10;box-shadow:0 2px 6px rgba(0,0,0,0.2)}
+.pn-amtpride-swatch[data-tip]:hover::before{content:'';position:absolute;bottom:100%;left:50%;transform:translateX(-50%);border:4px solid transparent;border-top-color:#2d3748;pointer-events:none;z-index:10}
+/* Known limit: tooltip uses position:absolute and can clip at the top edge of
+   the modal viewport on very short screens. Acceptable given short flag names
+   and the swatch's visible gradient already identifies the flag. */
+/* Dim primary/secondary inputs while a pride flag is active */
+.pn-design-panel.pn-pride-active .pn-color-presets,
+.pn-design-panel.pn-pride-active .pn-color-row,
+.pn-design-panel.pn-pride-active #pn-color-presets,
+.pn-design-panel.pn-pride-active #pn-gradient-presets{opacity:0.4;pointer-events:none}
 /* Shared section heading + checkbox toggle label inside Design panels */
 .pn-section-heading{font-size:13px;font-weight:700;color:#2d3748;margin-bottom:12px;background:transparent;border:none;padding:0;border-radius:0;text-shadow:none}
 .pn-section-toggle-label{display:flex;align-items:center;gap:10px;cursor:pointer;font-size:13px;font-weight:600;color:#4a5568}
@@ -874,6 +907,13 @@ html[data-theme="dark"] .pn-ms-custom-wrap { border-top-color: var(--ork-border)
 /* Colors-tab field labels — promote to secondary text so they stay legible */
 html[data-theme="dark"] .pn-color-field-label { color: var(--ork-text-secondary); }
 html[data-theme="dark"] .pn-gradient-toggle-label { color: var(--ork-text-secondary); }
+/* Amtpride Nameplate — dark mode */
+html[data-theme="dark"] .pn-amtpride-section { background: var(--ork-card-bg); border-color: var(--ork-border); }
+html[data-theme="dark"] .pn-amtpride-toggle { color: var(--ork-text-secondary); }
+html[data-theme="dark"] .pn-amtpride-toggle:hover { background: rgba(255,255,255,0.04); }
+html[data-theme="dark"] .pn-amtpride-swatch.pn-selected { border-color: var(--ork-text); box-shadow: 0 0 0 2px var(--ork-card-bg), 0 0 0 3px var(--ork-text); }
+html[data-theme="dark"] .pn-amtpride-swatch[data-tip]:hover::after { background: var(--ork-text); color: var(--ork-card-bg); }
+html[data-theme="dark"] .pn-amtpride-swatch[data-tip]:hover::before { border-top-color: var(--ork-text); }
 html[data-theme="dark"] .pn-section-heading { color: var(--ork-text); }
 html[data-theme="dark"] .pn-section-toggle-label { color: var(--ork-text-secondary); }
 
@@ -3110,6 +3150,28 @@ html[data-theme="dark"] .pn-cms-line strong { color: var(--ork-text-muted); }
 					<div class="pn-color-swatch" data-primary="#2c5282" data-accent="#4299e1" data-secondary="#285e61" style="background:linear-gradient(135deg,#2c5282,#285e61)" title="Ocean Teal"></div>
 					<div class="pn-color-swatch" data-primary="#744210" data-accent="#ecc94b" data-secondary="#9b2c2c" style="background:linear-gradient(135deg,#744210,#9b2c2c)" title="Autumn"></div>
 				</div>
+				<?php
+					$_pnPrideActiveKey = (!$isSuspended && !empty($Player['HeroGradient']) && isset($_pnPrideGradients[$Player['HeroGradient']])) ? $Player['HeroGradient'] : '';
+				?>
+				<div class="pn-amtpride-section<?= $_pnPrideActiveKey ? ' pn-amtpride-open' : '' ?>" id="pn-amtpride-section">
+					<button type="button" class="pn-amtpride-toggle" id="pn-amtpride-toggle" aria-expanded="<?= $_pnPrideActiveKey ? 'true' : 'false' ?>" aria-controls="pn-amtpride-body">
+						<i class="fas fa-chevron-right pn-amtpride-chev"></i>
+						<span>Amtpride Nameplate</span>
+						<span class="pn-amtpride-active-badge" id="pn-amtpride-active-badge"<?= $_pnPrideActiveKey ? '' : ' style="display:none"' ?>>Active</span>
+					</button>
+					<div class="pn-amtpride-body" id="pn-amtpride-body">
+						<div class="pn-design-hint" style="margin-bottom:8px">Display a pride flag as your nameplate background. Overrides the custom colors below while active.</div>
+						<div class="pn-amtpride-presets" id="pn-amtpride-presets">
+							<?php foreach ($_pnPrideGradients as $_pgKey => $_pg):
+								$_pgCss = 'linear-gradient(90deg, ' . implode(', ', $_pg['colors']) . ')';
+							?>
+							<div class="pn-amtpride-swatch<?= $_pnPrideActiveKey === $_pgKey ? ' pn-selected' : '' ?>" data-pride="<?= htmlspecialchars($_pgKey) ?>" data-tip="<?= htmlspecialchars($_pg['name']) ?>" style="background:<?= $_pgCss ?>"></div>
+							<?php endforeach; ?>
+						</div>
+						<button type="button" class="pn-btn pn-btn-ghost pn-btn-sm" id="pn-amtpride-clear" style="margin-top:10px<?= $_pnPrideActiveKey ? '' : ';display:none' ?>"><i class="fas fa-times"></i> Clear pride flag</button>
+					</div>
+				</div>
+				<input type="hidden" id="pn-hero-gradient" value="<?= htmlspecialchars($_pnPrideActiveKey) ?>" />
 				<div class="pn-design-preview-label" style="margin-top:14px">Custom Colors</div>
 				<div class="pn-color-row">
 					<div class="pn-color-col">
@@ -3816,6 +3878,7 @@ if (typeof nsKid !== 'undefined' && nsKid === 0 && PnConfig.kingdomId) nsKid = P
 	var allSwatches = document.querySelectorAll('.pn-color-swatch');
 	allSwatches.forEach(function(sw) {
 		sw.addEventListener('click', function() {
+			clearPrideFlag();
 			allSwatches.forEach(function(s) { s.classList.remove('pn-selected'); });
 			sw.classList.add('pn-selected');
 			gid('pn-color-primary').value = sw.dataset.primary;
@@ -3844,6 +3907,7 @@ if (typeof nsKid !== 'undefined' && nsKid === 0 && PnConfig.kingdomId) nsKid = P
 		if (/^#[0-9a-f]{6}$/i.test(this.value)) { gid('pn-color-accent').value = this.value; syncPresetSwatch(); updateColorPreview(); }
 	});
 	gid('pn-color-reset').addEventListener('click', function() {
+		clearPrideFlag();
 		gid('pn-color-primary').value = '#2c5282'; gid('pn-color-primary-hex').value = '#2c5282';
 		gid('pn-color-accent').value = '#4299e1'; gid('pn-color-accent-hex').value = '#4299e1';
 		gid('pn-color-secondary-hex').value = ''; gid('pn-color-secondary').value = '#2c5282';
@@ -3883,9 +3947,15 @@ if (typeof nsKid !== 'undefined' && nsKid === 0 && PnConfig.kingdomId) nsKid = P
 			sw.classList.toggle('pn-selected', matchBase && swSec === s);
 		});
 	}
+	var _pnPrideGradients = <?= json_encode($_pnPrideGradients, JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT) ?>;
 	function updateColorPreview() {
 		var preview = gid('pn-color-hero-preview');
 		if (!preview) return;
+		var prideKey = gid('pn-hero-gradient') ? gid('pn-hero-gradient').value : '';
+		if (prideKey && _pnPrideGradients[prideKey]) {
+			preview.style.background = 'linear-gradient(90deg, ' + _pnPrideGradients[prideKey].colors.join(', ') + ')';
+			return;
+		}
 		var primary = gid('pn-color-primary').value;
 		var gradientOn = gid('pn-gradient-enabled').checked;
 		var secondary = gid('pn-color-secondary').value;
@@ -3897,6 +3967,64 @@ if (typeof nsKid !== 'undefined' && nsKid === 0 && PnConfig.kingdomId) nsKid = P
 	}
 	updateColorPreview();
 	syncPresetSwatch();
+
+	// ---- Amtpride Nameplate ----
+	var prideSection = gid('pn-amtpride-section');
+	var prideToggle  = gid('pn-amtpride-toggle');
+	var prideBadge   = gid('pn-amtpride-active-badge');
+	var prideClear   = gid('pn-amtpride-clear');
+	var prideHidden  = gid('pn-hero-gradient');
+	var prideSwatches = document.querySelectorAll('.pn-amtpride-swatch');
+	var colorPanel   = document.getElementById('pn-design-colors');
+	// Function declarations are hoisted, so the regular swatch/reset handlers
+	// (which call clearPrideFlag) keep working even if the Amtpride DOM is
+	// missing — clearPrideFlag's own !prideHidden guard short-circuits cleanly.
+	function applyPrideFlag(key) {
+		prideHidden.value = key || '';
+		prideSwatches.forEach(function(sw) {
+			sw.classList.toggle('pn-selected', sw.dataset.pride === key);
+		});
+		if (key) {
+			prideBadge.style.display = '';
+			prideClear.style.display = '';
+			if (colorPanel) colorPanel.classList.add('pn-pride-active');
+			prideSection.classList.add('pn-amtpride-open');
+			prideToggle.setAttribute('aria-expanded', 'true');
+			// Deselect regular presets — they're no longer driving the hero.
+			allSwatches.forEach(function(s) { s.classList.remove('pn-selected'); });
+		} else {
+			prideBadge.style.display = 'none';
+			prideClear.style.display = 'none';
+			if (colorPanel) colorPanel.classList.remove('pn-pride-active');
+			// Deselect regular presets unconditionally — the user cleared the pride
+			// flag, they haven't re-chosen a color preset. Re-lighting a preset off
+			// the current input values would mislead them about saved state.
+			allSwatches.forEach(function(s) { s.classList.remove('pn-selected'); });
+		}
+		updateColorPreview();
+	}
+	function clearPrideFlag() {
+		if (!prideHidden || !prideHidden.value) return;
+		applyPrideFlag('');
+	}
+	// Listener wiring is gated on the Amtpride DOM existing. If a future feature
+	// flag hides the subsection, this block skips cleanly and the Name builder /
+	// save handler below still run.
+	if (prideSection && prideToggle && prideHidden && prideClear) {
+		prideSwatches.forEach(function(sw) {
+			sw.addEventListener('click', function() {
+				var key = sw.dataset.pride;
+				applyPrideFlag(prideHidden.value === key ? '' : key);
+			});
+		});
+		prideToggle.addEventListener('click', function() {
+			var open = prideSection.classList.toggle('pn-amtpride-open');
+			prideToggle.setAttribute('aria-expanded', open ? 'true' : 'false');
+		});
+		prideClear.addEventListener('click', function() { clearPrideFlag(); });
+		// Sync dim-state with the initial server-rendered selection.
+		if (prideHidden.value && colorPanel) colorPanel.classList.add('pn-pride-active');
+	}
 
 	// Name builder
 	var prefixSel = gid('pn-name-prefix-select');
@@ -4226,6 +4354,7 @@ if (typeof nsKid !== 'undefined' && nsKid === 0 && PnConfig.kingdomId) nsKid = P
 		fd.append('ColorPrimary', gid('pn-color-primary').value);
 		fd.append('ColorAccent', gid('pn-color-accent').value);
 		fd.append('ColorSecondary', gid('pn-gradient-enabled').checked ? gid('pn-color-secondary').value : '');
+		fd.append('HeroGradient', (gid('pn-hero-gradient') && gid('pn-hero-gradient').value) || '');
 		fd.append('HeroOverlay', gid('pn-hero-overlay').value);
 		fd.append('NamePrefix', prefix);
 		fd.append('NameSuffix', suffix);

--- a/orkui/template/revised-frontend/Playernew_index.tpl
+++ b/orkui/template/revised-frontend/Playernew_index.tpl
@@ -2738,7 +2738,7 @@ html[data-theme="dark"] .pn-cms-line strong { color: var(--ork-text-muted); }
 
 			<!-- Rank Picker (only for ladder awards) -->
 			<div class="pn-acct-field" id="pn-award-rank-row" style="display:none">
-				<label>Rank <span id="pn-rank-hint" style="color:#a0aec0;font-weight:400;font-size:11px">— click to select; light blue = already held, green border = suggested; dark blue = selected</span></label>
+				<label>Rank <span id="pn-rank-hint" style="color:#a0aec0;font-weight:400;font-size:11px">— Select a rank of the award to recommend. Green ranks have already been awarded. You can suggest a rank higher than their next if you believe they have achieved it.</span></label>
 				<div class="pn-rank-pills-wrap" id="pn-rank-pills"></div>
 				<input type="hidden" name="Rank" id="pn-award-rank-val" value="" />
 			</div>
@@ -3516,7 +3516,7 @@ html[data-theme="dark"] .pn-cms-line strong { color: var(--ork-text-muted); }
 					<div id="pn-rec-award-desc" class="pn-rec-award-desc" style="display:none"></div>
 				</div>
 				<div class="pn-rec-field" id="pn-rec-rank-row" style="display:none">
-					<label>Rank <span id="pn-rec-rank-hint" style="color:#a0aec0;font-weight:400;font-size:11px">— click to select; light blue = already held, green border = suggested; dark blue = selected</span></label>
+					<label>Rank <span id="pn-rec-rank-hint" style="color:#a0aec0;font-weight:400;font-size:11px">— Select a rank of the award to recommend. Green ranks have already been awarded. You can suggest a rank higher than their next if you believe they have achieved it.</span></label>
 					<div class="pn-rank-pills-wrap" id="pn-rec-rank-pills"></div>
 					<input type="hidden" name="Rank" id="pn-rec-rank-val" value="" />
 				</div>

--- a/orkui/template/revised-frontend/Playernew_index.tpl
+++ b/orkui/template/revised-frontend/Playernew_index.tpl
@@ -636,6 +636,14 @@ html[data-theme="dark"] .pn-about-edit-btn:hover,html[data-theme="dark"] .pn-abo
 .pn-color-input-wrap input[type="text"]:focus{outline:none;border-color:var(--pn-accent,#4299e1);box-shadow:0 0 0 3px rgba(66,153,225,0.15)}
 .pn-hero-preview{border-radius:8px;padding:16px 20px;color:#fff;margin:12px 0;position:relative;overflow:hidden;min-height:60px}
 .pn-hero-preview-name{font-size:18px;font-weight:700;text-shadow:0 1px 3px rgba(0,0,0,0.4)}
+/* Amtpride: darken the name drop shadow ~20% (0.4 -> 0.6 alpha) so it stays legible over light flag stops */
+.pn-hero-pride .pn-persona,.pn-hero-pride .pn-hero-preview-name{text-shadow:0 1px 3px rgba(0,0,0,0.6)}
+html[data-theme="dark"] .pn-hero-pride .pn-persona{text-shadow:0 1px 3px rgba(0,0,0,0.6)!important}
+/* Amtpride: lift the translucent subline/breadcrumb text so it reads over light flag stops (text-shadow inherits to children) */
+.pn-hero-pride .pn-hero-subline,.pn-hero-pride .pn-breadcrumb{color:rgba(255,255,255,0.95);text-shadow:0 1px 3px rgba(0,0,0,0.6)}
+.pn-hero-pride .pn-breadcrumb a{color:#fff}
+.pn-hero-pride .pn-sub-pronunciation,.pn-hero-pride .pn-sub-pronouns{color:rgba(255,255,255,0.9)}
+.pn-hero-pride .pn-sub-sep,.pn-hero-pride .pn-breadcrumb .pn-sep{color:rgba(255,255,255,0.85);opacity:1}
 .pn-hero-preview-sub{font-size:12px;opacity:0.7;margin-top:4px}
 .pn-overlay-btn{padding:8px 20px;border:2px solid #e2e8f0;border-radius:6px;background:#fff;font-size:12px;font-weight:600;color:#4a5568;cursor:pointer;transition:all .15s}
 .pn-overlay-btn:hover{border-color:#a0aec0}
@@ -940,7 +948,7 @@ html[data-theme="dark"] .pn-cms-line strong { color: var(--ork-text-muted); }
 <!-- =============================================
      ZONE 1: Profile Hero Header
      ============================================= -->
-<div class="pn-hero">
+<div class="pn-hero<?= $_pnHeroGradientKey ? ' pn-hero-pride' : '' ?>">
 <?php if ($_pnOverlayIsVignette): ?>
 	<div class="pn-hero-bg pn-hero-bg-vignette-base" style="background-image: url('<?= htmlspecialchars($heraldryUrl) ?>')"></div>
 	<div class="pn-hero-bg-vignette-sharp" style="background-image: url('<?= htmlspecialchars($heraldryUrl) ?>')"></div>
@@ -3952,7 +3960,9 @@ if (typeof nsKid !== 'undefined' && nsKid === 0 && PnConfig.kingdomId) nsKid = P
 		var preview = gid('pn-color-hero-preview');
 		if (!preview) return;
 		var prideKey = gid('pn-hero-gradient') ? gid('pn-hero-gradient').value : '';
-		if (prideKey && _pnPrideGradients[prideKey]) {
+		var prideActive = !!(prideKey && _pnPrideGradients[prideKey]);
+		preview.classList.toggle('pn-hero-pride', prideActive);
+		if (prideActive) {
 			preview.style.background = 'linear-gradient(90deg, ' + _pnPrideGradients[prideKey].colors.join(', ') + ')';
 			return;
 		}

--- a/orkui/template/revised-frontend/Playernew_index.tpl
+++ b/orkui/template/revised-frontend/Playernew_index.tpl
@@ -638,16 +638,21 @@ html[data-theme="dark"] .pn-about-edit-btn:hover,html[data-theme="dark"] .pn-abo
 .pn-hero-preview-name{font-size:18px;font-weight:700;text-shadow:0 1px 3px rgba(0,0,0,0.4)}
 /* Amtpride: darken the name drop shadow ~20% (0.4 -> 0.6 alpha) so it stays legible over light flag stops.
    Legibility contract: any future hero surface (kn-/pk-) that gains a pride gradient must replicate this
-   intensified text-shadow on its name/subline elements, since light flag stops wash out the default 0.4 shadow. */
-.pn-hero-pride .pn-persona,.pn-hero-pride .pn-hero-preview-name{text-shadow:0 1px 3px rgba(0,0,0,0.7)}
-html[data-theme="dark"] .pn-hero-pride .pn-persona{text-shadow:0 1px 3px rgba(0,0,0,0.7)!important}
+   crisp-halo text-shadow on its name element, since light flag stops wash out a soft single shadow.
+   A soft directional shadow only blurs the underside of the glyphs; over a near-white flag stop the
+   top/sides of white text still bleed. A tight multi-directional outline wraps every glyph in a dark
+   edge so the title reads on any stop — light or dark — while keeping the flag fully visible (no overlay). */
+.pn-hero-pride .pn-persona,.pn-hero-pride .pn-hero-preview-name{text-shadow:0 0 2px rgba(0,0,0,.55),1px 1px 1px rgba(0,0,0,.5),-1px 1px 1px rgba(0,0,0,.5),1px -1px 1px rgba(0,0,0,.5),-1px -1px 1px rgba(0,0,0,.5),0 2px 4px rgba(0,0,0,.45)}
+html[data-theme="dark"] .pn-hero-pride .pn-persona{text-shadow:0 0 2px rgba(0,0,0,.55),1px 1px 1px rgba(0,0,0,.5),-1px 1px 1px rgba(0,0,0,.5),1px -1px 1px rgba(0,0,0,.5),-1px -1px 1px rgba(0,0,0,.5),0 2px 4px rgba(0,0,0,.45)!important}
 /* Amtpride: lift the translucent subline text so it reads over light flag stops (text-shadow inherits to children).
    The breadcrumb uses self-contained .pn-crumb pills (dark bg) so it needs no pride-specific shadow. */
 .pn-hero-pride .pn-hero-subline{color:rgba(255,255,255,0.95);text-shadow:0 1px 3px rgba(0,0,0,0.6)}
 .pn-hero-pride .pn-sub-pronunciation,.pn-hero-pride .pn-sub-pronouns{color:rgba(255,255,255,0.9)}
 .pn-hero-pride .pn-sub-sep{color:rgba(255,255,255,0.85);opacity:1}
-/* Amtpride: faint dark translucent backing box behind the subline so it reads over light flag stops */
-.pn-hero-pride .pn-hero-subline{display:flex;width:fit-content;align-items:center;background:rgba(0,0,0,0.22);padding:2px 9px;border-radius:6px}
+/* Amtpride: dark translucent backing box behind the subline so it reads over light flag stops.
+   0.22 was too faint over a bright-yellow stop (small text needs a real panel, not a halo); 0.45
+   gives the white subline a reliable dark surface on any flag while staying clearly translucent. */
+.pn-hero-pride .pn-hero-subline{display:flex;width:fit-content;align-items:center;background:rgba(0,0,0,0.45);padding:2px 9px;border-radius:6px}
 .pn-hero-preview-sub{font-size:12px;opacity:0.7;margin-top:4px}
 /* Design-modal preview: heraldry-overlay layers mirror the production hero so the
    Low/Med/High/Vignette buttons preview live. Driven by a preview-scoped opacity var

--- a/orkui/template/revised-frontend/Playernew_index.tpl
+++ b/orkui/template/revised-frontend/Playernew_index.tpl
@@ -645,6 +645,15 @@ html[data-theme="dark"] .pn-hero-pride .pn-persona{text-shadow:0 1px 3px rgba(0,
 .pn-hero-pride .pn-sub-pronunciation,.pn-hero-pride .pn-sub-pronouns{color:rgba(255,255,255,0.9)}
 .pn-hero-pride .pn-sub-sep,.pn-hero-pride .pn-breadcrumb .pn-sep{color:rgba(255,255,255,0.85);opacity:1}
 .pn-hero-preview-sub{font-size:12px;opacity:0.7;margin-top:4px}
+/* Design-modal preview: heraldry-overlay layers mirror the production hero so the
+   Low/Med/High/Vignette buttons preview live. Driven by a preview-scoped opacity var
+   so the real hero's --pn-overlay-opacity is untouched. */
+.pn-preview-bg{position:absolute;top:-10px;left:-10px;right:-10px;bottom:-10px;background-size:cover;background-position:center}
+.pn-preview-bg-base{filter:blur(6px);opacity:var(--pn-preview-overlay-opacity,0.12)}
+.pn-preview-bg-sharp{filter:blur(1px);opacity:0}
+.pn-preview-vignette .pn-preview-bg-base{-webkit-mask-image:radial-gradient(ellipse at center,rgba(0,0,0,0) 20%,rgba(0,0,0,1) 60%);mask-image:radial-gradient(ellipse at center,rgba(0,0,0,0) 20%,rgba(0,0,0,1) 60%)}
+.pn-preview-vignette .pn-preview-bg-sharp{opacity:0.30;-webkit-mask-image:radial-gradient(ellipse at center,rgba(0,0,0,1) 20%,rgba(0,0,0,0) 60%);mask-image:radial-gradient(ellipse at center,rgba(0,0,0,1) 20%,rgba(0,0,0,0) 60%)}
+.pn-hero-preview-content{position:relative;z-index:1}
 .pn-overlay-btn{padding:8px 20px;border:2px solid #e2e8f0;border-radius:6px;background:#fff;font-size:12px;font-weight:600;color:#4a5568;cursor:pointer;transition:all .15s}
 .pn-overlay-btn:hover{border-color:#a0aec0}
 .pn-overlay-btn.pn-active{border-color:var(--pn-accent,#4299e1);background:var(--pn-accent,#4299e1);color:#fff}
@@ -3133,8 +3142,12 @@ html[data-theme="dark"] .pn-cms-line strong { color: var(--ork-text-muted); }
 				</div>
 				<div class="pn-design-preview-label">Preview</div>
 				<div class="pn-hero-preview" id="pn-color-hero-preview">
-					<div class="pn-hero-preview-name ork-font-sample"><?= htmlspecialchars($Player['Persona']) ?></div>
-					<div class="pn-hero-preview-sub">Your profile will look like this</div>
+					<div class="pn-preview-bg pn-preview-bg-base" style="background-image:url('<?= htmlspecialchars($heraldryUrl) ?>')"></div>
+					<div class="pn-preview-bg pn-preview-bg-sharp" style="background-image:url('<?= htmlspecialchars($heraldryUrl) ?>')"></div>
+					<div class="pn-hero-preview-content">
+						<div class="pn-hero-preview-name ork-font-sample"><?= htmlspecialchars($Player['Persona']) ?></div>
+						<div class="pn-hero-preview-sub">Your profile will look like this</div>
+					</div>
 				</div>
 				<div class="pn-design-preview-label" style="margin-top:14px">Presets</div>
 				<div class="pn-color-presets" id="pn-color-presets">
@@ -3923,6 +3936,7 @@ if (typeof nsKid !== 'undefined' && nsKid === 0 && PnConfig.kingdomId) nsKid = P
 		gid('pn-hero-overlay').value = 'med';
 		document.querySelectorAll('.pn-overlay-btn').forEach(function(b) { b.classList.remove('pn-active'); });
 		document.querySelector('.pn-overlay-btn[data-overlay="med"]').classList.add('pn-active');
+		applyOverlayPreview('med');
 		syncPresetSwatch(); updateColorPreview();
 	});
 	// Secondary color / gradient toggle
@@ -3943,6 +3957,7 @@ if (typeof nsKid !== 'undefined' && nsKid === 0 && PnConfig.kingdomId) nsKid = P
 			document.querySelectorAll('.pn-overlay-btn').forEach(function(b) { b.classList.remove('pn-active'); });
 			btn.classList.add('pn-active');
 			gid('pn-hero-overlay').value = btn.dataset.overlay;
+			applyOverlayPreview(btn.dataset.overlay);
 		});
 	});
 	function syncPresetSwatch() {
@@ -3956,6 +3971,13 @@ if (typeof nsKid !== 'undefined' && nsKid === 0 && PnConfig.kingdomId) nsKid = P
 		});
 	}
 	var _pnPrideGradients = <?= json_encode($_pnPrideGradients, JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT) ?>;
+	function applyOverlayPreview(level) {
+		var preview = gid('pn-color-hero-preview');
+		if (!preview) return;
+		var opac = { low: '0.06', med: '0.12', high: '0.22', vignette: '0.12' }[level] || '0.12';
+		preview.style.setProperty('--pn-preview-overlay-opacity', opac);
+		preview.classList.toggle('pn-preview-vignette', level === 'vignette');
+	}
 	function updateColorPreview() {
 		var preview = gid('pn-color-hero-preview');
 		if (!preview) return;
@@ -3977,6 +3999,7 @@ if (typeof nsKid !== 'undefined' && nsKid === 0 && PnConfig.kingdomId) nsKid = P
 	}
 	updateColorPreview();
 	syncPresetSwatch();
+	applyOverlayPreview(gid('pn-hero-overlay') ? gid('pn-hero-overlay').value : 'med');
 
 	// ---- Amtpride Nameplate ----
 	var prideSection = gid('pn-amtpride-section');

--- a/orkui/template/revised-frontend/Playernew_index.tpl
+++ b/orkui/template/revised-frontend/Playernew_index.tpl
@@ -636,7 +636,9 @@ html[data-theme="dark"] .pn-about-edit-btn:hover,html[data-theme="dark"] .pn-abo
 .pn-color-input-wrap input[type="text"]:focus{outline:none;border-color:var(--pn-accent,#4299e1);box-shadow:0 0 0 3px rgba(66,153,225,0.15)}
 .pn-hero-preview{border-radius:8px;padding:16px 20px;color:#fff;margin:12px 0;position:relative;overflow:hidden;min-height:60px}
 .pn-hero-preview-name{font-size:18px;font-weight:700;text-shadow:0 1px 3px rgba(0,0,0,0.4)}
-/* Amtpride: darken the name drop shadow ~20% (0.4 -> 0.6 alpha) so it stays legible over light flag stops */
+/* Amtpride: darken the name drop shadow ~20% (0.4 -> 0.6 alpha) so it stays legible over light flag stops.
+   Legibility contract: any future hero surface (kn-/pk-) that gains a pride gradient must replicate this
+   intensified text-shadow on its name/subline elements, since light flag stops wash out the default 0.4 shadow. */
 .pn-hero-pride .pn-persona,.pn-hero-pride .pn-hero-preview-name{text-shadow:0 1px 3px rgba(0,0,0,0.6)}
 html[data-theme="dark"] .pn-hero-pride .pn-persona{text-shadow:0 1px 3px rgba(0,0,0,0.6)!important}
 /* Amtpride: lift the translucent subline/breadcrumb text so it reads over light flag stops (text-shadow inherits to children) */
@@ -2724,7 +2726,7 @@ html[data-theme="dark"] .pn-cms-line strong { color: var(--ork-text-muted); }
 
 			<!-- Alias dropdown (shown only for "Custom Title") -->
 			<div class="pn-acct-field" id="pn-award-alias-row" style="display:none">
-				<label for="pn-award-alias">Alias of <span style="color:#a0aec0;font-weight:400;font-size:11px">(optional)</span></label>
+				<label for="pn-award-alias">Alias of <span style="color:var(--ork-text-lighter);font-weight:400;font-size:11px">(optional)</span></label>
 				<select name="AliasAwardId" id="pn-award-alias">
 					<option value="0">— None —</option>
 					<?php if (!empty($CustomTitleAliasOptions['Peerage'])): ?>
@@ -2742,7 +2744,7 @@ html[data-theme="dark"] .pn-cms-line strong { color: var(--ork-text-muted); }
 					</optgroup>
 					<?php endif; ?>
 				</select>
-				<div style="font-size:11px;color:#718096;margin-top:4px">Aliasing makes this title count as the selected core award for belt relationships and reports.</div>
+				<div style="font-size:11px;color:var(--ork-text-muted);margin-top:4px">Aliasing makes this title count as the selected core award for belt relationships and reports.</div>
 			</div>
 
 			<!-- Rank Picker (only for ladder awards) -->
@@ -2871,7 +2873,7 @@ html[data-theme="dark"] .pn-cms-line strong { color: var(--ork-text-muted); }
 				<input type="text" id="pn-edit-custom-name" maxlength="64" />
 			</div>
 			<div class="pn-acct-field" id="pn-edit-alias-row" style="display:none">
-				<label for="pn-edit-alias">Alias of <span style="color:#a0aec0;font-weight:400;font-size:11px">(optional)</span></label>
+				<label for="pn-edit-alias">Alias of <span style="color:var(--ork-text-lighter);font-weight:400;font-size:11px">(optional)</span></label>
 				<select id="pn-edit-alias">
 					<option value="0">— None —</option>
 					<?php if (!empty($CustomTitleAliasOptions['Peerage'])): ?>
@@ -2889,7 +2891,7 @@ html[data-theme="dark"] .pn-cms-line strong { color: var(--ork-text-muted); }
 					</optgroup>
 					<?php endif; ?>
 				</select>
-				<div style="font-size:11px;color:#718096;margin-top:4px">Aliasing makes this title count as the selected core award for belt relationships and reports.</div>
+				<div style="font-size:11px;color:var(--ork-text-muted);margin-top:4px">Aliasing makes this title count as the selected core award for belt relationships and reports.</div>
 			</div>
 
 			<div class="pn-acct-field" id="pn-edit-rank-row" style="display:none">
@@ -3172,7 +3174,7 @@ html[data-theme="dark"] .pn-cms-line strong { color: var(--ork-text-muted); }
 					<div class="pn-color-swatch" data-primary="#744210" data-accent="#ecc94b" data-secondary="#9b2c2c" style="background:linear-gradient(135deg,#744210,#9b2c2c)" title="Autumn"></div>
 				</div>
 				<?php
-					$_pnPrideActiveKey = (!$isSuspended && !empty($Player['HeroGradient']) && isset($_pnPrideGradients[$Player['HeroGradient']])) ? $Player['HeroGradient'] : '';
+					$_pnPrideActiveKey = $_pnHeroGradientKey;
 				?>
 				<div class="pn-amtpride-section<?= $_pnPrideActiveKey ? ' pn-amtpride-open' : '' ?>" id="pn-amtpride-section">
 					<button type="button" class="pn-amtpride-toggle" id="pn-amtpride-toggle" aria-expanded="<?= $_pnPrideActiveKey ? 'true' : 'false' ?>" aria-controls="pn-amtpride-body">
@@ -4013,6 +4015,7 @@ if (typeof nsKid !== 'undefined' && nsKid === 0 && PnConfig.kingdomId) nsKid = P
 	// (which call clearPrideFlag) keep working even if the Amtpride DOM is
 	// missing — clearPrideFlag's own !prideHidden guard short-circuits cleanly.
 	function applyPrideFlag(key) {
+		if (!prideHidden || !prideBadge || !prideClear || !prideSection || !prideToggle) return;
 		prideHidden.value = key || '';
 		prideSwatches.forEach(function(sw) {
 			sw.classList.toggle('pn-selected', sw.dataset.pride === key);

--- a/orkui/template/revised-frontend/Playernew_index.tpl
+++ b/orkui/template/revised-frontend/Playernew_index.tpl
@@ -639,13 +639,15 @@ html[data-theme="dark"] .pn-about-edit-btn:hover,html[data-theme="dark"] .pn-abo
 /* Amtpride: darken the name drop shadow ~20% (0.4 -> 0.6 alpha) so it stays legible over light flag stops.
    Legibility contract: any future hero surface (kn-/pk-) that gains a pride gradient must replicate this
    intensified text-shadow on its name/subline elements, since light flag stops wash out the default 0.4 shadow. */
-.pn-hero-pride .pn-persona,.pn-hero-pride .pn-hero-preview-name{text-shadow:0 1px 3px rgba(0,0,0,0.6)}
-html[data-theme="dark"] .pn-hero-pride .pn-persona{text-shadow:0 1px 3px rgba(0,0,0,0.6)!important}
-/* Amtpride: lift the translucent subline/breadcrumb text so it reads over light flag stops (text-shadow inherits to children) */
-.pn-hero-pride .pn-hero-subline,.pn-hero-pride .pn-breadcrumb{color:rgba(255,255,255,0.95);text-shadow:0 1px 3px rgba(0,0,0,0.6)}
-.pn-hero-pride .pn-breadcrumb a{color:#fff}
+.pn-hero-pride .pn-persona,.pn-hero-pride .pn-hero-preview-name{text-shadow:0 1px 3px rgba(0,0,0,0.7)}
+html[data-theme="dark"] .pn-hero-pride .pn-persona{text-shadow:0 1px 3px rgba(0,0,0,0.7)!important}
+/* Amtpride: lift the translucent subline text so it reads over light flag stops (text-shadow inherits to children).
+   The breadcrumb uses self-contained .pn-crumb pills (dark bg) so it needs no pride-specific shadow. */
+.pn-hero-pride .pn-hero-subline{color:rgba(255,255,255,0.95);text-shadow:0 1px 3px rgba(0,0,0,0.6)}
 .pn-hero-pride .pn-sub-pronunciation,.pn-hero-pride .pn-sub-pronouns{color:rgba(255,255,255,0.9)}
-.pn-hero-pride .pn-sub-sep,.pn-hero-pride .pn-breadcrumb .pn-sep{color:rgba(255,255,255,0.85);opacity:1}
+.pn-hero-pride .pn-sub-sep{color:rgba(255,255,255,0.85);opacity:1}
+/* Amtpride: faint dark translucent backing box behind the subline so it reads over light flag stops */
+.pn-hero-pride .pn-hero-subline{display:flex;width:fit-content;align-items:center;background:rgba(0,0,0,0.22);padding:2px 9px;border-radius:6px}
 .pn-hero-preview-sub{font-size:12px;opacity:0.7;margin-top:4px}
 /* Design-modal preview: heraldry-overlay layers mirror the production hero so the
    Low/Med/High/Vignette buttons preview live. Driven by a preview-scoped opacity var
@@ -771,7 +773,12 @@ html[data-theme="dark"] .pn-hero-pride .pn-persona{text-shadow:0 1px 3px rgba(0,
 .pn-design-panel.pn-pride-active .pn-color-presets,
 .pn-design-panel.pn-pride-active .pn-color-row,
 .pn-design-panel.pn-pride-active #pn-color-presets,
-.pn-design-panel.pn-pride-active #pn-gradient-presets{opacity:0.4;pointer-events:none}
+.pn-design-panel.pn-pride-active #pn-gradient-presets{opacity:0.45}
+/* The custom color row (pickers/hex) stays inert while a flag is active — use a preset or Clear to switch off. */
+.pn-design-panel.pn-pride-active .pn-color-row{pointer-events:none}
+/* Presets remain clickable: clicking one removes the pride flag and applies that color/gradient. Brighten on hover to signal it. */
+.pn-design-panel.pn-pride-active #pn-color-presets:hover,
+.pn-design-panel.pn-pride-active #pn-gradient-presets:hover{opacity:1}
 /* Shared section heading + checkbox toggle label inside Design panels */
 .pn-section-heading{font-size:13px;font-weight:700;color:#2d3748;margin-bottom:12px;background:transparent;border:none;padding:0;border-radius:0;text-shadow:none}
 .pn-section-toggle-label{display:flex;align-items:center;gap:10px;cursor:pointer;font-size:13px;font-weight:600;color:#4a5568}
@@ -1012,9 +1019,8 @@ html[data-theme="dark"] .pn-cms-line strong { color: var(--ork-text-muted); }
 			<?php endif; ?>
 			<div class="pn-breadcrumb">
 				<?php if (valid_id($this->__session->kingdom_id)): ?>
-					<a href="<?= UIR ?>Kingdom/profile/<?= $this->__session->kingdom_id ?>"><?= htmlspecialchars($this->__session->kingdom_name) ?></a>
-					<span class="pn-sep"><i class="fas fa-chevron-right" style="font-size:10px"></i></span>
-					<a href="<?= UIR ?>Park/profile/<?= $this->__session->park_id ?>"><?= htmlspecialchars($this->__session->park_name) ?></a>
+					<a class="pn-crumb" href="<?= UIR ?>Kingdom/profile/<?= $this->__session->kingdom_id ?>"><i class="fas fa-crown"></i> <?= htmlspecialchars($this->__session->kingdom_name) ?></a>
+					<a class="pn-crumb" href="<?= UIR ?>Park/profile/<?= $this->__session->park_id ?>"><i class="fas fa-map-marker-alt"></i> <?= htmlspecialchars($this->__session->park_name) ?></a>
 				<?php endif; ?>
 			</div>
 			<div class="pn-badges">
@@ -3191,7 +3197,7 @@ html[data-theme="dark"] .pn-cms-line strong { color: var(--ork-text-muted); }
 							<div class="pn-amtpride-swatch<?= $_pnPrideActiveKey === $_pgKey ? ' pn-selected' : '' ?>" data-pride="<?= htmlspecialchars($_pgKey) ?>" data-tip="<?= htmlspecialchars($_pg['name']) ?>" style="background:<?= $_pgCss ?>"></div>
 							<?php endforeach; ?>
 						</div>
-						<button type="button" class="pn-btn pn-btn-ghost pn-btn-sm" id="pn-amtpride-clear" style="margin-top:10px<?= $_pnPrideActiveKey ? '' : ';display:none' ?>"><i class="fas fa-times"></i> Clear pride flag</button>
+						<button type="button" class="pn-btn pn-btn-ghost pn-btn-sm" id="pn-amtpride-clear" style="margin-top:10px<?= $_pnPrideActiveKey ? '' : ';display:none' ?>"><i class="fas fa-times"></i> Go Back to Previous Color/Gradient</button>
 					</div>
 				</div>
 				<input type="hidden" id="pn-hero-gradient" value="<?= htmlspecialchars($_pnPrideActiveKey) ?>" />
@@ -3200,14 +3206,14 @@ html[data-theme="dark"] .pn-cms-line strong { color: var(--ork-text-muted); }
 					<div class="pn-color-col">
 						<label class="pn-color-field-label">Primary (Hero Background)</label>
 						<div class="pn-color-input-wrap">
-							<input type="color" id="pn-color-primary" value="<?= htmlspecialchars($Player['ColorPrimary'] ?? '#2c5282') ?>" />
+							<input type="color" id="pn-color-primary" value="<?= htmlspecialchars(!empty($Player['ColorPrimary']) ? $Player['ColorPrimary'] : '#2c5282') ?>" />
 							<input type="text" id="pn-color-primary-hex" value="<?= htmlspecialchars($Player['ColorPrimary'] ?? '#2c5282') ?>" maxlength="7" />
 						</div>
 					</div>
 					<div class="pn-color-col">
 						<label class="pn-color-field-label">Accent (Tabs, Links, Stat Cards)</label>
 						<div class="pn-color-input-wrap">
-							<input type="color" id="pn-color-accent" value="<?= htmlspecialchars($Player['ColorAccent'] ?? '#4299e1') ?>" />
+							<input type="color" id="pn-color-accent" value="<?= htmlspecialchars(!empty($Player['ColorAccent']) ? $Player['ColorAccent'] : '#4299e1') ?>" />
 							<input type="text" id="pn-color-accent-hex" value="<?= htmlspecialchars($Player['ColorAccent'] ?? '#4299e1') ?>" maxlength="7" />
 						</div>
 					</div>
@@ -3217,7 +3223,7 @@ html[data-theme="dark"] .pn-cms-line strong { color: var(--ork-text-muted); }
 					<div class="pn-color-col">
 						<label class="pn-color-field-label">Secondary Color</label>
 						<div class="pn-color-input-wrap">
-							<input type="color" id="pn-color-secondary" value="<?= htmlspecialchars($Player['ColorSecondary'] ?? '#2c5282') ?>" />
+							<input type="color" id="pn-color-secondary" value="<?= htmlspecialchars(!empty($Player['ColorSecondary']) ? $Player['ColorSecondary'] : '#2c5282') ?>" />
 							<input type="text" id="pn-color-secondary-hex" value="<?= htmlspecialchars($Player['ColorSecondary'] ?? '') ?>" maxlength="7" placeholder="None" />
 						</div>
 					</div>
@@ -4032,15 +4038,20 @@ if (typeof nsKid !== 'undefined' && nsKid === 0 && PnConfig.kingdomId) nsKid = P
 			prideBadge.style.display = 'none';
 			prideClear.style.display = 'none';
 			if (colorPanel) colorPanel.classList.remove('pn-pride-active');
-			// Deselect regular presets unconditionally — the user cleared the pride
-			// flag, they haven't re-chosen a color preset. Re-lighting a preset off
-			// the current input values would mislead them about saved state.
-			allSwatches.forEach(function(s) { s.classList.remove('pn-selected'); });
+			// Going back to the previous color/gradient: the custom color inputs were
+			// never overwritten while the flag was active, so re-light whichever preset
+			// matches them (if any) to make the restored selection visible.
+			syncPresetSwatch();
 		}
 		updateColorPreview();
 	}
 	function clearPrideFlag() {
 		if (!prideHidden || !prideHidden.value) return;
+		// Reset the hidden field directly first — it is the source of truth the save
+		// reads. applyPrideFlag('') refreshes the badge/dim/preview too, but its guard
+		// can bail before clearing the value if any Amtpride sub-element is missing,
+		// which would otherwise let the stale pride key survive into the save.
+		prideHidden.value = '';
 		applyPrideFlag('');
 	}
 	// Listener wiring is gated on the Amtpride DOM existing. If a future feature

--- a/orkui/template/revised-frontend/script/revised.js
+++ b/orkui/template/revised-frontend/script/revised.js
@@ -1791,6 +1791,9 @@ if (PnConfig.recError) {
                 if (child.tagName === 'OPTION') {
                     if (child.value === '') return;
                     aw += child.outerHTML;
+                    // "Custom Title" also belongs under Achievement Titles — surface it at the very
+                    // top of that dropdown (it precedes the title optgroups in document order).
+                    if (child.getAttribute('data-custom-title') === '1') ach += child.outerHTML;
                 } else if (child.tagName === 'OPTGROUP') {
                     var lbl = child.label;
                     if (lbl === 'Knighthoods' || lbl === 'Masterhoods' || lbl === 'Paragons' || lbl === 'Noble Titles') {
@@ -2850,6 +2853,9 @@ $(document).ready(function() {
             if (child.tagName === 'OPTION') {
                 if (child.value === '') return;
                 aw += child.outerHTML;
+                // "Custom Title" also belongs under Achievement Titles — surface it at the very
+                // top of that dropdown (it precedes the title optgroups in document order).
+                if (child.getAttribute('data-custom-title') === '1') ach += child.outerHTML;
             } else if (child.tagName === 'OPTGROUP') {
                 var lbl = child.label;
                 if (lbl === 'Knighthoods' || lbl === 'Masterhoods' || lbl === 'Paragons' || lbl === 'Noble Titles') {
@@ -2977,12 +2983,20 @@ $(document).ready(function() {
     if (gid('kn-award-select')) awInitPicker(gid('kn-award-select'));
     gid('kn-award-select').addEventListener('change', function() {
         var awardId = this.value;
-        var isCustom = this.options[this.selectedIndex] && this.options[this.selectedIndex].text.toLowerCase().indexOf('custom') >= 0;
-        gid('kn-award-custom-row').style.display = isCustom ? '' : 'none';
+        var opt = this.options[this.selectedIndex];
+        var isCustomAward = opt && (opt.getAttribute('data-custom-award') === '1' || opt.text === 'Custom Award');
+        var isCustomTitle = opt && (opt.getAttribute('data-custom-title') === '1' || opt.text === 'Custom Title');
+        gid('kn-award-custom-row').style.display = (isCustomAward || isCustomTitle) ? '' : 'none';
+        var labelEl = gid('kn-award-custom-label');
+        if (labelEl) labelEl.textContent = isCustomTitle ? 'Custom Title Name' : 'Custom Award Name';
+        var nameInput = gid('kn-award-custom-name');
+        if (nameInput) nameInput.placeholder = isCustomTitle ? 'Enter custom title name...' : 'Enter custom award name...';
+        var aliasRow = gid('kn-award-alias-row');
+        if (aliasRow) aliasRow.style.display = isCustomTitle ? '' : 'none';
+        if (!isCustomTitle) { var aliasSel = gid('kn-award-alias'); if (aliasSel) aliasSel.value = '0'; }
         buildRankPills(awardId);
         var infoEl = gid('kn-award-info-line');
         if (awardId) {
-            var opt = this.querySelector('option[value="' + awardId + '"]');
             infoEl.innerHTML = opt && opt.getAttribute('data-is-ladder') === '1'
                 ? '<span class="kn-badge-ladder"><i class="fas fa-layer-group"></i> Ladder Award</span>'
                 : '';
@@ -3296,6 +3310,8 @@ $(document).ready(function() {
         gid('kn-award-info-line').innerHTML      = '';
         gid('kn-award-custom-name').value        = '';
         gid('kn-award-custom-row').style.display = 'none';
+        if (gid('kn-award-alias')) gid('kn-award-alias').value = '0';
+        if (gid('kn-award-alias-row')) gid('kn-award-alias-row').style.display = 'none';
         checkRequired();
     }
     function knDoSave(onSuccess) {
@@ -3323,6 +3339,9 @@ $(document).ready(function() {
         if (rank) fd.append('Rank', rank);
         var customName = gid('kn-award-custom-name') ? gid('kn-award-custom-name').value.trim() : '';
         if (customName) fd.append('AwardName', customName);
+        var aliasSel = gid('kn-award-alias');
+        var aliasVal = aliasSel && aliasSel.value ? parseInt(aliasSel.value, 10) : 0;
+        if (aliasVal > 0) fd.append('AliasAwardId', String(aliasVal));
 
         var btnNew  = gid('kn-award-save-new');
         var btnSame = gid('kn-award-save-same');
@@ -5843,6 +5862,9 @@ $(document).ready(function() {
             if (child.tagName === 'OPTION') {
                 if (child.value === '') return;
                 aw += child.outerHTML;
+                // "Custom Title" also belongs under Achievement Titles — surface it at the very
+                // top of that dropdown (it precedes the title optgroups in document order).
+                if (child.getAttribute('data-custom-title') === '1') ach += child.outerHTML;
             } else if (child.tagName === 'OPTGROUP') {
                 var lbl = child.label;
                 if (lbl === 'Knighthoods' || lbl === 'Masterhoods' || lbl === 'Paragons' || lbl === 'Noble Titles') {
@@ -5978,12 +6000,20 @@ $(document).ready(function() {
     if (gid('pk-award-select')) awInitPicker(gid('pk-award-select'));
     gid('pk-award-select').addEventListener('change', function() {
         var awardId = this.value;
-        var isCustom = this.options[this.selectedIndex] && this.options[this.selectedIndex].text.toLowerCase().indexOf('custom') >= 0;
-        gid('pk-award-custom-row').style.display = isCustom ? '' : 'none';
+        var opt = this.options[this.selectedIndex];
+        var isCustomAward = opt && (opt.getAttribute('data-custom-award') === '1' || opt.text === 'Custom Award');
+        var isCustomTitle = opt && (opt.getAttribute('data-custom-title') === '1' || opt.text === 'Custom Title');
+        gid('pk-award-custom-row').style.display = (isCustomAward || isCustomTitle) ? '' : 'none';
+        var labelEl = gid('pk-award-custom-label');
+        if (labelEl) labelEl.textContent = isCustomTitle ? 'Custom Title Name' : 'Custom Award Name';
+        var nameInput = gid('pk-award-custom-name');
+        if (nameInput) nameInput.placeholder = isCustomTitle ? 'Enter custom title name...' : 'Enter custom award name...';
+        var aliasRow = gid('pk-award-alias-row');
+        if (aliasRow) aliasRow.style.display = isCustomTitle ? '' : 'none';
+        if (!isCustomTitle) { var aliasSel = gid('pk-award-alias'); if (aliasSel) aliasSel.value = '0'; }
         buildRankPills(awardId);
         var infoEl = gid('pk-award-info-line');
         if (awardId) {
-            var opt = this.querySelector('option[value="' + awardId + '"]');
             infoEl.innerHTML = opt && opt.getAttribute('data-is-ladder') === '1'
                 ? '<span class="pk-badge-ladder"><i class="fas fa-layer-group"></i> Ladder Award</span>'
                 : '';
@@ -6301,6 +6331,8 @@ $(document).ready(function() {
         gid('pk-award-info-line').innerHTML      = '';
         gid('pk-award-custom-name').value        = '';
         gid('pk-award-custom-row').style.display = 'none';
+        if (gid('pk-award-alias')) gid('pk-award-alias').value = '0';
+        if (gid('pk-award-alias-row')) gid('pk-award-alias-row').style.display = 'none';
         checkRequired();
     }
     function pkDoSave(onSuccess) {
@@ -6328,6 +6360,9 @@ $(document).ready(function() {
         if (rank) fd.append('Rank', rank);
         var customName = gid('pk-award-custom-name') ? gid('pk-award-custom-name').value.trim() : '';
         if (customName) fd.append('AwardName', customName);
+        var aliasSel = gid('pk-award-alias');
+        var aliasVal = aliasSel && aliasSel.value ? parseInt(aliasSel.value, 10) : 0;
+        if (aliasVal > 0) fd.append('AliasAwardId', String(aliasVal));
 
         var btnNew  = gid('pk-award-save-new');
         var btnSame = gid('pk-award-save-same');

--- a/orkui/template/revised-frontend/script/revised.js
+++ b/orkui/template/revised-frontend/script/revised.js
@@ -848,9 +848,7 @@ if (PnConfig.recError) {
         row.style.display = '';
         var baseAwardId = parseInt(opt.getAttribute('data-award-id')) || 0;
         var hint = document.getElementById('pn-rec-rank-hint');
-        if (hint) hint.textContent = baseAwardId === 0
-            ? '— Select a rank of the award to recommend. Green ranks have already been awarded. You can suggest a rank higher than their next if you believe they have achieved it.'
-            : '— Select a rank of the award to recommend. Green ranks have already been awarded. You can suggest a rank higher than their next if you believe they have achieved it.';
+        if (hint) hint.textContent = '— Select a rank of the award to recommend. Green ranks have already been awarded. You can suggest a rank higher than their next if you believe they have achieved it.';
         var maxRank   = /zodiac/i.test(opt.textContent) ? 12 : 10;
         var held      = pnAwardRanks[baseAwardId] || 0;
         var suggested = Math.min(held + 1, maxRank);
@@ -1942,9 +1940,7 @@ if (PnConfig.recError) {
             var held      = playerRanks[awardId] || 0;
             var suggested = Math.min(held + 1, maxRank);
             var hint = gid('pn-rank-hint');
-            if (hint) hint.textContent = awardId === 0
-                ? '— Select a rank of the award to recommend. Green ranks have already been awarded. You can suggest a rank higher than their next if you believe they have achieved it.'
-                : '— Select a rank of the award to recommend. Green ranks have already been awarded. You can suggest a rank higher than their next if you believe they have achieved it.';
+            if (hint) hint.textContent = '— Select a rank of the award to recommend. Green ranks have already been awarded. You can suggest a rank higher than their next if you believe they have achieved it.';
             var html = '';
             for (var i = 1; i <= maxRank; i++) {
                 html += '<div class="pn-rank-pill" data-rank="' + i + '">' + tnRankPillInner('pn', i) + '</div>';
@@ -2977,9 +2973,7 @@ $(document).ready(function() {
         row.style.display = '';
         var baseAwardId = parseInt(opt.getAttribute('data-award-id')) || 0;
         var hint = gid('kn-rank-hint');
-        if (hint) hint.textContent = baseAwardId === 0
-            ? '— Select a rank of the award to recommend. Green ranks have already been awarded. You can suggest a rank higher than their next if you believe they have achieved it.'
-            : '— Select a rank of the award to recommend. Green ranks have already been awarded. You can suggest a rank higher than their next if you believe they have achieved it.';
+        if (hint) hint.textContent = '— Select a rank of the award to recommend. Green ranks have already been awarded. You can suggest a rank higher than their next if you believe they have achieved it.';
         var maxRank   = /zodiac/i.test(opt.textContent) ? 12 : 10;
         var held      = knPlayerRanks[baseAwardId] || 0;
         var suggested = Math.min(held + 1, maxRank);
@@ -3441,9 +3435,7 @@ $(document).ready(function() {
         row.style.display = '';
         var baseAwardId = parseInt(opt.getAttribute('data-award-id')) || 0;
         var hint = gid('kn-rec-rank-hint');
-        if (hint) hint.textContent = baseAwardId === 0
-            ? '— Select a rank of the award to recommend. Green ranks have already been awarded. You can suggest a rank higher than their next if you believe they have achieved it.'
-            : '— Select a rank of the award to recommend. Green ranks have already been awarded. You can suggest a rank higher than their next if you believe they have achieved it.';
+        if (hint) hint.textContent = '— Select a rank of the award to recommend. Green ranks have already been awarded. You can suggest a rank higher than their next if you believe they have achieved it.';
         var maxRank   = /zodiac/i.test(opt.textContent) ? 12 : 10;
         var held      = knRecRanks[baseAwardId] || 0;
         var suggested = Math.min(held + 1, maxRank);
@@ -3451,18 +3443,18 @@ $(document).ready(function() {
         for (var r = 1; r <= maxRank; r++) {
             var pill = document.createElement('button');
             pill.type = 'button';
-            pill.className = 'pk-rank-pill';
-            pill.innerHTML = tnRankPillInner('pk', r);
+            pill.className = 'kn-rank-pill';
+            pill.innerHTML = tnRankPillInner('kn', r);
             pill.dataset.rank = r;
             pill.addEventListener('click', (function(rank) {
                 return function() {
                     input.value = rank;
-                    tnRankPaint(wrap, 'pk', held, rank);
+                    tnRankPaint(wrap, 'kn', held, rank);
                 };
             })(r));
             wrap.appendChild(pill);
         }
-        tnRankPaint(wrap, 'pk', held, suggested);
+        tnRankPaint(wrap, 'kn', held, suggested);
         input.value = suggested;
     }
 
@@ -5989,9 +5981,7 @@ $(document).ready(function() {
         row.style.display = '';
         var baseAwardId = parseInt(opt.getAttribute('data-award-id')) || 0;
         var hint = gid('pk-rank-hint');
-        if (hint) hint.textContent = baseAwardId === 0
-            ? '— Select a rank of the award to recommend. Green ranks have already been awarded. You can suggest a rank higher than their next if you believe they have achieved it.'
-            : '— Select a rank of the award to recommend. Green ranks have already been awarded. You can suggest a rank higher than their next if you believe they have achieved it.';
+        if (hint) hint.textContent = '— Select a rank of the award to recommend. Green ranks have already been awarded. You can suggest a rank higher than their next if you believe they have achieved it.';
         var maxRank   = /zodiac/i.test(opt.textContent) ? 12 : 10;
         var held      = pkPlayerRanks[baseAwardId] || 0;
         var suggested = Math.min(held + 1, maxRank);
@@ -6478,9 +6468,7 @@ $(document).ready(function() {
         row.style.display = '';
         var baseAwardId = parseInt(opt.getAttribute('data-award-id')) || 0;
         var hint = gid('pk-rec-rank-hint');
-        if (hint) hint.textContent = baseAwardId === 0
-            ? '— Select a rank of the award to recommend. Green ranks have already been awarded. You can suggest a rank higher than their next if you believe they have achieved it.'
-            : '— Select a rank of the award to recommend. Green ranks have already been awarded. You can suggest a rank higher than their next if you believe they have achieved it.';
+        if (hint) hint.textContent = '— Select a rank of the award to recommend. Green ranks have already been awarded. You can suggest a rank higher than their next if you believe they have achieved it.';
         var maxRank  = /zodiac/i.test(opt.textContent) ? 12 : 10;
         var held     = pkRecRanks[baseAwardId] || 0;
         var suggested = Math.min(held + 1, maxRank);

--- a/orkui/template/revised-frontend/script/revised.js
+++ b/orkui/template/revised-frontend/script/revised.js
@@ -1,3 +1,33 @@
+/* ============================================================
+   Rank pill painter — shared by every "add award" / "recommend"
+   surface (player / kingdom / park). Given the player's held rank
+   and the chosen rank, paints each pill:
+     r <= held              -> held    (green + ✓ watermark)
+     held < r <= selected   -> forward (blue  + → watermark; each step
+                               forward of the chosen rank)
+     r === selected         -> selected (pops up)
+   `prefix` is the class namespace ('pn' | 'kn' | 'pk'). The number is
+   wrapped in a .<prefix>-rank-num span so the watermark sits behind it.
+   ============================================================ */
+function tnRankPaint(wrap, prefix, held, selected) {
+    if (!wrap) return;
+    held     = parseInt(held, 10)     || 0;
+    selected = parseInt(selected, 10) || 0;
+    wrap.querySelectorAll('.' + prefix + '-rank-pill').forEach(function(pill) {
+        var r = parseInt(pill.dataset.rank, 10);
+        pill.classList.remove(prefix + '-rank-held', prefix + '-rank-forward',
+                              prefix + '-rank-selected', prefix + '-rank-suggested');
+        if (r <= held)          pill.classList.add(prefix + '-rank-held');
+        else if (r <= selected) pill.classList.add(prefix + '-rank-forward');
+        if (r === selected)     pill.classList.add(prefix + '-rank-selected');
+    });
+}
+/* Build the inner markup for a single pill (number wrapped for the watermark). */
+function tnRankPillInner(prefix, r) {
+    return '<span class="' + prefix + '-rank-num">' + r + '</span>';
+}
+if (typeof window !== 'undefined') { window.tnRankPaint = tnRankPaint; window.tnRankPillInner = tnRankPillInner; }
+
 /* ===========================
    HTML escape helper
    =========================== */
@@ -819,31 +849,29 @@ if (PnConfig.recError) {
         var baseAwardId = parseInt(opt.getAttribute('data-award-id')) || 0;
         var hint = document.getElementById('pn-rec-rank-hint');
         if (hint) hint.textContent = baseAwardId === 0
-            ? '— click to select; green border = suggested next; dark blue = selected'
-            : '— click to select; light blue = already held, green border = suggested; dark blue = selected';
+            ? '— Select a rank of the award to recommend. Green ranks have already been awarded. You can suggest a rank higher than their next if you believe they have achieved it.'
+            : '— Select a rank of the award to recommend. Green ranks have already been awarded. You can suggest a rank higher than their next if you believe they have achieved it.';
         var maxRank   = /zodiac/i.test(opt.textContent) ? 12 : 10;
         var held      = pnAwardRanks[baseAwardId] || 0;
         var suggested = Math.min(held + 1, maxRank);
+        wrap.dataset.rankHeld = held;
         for (var r = 1; r <= maxRank; r++) {
             var pill = document.createElement('div');
             pill.className = 'pn-rank-pill';
-            if (r <= held)       pill.className += ' pn-rank-held';
-            if (r === suggested) pill.className += ' pn-rank-suggested';
-            pill.textContent  = r;
+            pill.innerHTML  = tnRankPillInner('pn', r);
             pill.dataset.rank = r;
             wrap.appendChild(pill);
         }
-        var suggestedPill = wrap.querySelector('[data-rank="' + suggested + '"]');
-        if (suggestedPill) { suggestedPill.classList.add('pn-rank-selected'); input.value = suggested; }
+        tnRankPaint(wrap, 'pn', held, suggested);
+        input.value = suggested;
     }
     var pnRecRankPillsEl = document.getElementById('pn-rec-rank-pills');
     if (pnRecRankPillsEl) pnRecRankPillsEl.addEventListener('click', function(e) {
         var p = e.target.closest ? e.target.closest('.pn-rank-pill') : (e.target.classList.contains('pn-rank-pill') ? e.target : null);
         if (!p) return;
         var input = document.getElementById('pn-rec-rank-val');
-        this.querySelectorAll('.pn-rank-pill').forEach(function(x) { x.classList.remove('pn-rank-selected'); });
-        p.classList.add('pn-rank-selected');
         input.value = p.dataset.rank;
+        tnRankPaint(this, 'pn', this.dataset.rankHeld, p.dataset.rank);
         pnRecRefreshWarn();
     });
     var _recAwardEl = document.getElementById('pn-rec-award');
@@ -1915,25 +1943,21 @@ if (PnConfig.recError) {
             var suggested = Math.min(held + 1, maxRank);
             var hint = gid('pn-rank-hint');
             if (hint) hint.textContent = awardId === 0
-                ? '— click to select; green border = suggested next; dark blue = selected'
-                : '— click to select; light blue = already held, green border = suggested; dark blue = selected';
+                ? '— Select a rank of the award to recommend. Green ranks have already been awarded. You can suggest a rank higher than their next if you believe they have achieved it.'
+                : '— Select a rank of the award to recommend. Green ranks have already been awarded. You can suggest a rank higher than their next if you believe they have achieved it.';
             var html = '';
             for (var i = 1; i <= maxRank; i++) {
-                var cls = 'pn-rank-pill';
-                if (i <= held)       cls += ' pn-rank-held';
-                if (i === suggested) cls += ' pn-rank-suggested';
-                html += '<div class="' + cls + '" data-rank="' + i + '">' + i + '</div>';
+                html += '<div class="pn-rank-pill" data-rank="' + i + '">' + tnRankPillInner('pn', i) + '</div>';
             }
             var pills = gid('pn-rank-pills');
+            pills.dataset.rankHeld = held;
             pills.innerHTML = html;
             selectRankPill(suggested, pills);
         }
         function selectRankPill(rank, container) {
             var c = container || gid('pn-rank-pills');
-            c.querySelectorAll('.pn-rank-pill').forEach(function(p) { p.classList.remove('pn-rank-selected'); });
-            var target = c.querySelector('[data-rank="' + rank + '"]');
-            if (target) {
-                target.classList.add('pn-rank-selected');
+            tnRankPaint(c, 'pn', c.dataset.rankHeld, rank);
+            if (c.querySelector('[data-rank="' + rank + '"]')) {
                 gid('pn-award-rank-val').value = rank;
             }
         }
@@ -2954,30 +2978,28 @@ $(document).ready(function() {
         var baseAwardId = parseInt(opt.getAttribute('data-award-id')) || 0;
         var hint = gid('kn-rank-hint');
         if (hint) hint.textContent = baseAwardId === 0
-            ? '— click to select; green border = suggested next; dark blue = selected'
-            : '— click to select; blue = already held, green border = suggested next';
+            ? '— Select a rank of the award to recommend. Green ranks have already been awarded. You can suggest a rank higher than their next if you believe they have achieved it.'
+            : '— Select a rank of the award to recommend. Green ranks have already been awarded. You can suggest a rank higher than their next if you believe they have achieved it.';
         var maxRank   = /zodiac/i.test(opt.textContent) ? 12 : 10;
         var held      = knPlayerRanks[baseAwardId] || 0;
         var suggested = Math.min(held + 1, maxRank);
+        wrap.dataset.rankHeld = held;
         for (var r = 1; r <= maxRank; r++) {
             var pill = document.createElement('button');
             pill.type      = 'button';
             pill.className = 'kn-rank-pill';
-            if (r <= held)       pill.className += ' kn-rank-held';
-            if (r === suggested) pill.className += ' kn-rank-suggested';
-            pill.textContent = r;
+            pill.innerHTML = tnRankPillInner('kn', r);
             pill.dataset.rank = r;
-            pill.addEventListener('click', (function(rank, el) {
+            pill.addEventListener('click', (function(rank) {
                 return function() {
-                    document.querySelectorAll('#kn-rank-pills .kn-rank-pill').forEach(function(p) { p.classList.remove('kn-rank-selected'); });
-                    el.classList.add('kn-rank-selected');
                     input.value = rank;
+                    tnRankPaint(wrap, 'kn', held, rank);
                 };
-            })(r, pill));
+            })(r));
             wrap.appendChild(pill);
         }
-        var suggestedPill = wrap.querySelector('[data-rank="' + suggested + '"]');
-        if (suggestedPill) { suggestedPill.classList.add('kn-rank-selected'); input.value = suggested; }
+        tnRankPaint(wrap, 'kn', held, suggested);
+        input.value = suggested;
     }
 
     if (gid('kn-award-select')) awInitPicker(gid('kn-award-select'));
@@ -3420,30 +3442,28 @@ $(document).ready(function() {
         var baseAwardId = parseInt(opt.getAttribute('data-award-id')) || 0;
         var hint = gid('kn-rec-rank-hint');
         if (hint) hint.textContent = baseAwardId === 0
-            ? '— click to select; green border = suggested next; dark blue = selected'
-            : '(optional) — blue = already held, green border = suggested next';
+            ? '— Select a rank of the award to recommend. Green ranks have already been awarded. You can suggest a rank higher than their next if you believe they have achieved it.'
+            : '— Select a rank of the award to recommend. Green ranks have already been awarded. You can suggest a rank higher than their next if you believe they have achieved it.';
         var maxRank   = /zodiac/i.test(opt.textContent) ? 12 : 10;
         var held      = knRecRanks[baseAwardId] || 0;
         var suggested = Math.min(held + 1, maxRank);
+        wrap.dataset.rankHeld = held;
         for (var r = 1; r <= maxRank; r++) {
             var pill = document.createElement('button');
             pill.type = 'button';
             pill.className = 'pk-rank-pill';
-            if (r <= held)       pill.className += ' pk-rank-held';
-            if (r === suggested) pill.className += ' pk-rank-suggested';
-            pill.textContent = r;
+            pill.innerHTML = tnRankPillInner('pk', r);
             pill.dataset.rank = r;
-            pill.addEventListener('click', (function(rank, el) {
+            pill.addEventListener('click', (function(rank) {
                 return function() {
-                    wrap.querySelectorAll('.pk-rank-pill').forEach(function(p) { p.classList.remove('pk-rank-selected'); });
-                    el.classList.add('pk-rank-selected');
                     input.value = rank;
+                    tnRankPaint(wrap, 'pk', held, rank);
                 };
-            })(r, pill));
+            })(r));
             wrap.appendChild(pill);
         }
-        var suggestedPill = wrap.querySelector('[data-rank="' + suggested + '"]');
-        if (suggestedPill) { suggestedPill.classList.add('pk-rank-selected'); input.value = suggested; }
+        tnRankPaint(wrap, 'pk', held, suggested);
+        input.value = suggested;
     }
 
     if (gid('kn-rec-award-select')) {
@@ -5970,31 +5990,29 @@ $(document).ready(function() {
         var baseAwardId = parseInt(opt.getAttribute('data-award-id')) || 0;
         var hint = gid('pk-rank-hint');
         if (hint) hint.textContent = baseAwardId === 0
-            ? '— click to select; green border = suggested next; dark blue = selected'
-            : '— click to select; blue = already held, green border = suggested next';
+            ? '— Select a rank of the award to recommend. Green ranks have already been awarded. You can suggest a rank higher than their next if you believe they have achieved it.'
+            : '— Select a rank of the award to recommend. Green ranks have already been awarded. You can suggest a rank higher than their next if you believe they have achieved it.';
         var maxRank   = /zodiac/i.test(opt.textContent) ? 12 : 10;
         var held      = pkPlayerRanks[baseAwardId] || 0;
         var suggested = Math.min(held + 1, maxRank);
+        wrap.dataset.rankHeld = held;
         for (var r = 1; r <= maxRank; r++) {
             var pill = document.createElement('button');
             pill.type      = 'button';
             pill.className = 'pk-rank-pill';
-            if (r <= held)       pill.className += ' pk-rank-held';
-            if (r === suggested) pill.className += ' pk-rank-suggested';
-            pill.textContent = r;
+            pill.innerHTML = tnRankPillInner('pk', r);
             pill.dataset.rank = r;
-            pill.addEventListener('click', (function(rank, el) {
+            pill.addEventListener('click', (function(rank) {
                 return function() {
-                    document.querySelectorAll('#pk-rank-pills .pk-rank-pill').forEach(function(p) { p.classList.remove('pk-rank-selected'); });
-                    el.classList.add('pk-rank-selected');
                     input.value = rank;
+                    tnRankPaint(wrap, 'pk', held, rank);
                 };
-            })(r, pill));
+            })(r));
             wrap.appendChild(pill);
         }
         // Auto-select suggested rank
-        var suggestedPill = wrap.querySelector('[data-rank="' + suggested + '"]');
-        if (suggestedPill) { suggestedPill.classList.add('pk-rank-selected'); input.value = suggested; }
+        tnRankPaint(wrap, 'pk', held, suggested);
+        input.value = suggested;
     }
 
     if (gid('pk-award-select')) awInitPicker(gid('pk-award-select'));
@@ -6461,30 +6479,28 @@ $(document).ready(function() {
         var baseAwardId = parseInt(opt.getAttribute('data-award-id')) || 0;
         var hint = gid('pk-rec-rank-hint');
         if (hint) hint.textContent = baseAwardId === 0
-            ? '— click to select; green border = suggested next; dark blue = selected'
-            : '(optional) — blue = already held, green border = suggested next';
+            ? '— Select a rank of the award to recommend. Green ranks have already been awarded. You can suggest a rank higher than their next if you believe they have achieved it.'
+            : '— Select a rank of the award to recommend. Green ranks have already been awarded. You can suggest a rank higher than their next if you believe they have achieved it.';
         var maxRank  = /zodiac/i.test(opt.textContent) ? 12 : 10;
         var held     = pkRecRanks[baseAwardId] || 0;
         var suggested = Math.min(held + 1, maxRank);
+        wrap.dataset.rankHeld = held;
         for (var r = 1; r <= maxRank; r++) {
             var pill = document.createElement('button');
             pill.type = 'button';
             pill.className = 'pk-rank-pill';
-            if (r <= held)       pill.className += ' pk-rank-held';
-            if (r === suggested) pill.className += ' pk-rank-suggested';
-            pill.textContent = r;
+            pill.innerHTML = tnRankPillInner('pk', r);
             pill.dataset.rank = r;
-            pill.addEventListener('click', (function(rank, el) {
+            pill.addEventListener('click', (function(rank) {
                 return function() {
-                    wrap.querySelectorAll('.pk-rank-pill').forEach(function(p) { p.classList.remove('pk-rank-selected'); });
-                    el.classList.add('pk-rank-selected');
                     input.value = rank;
+                    tnRankPaint(wrap, 'pk', held, rank);
                 };
-            })(r, pill));
+            })(r));
             wrap.appendChild(pill);
         }
-        var suggestedPill = wrap.querySelector('[data-rank="' + suggested + '"]');
-        if (suggestedPill) { suggestedPill.classList.add('pk-rank-selected'); input.value = suggested; }
+        tnRankPaint(wrap, 'pk', held, suggested);
+        input.value = suggested;
     }
 
     if (gid('pk-rec-award-select')) {
@@ -8605,18 +8621,19 @@ function setupPronounPicker(cfg) {
         for (var i = 1; i <= maxRank; i++) {
             var pill = document.createElement('button');
             pill.type        = 'button';
-            pill.className   = 'pn-rank-pill' + (i == currentRank ? ' pn-rank-selected' : '');
-            pill.textContent = i;
+            pill.className   = 'pn-rank-pill';
+            pill.innerHTML   = tnRankPillInner('pn', i);
             pill.dataset.rank = i;
             (function(p, rank) {
                 p.addEventListener('click', function() {
-                    wrap.querySelectorAll('.pn-rank-pill').forEach(function(el) { el.classList.remove('pn-rank-selected'); });
-                    p.classList.add('pn-rank-selected');
                     gid('pn-edit-rank-val').value = rank;
+                    tnRankPaint(wrap, 'pn', rank, rank);
                 });
             })(pill, i);
             wrap.appendChild(pill);
         }
+        var _curRank = parseInt(currentRank, 10) || 0;
+        tnRankPaint(wrap, 'pn', _curRank, _curRank);
         gid('pn-edit-rank-val') && (gid('pn-edit-rank-val').value = currentRank || '');
     }
 
@@ -8906,25 +8923,20 @@ function setupPronounPicker(cfg) {
                 for (var i = 1; i <= maxRank; i++) {
                     var pill = document.createElement('button');
                     pill.type      = 'button';
-                    pill.className = 'pn-rank-pill'
-                        + (i <= heldMax    ? ' pn-rank-held'     : '')
-                        + (i === suggested ? ' pn-rank-suggested' : '');
-                    pill.textContent  = i;
+                    pill.className = 'pn-rank-pill';
+                    pill.innerHTML  = tnRankPillInner('pn', i);
                     pill.dataset.rank = i;
                     (function(p, rank) {
                         p.addEventListener('click', function() {
-                            rcRankPills.querySelectorAll('.pn-rank-pill').forEach(function(el) { el.classList.remove('pn-rank-selected'); });
-                            p.classList.add('pn-rank-selected');
                             rcRankVal.value = rank;
+                            tnRankPaint(rcRankPills, 'pn', heldMax, rank);
                         });
                     })(pill, i);
                     rcRankPills.appendChild(pill);
                 }
-                /* auto-select the suggested rank */
-                if (suggested > 0) {
-                    var sugPill = rcRankPills.querySelector('[data-rank="' + suggested + '"]');
-                    if (sugPill) { sugPill.classList.add('pn-rank-selected'); rcRankVal.value = suggested; }
-                }
+                rcRankPills.dataset.rankHeld = heldMax;
+                tnRankPaint(rcRankPills, 'pn', heldMax, suggested);
+                if (suggested > 0) { rcRankVal.value = suggested; }
             });
         }
 

--- a/orkui/template/revised-frontend/style/revised.css
+++ b/orkui/template/revised-frontend/style/revised.css
@@ -1499,11 +1499,25 @@ html[data-theme="dark"] .pn-acct-help-tip:hover { background: var(--ork-hover); 
 	.pn-rank-pill:hover:not(.pn-rank-selected),
 	.kn-rank-pill:hover:not(.kn-rank-selected),
 	.pk-rank-pill:hover:not(.pk-rank-selected) { box-shadow: 0 2px 6px rgba(0,0,0,0.18); }
+	/* Dark mode: a dark box-shadow on a dark surface is invisible — give a
+	   visible background/border shift instead so hover feedback survives. */
+	html[data-theme="dark"] .pn-rank-pill:hover:not(.pn-rank-selected),
+	html[data-theme="dark"] .kn-rank-pill:hover:not(.kn-rank-selected),
+	html[data-theme="dark"] .pk-rank-pill:hover:not(.pk-rank-selected) {
+		background: var(--ork-bg-tertiary);
+		border-color: var(--ork-text-lighter);
+	}
 }
 /* On phones the 36px pills make the rank grid overly tall — shrink ~30%. */
 @media (max-width: 600px) {
 	.pn-rank-pills-wrap { gap: 5px; }
 	.pn-rank-pill { width: 25px; height: 25px; font-size: 11px; border-width: 1.5px; }
+	/* The desktop selected lift (translateY(-3px) scale(1.16)) is proportionally
+	   too aggressive on the shrunken 25px pills — soften it so the pop stays
+	   inside the row. */
+	.pn-rank-pill.pn-rank-selected,
+	.kn-rank-pill.kn-rank-selected,
+	.pk-rank-pill.pk-rank-selected { transform: translateY(-2px) scale(1.08); }
 }
 /* Officer / giver quick chips */
 .pn-officer-chips {

--- a/orkui/template/revised-frontend/style/revised.css
+++ b/orkui/template/revised-frontend/style/revised.css
@@ -993,6 +993,10 @@ html[data-theme="dark"] .pn-rec-field label { color: var(--ork-text); }
 	border-radius: 12px;
 	width: 500px;
 	max-width: calc(100vw - 40px);
+	max-height: calc(100vh - 32px);
+	max-height: calc(100dvh - 32px);
+	display: flex;
+	flex-direction: column;
 	box-shadow: 0 25px 60px rgba(0,0,0,0.25);
 	transform: translateY(-16px) scale(0.98);
 	opacity: 0;
@@ -1008,6 +1012,7 @@ html[data-theme="dark"] .pn-rec-field label { color: var(--ork-text); }
 	justify-content: space-between;
 	padding: 18px 20px;
 	border-bottom: 1px solid #e2e8f0;
+	flex-shrink: 0;
 }
 .pn-modal-title {
 	margin: 0;
@@ -1039,6 +1044,8 @@ html[data-theme="dark"] .pn-rec-field label { color: var(--ork-text); }
 .pn-modal-close-btn:hover { background: #f7fafc; color: #4a5568; }
 .pn-modal-body {
 	padding: 20px;
+	overflow-y: auto;
+	flex: 1 1 auto;
 	overscroll-behavior: contain;
 	-webkit-overflow-scrolling: touch;
 }
@@ -1049,6 +1056,7 @@ html[data-theme="dark"] .pn-rec-field label { color: var(--ork-text); }
 	display: flex;
 	justify-content: flex-end;
 	gap: 10px;
+	flex-shrink: 0;
 }
 .pn-btn-primary { background: #2c5282; color: #fff; }
 .pn-btn-primary:hover:not(:disabled) { background: #2a4a7f; }
@@ -1435,6 +1443,11 @@ html[data-theme="dark"] .pn-acct-help-tip:hover { background: var(--ork-hover); 
 .pn-rank-pill.pn-rank-held { background: #ebf4ff; border-color: #90cdf4; color: #0891b2; }
 .pn-rank-pill.pn-rank-suggested { border-color: #68d391; }
 .pn-rank-pill.pn-rank-selected { background: #2c5282; border-color: #2c5282; color: #fff; }
+/* On phones the 36px pills make the rank grid overly tall — shrink ~30%. */
+@media (max-width: 600px) {
+	.pn-rank-pills-wrap { gap: 5px; }
+	.pn-rank-pill { width: 25px; height: 25px; font-size: 11px; border-width: 1.5px; }
+}
 /* Officer / giver quick chips */
 .pn-officer-chips {
 	display: flex;
@@ -2676,6 +2689,11 @@ html[data-theme="dark"] .kn-award-type-btn.kn-active { border-color:#63b3ed; bac
 .kn-rank-pill.kn-rank-held { background:#ebf4ff; border-color:#90cdf4; color:var(--kn-accent-mid, #276749); }
 .kn-rank-pill.kn-rank-suggested { border-color:#68d391; }
 .kn-rank-pill.kn-rank-selected { background:#2c5282; border-color:#2c5282; color:#fff; }
+/* On phones the 36px pills make the rank grid overly tall — shrink ~30%. */
+@media (max-width: 600px) {
+	.kn-rank-pills-wrap { gap: 5px; }
+	.kn-rank-pill { width: 25px; height: 25px; font-size: 11px; border-width: 1.5px; }
+}
 .kn-officer-chips { display:flex; flex-wrap:wrap; gap:5px; margin-bottom:6px; }
 .kn-officer-chip { padding:4px 10px; background:var(--ork-bg-tertiary); border:1px solid var(--ork-border); border-radius:14px; font-size:12px; color:var(--ork-text); cursor:pointer; }
 .kn-officer-chip.kn-selected { background:#ebf4ff; border-color:#90cdf4; color:var(--kn-accent-mid, #276749); font-weight:600; }
@@ -3742,6 +3760,11 @@ html[data-theme="dark"] .pk-stat-tip-text::after { border-top-color: #e2e8f0; }
 .pk-rank-pill.pk-rank-held { background:#ebf4ff; border-color:#90cdf4; color:#0891b2; }
 .pk-rank-pill.pk-rank-suggested { border-color:#68d391; }
 .pk-rank-pill.pk-rank-selected { background:#2c5282; border-color:#2c5282; color:#fff; }
+/* On phones the 36px pills make the rank grid overly tall — shrink ~30%. */
+@media (max-width: 600px) {
+	.pk-rank-pills-wrap { gap: 5px; }
+	.pk-rank-pill { width: 25px; height: 25px; font-size: 11px; border-width: 1.5px; }
+}
 .pk-officer-chips { display:flex; flex-wrap:wrap; gap:5px; margin-bottom:6px; }
 .pk-officer-chip { padding:4px 10px; background:#edf2f7; border:1px solid #e2e8f0; border-radius:14px; font-size:12px; color:#2d3748; cursor:pointer; }
 .pk-officer-chip.pk-selected { background:#ebf4ff; border-color:#90cdf4; color:#0891b2; font-weight:600; }

--- a/orkui/template/revised-frontend/style/revised.css
+++ b/orkui/template/revised-frontend/style/revised.css
@@ -261,17 +261,49 @@ html[data-theme="dark"] .pk-btn-white {
 	margin-bottom: 4px;
 }
 .pn-breadcrumb {
-	color: rgba(255,255,255,0.75);
-	font-size: 13px;
+	display: flex;
+	flex-wrap: wrap;
+	align-items: center;
+	gap: 8px;
 	margin-bottom: 10px;
 }
-.pn-breadcrumb a {
-	color: rgba(255,255,255,0.9);
-	text-decoration: underline;
+/* Breadcrumb squircle-pills (crown = kingdom, pin = park) — distinct from the rounder status badges */
+.pn-crumb,
+.pn-crumb:link,
+.pn-crumb:visited,
+.pn-crumb:hover {
+	color: #fff;
 }
-.pn-breadcrumb .pn-sep {
-	margin: 0 5px;
-	opacity: 0.5;
+.pn-crumb {
+	display: inline-flex;
+	align-items: center;
+	gap: 6px;
+	padding: 4px 12px;
+	border-radius: 7px;
+	background: rgba(0,0,0,0.3);
+	color: #fff;
+	font-size: 13px;
+	font-weight: 600;
+	text-decoration: none;
+	text-shadow: 0 1px 3px rgba(0,0,0,0.6);
+	transition: background 0.15s;
+}
+.pn-crumb:hover {
+	background: rgba(0,0,0,0.42);
+	text-decoration: none;
+}
+.pn-crumb i {
+	font-size: 11px;
+	opacity: 0.85;
+}
+/* Dark mode: override the global `html[data-theme="dark"] a { color:#63b3ed }` link tint — pills stay white.
+   Uses !important to match the project pattern for beating that global rule (see .ev-table / .en-table overrides). */
+html[data-theme="dark"] .pn-crumb,
+html[data-theme="dark"] .pn-crumb:link,
+html[data-theme="dark"] .pn-crumb:visited,
+html[data-theme="dark"] .pn-crumb:hover,
+html[data-theme="dark"] .pn-crumb i {
+	color: #fff !important;
 }
 .pn-badges {
 	display: flex;

--- a/orkui/template/revised-frontend/style/revised.css
+++ b/orkui/template/revised-frontend/style/revised.css
@@ -1432,17 +1432,74 @@ html[data-theme="dark"] .pn-acct-help-tip:hover { background: var(--ork-hover); 
 	cursor: pointer;
 	background: #fff;
 	color: #4a5568;
-	transition: all 0.12s;
+	transition: transform 0.12s, box-shadow 0.12s, background 0.12s, border-color 0.12s, color 0.12s;
 	user-select: none;
+	position: relative;
+	overflow: hidden;
 }
-/* Gate hover styles on real pointer devices — on iOS the :hover state
-   sticks after a tap, which would visually override .pn-rank-selected. */
+
+/* ============================================================
+   Rank pills — unified state scheme (all surfaces: pn / kn / pk)
+   held    = green  + ✓ watermark behind the number (already earned)
+   forward = blue   + → watermark behind the number (being granted /
+             recommended; every step forward of the chosen rank)
+   selected= pops up (lift + shadow), layered over its held/forward color
+   Identical on every surface — no kingdom/park divergence.
+   ============================================================ */
+/* the number sits above the watermark — big & bold for legibility */
+.pn-rank-num, .kn-rank-num, .pk-rank-num {
+	position: relative; z-index: 1;
+	font-weight: 800; font-size: 1.25em; line-height: 1;
+	text-shadow: 0 1px 2px rgba(0,0,0,0.20);
+}
+/* watermark glyph — large + faint so the number reads clearly through it */
+.pn-rank-held::before, .pn-rank-forward::before,
+.kn-rank-held::before, .kn-rank-forward::before,
+.pk-rank-held::before, .pk-rank-forward::before {
+	position: absolute; inset: 0; z-index: 0;
+	display: flex; align-items: center; justify-content: center;
+	font-family: 'Font Awesome 5 Free'; font-weight: 900;
+	font-size: 2em; line-height: 1; color: #fff; opacity: 0.25;
+	pointer-events: none;
+}
+.pn-rank-held::before, .kn-rank-held::before, .pk-rank-held::before { content: '\f00c'; } /* check — already earned */
+.pn-rank-forward::before, .kn-rank-forward::before, .pk-rank-forward::before { content: '\f061'; } /* arrow-right — skipped/intermediate step */
+/* the chosen rank itself = up arrow ("leveling up to here") */
+.pn-rank-forward.pn-rank-selected::before,
+.kn-rank-forward.kn-rank-selected::before,
+.pk-rank-forward.pk-rank-selected::before { content: '\f062'; } /* arrow-up */
+
+/* held — ranks the player already has (green, soft gradient) */
+.pn-rank-pill.pn-rank-held, .kn-rank-pill.kn-rank-held, .pk-rank-pill.pk-rank-held {
+	background: linear-gradient(135deg, #a7ecbd, #7fd99e);
+	border-color: #48bb78; color: #1c4532;
+}
+/* forward — ranks being granted / recommended (blue, soft gradient) */
+.pn-rank-pill.pn-rank-forward, .kn-rank-pill.kn-rank-forward, .pk-rank-pill.pk-rank-forward {
+	background: linear-gradient(135deg, #9fd6f7, #6cb8ef);
+	border-color: #3182ce; color: #15314f;
+}
+/* selected — pops up over its underlying held/forward color */
+.pn-rank-pill.pn-rank-selected, .kn-rank-pill.kn-rank-selected, .pk-rank-pill.pk-rank-selected {
+	transform: translateY(-3px) scale(1.16);
+	box-shadow: 0 7px 16px rgba(0,0,0,0.32), inset 0 1px 0 rgba(255,255,255,0.55);
+	border-width: 2px;
+	z-index: 2;
+}
+/* colored glow ring keyed to the underlying state */
+.pn-rank-forward.pn-rank-selected, .kn-rank-forward.kn-rank-selected, .pk-rank-forward.pk-rank-selected {
+	box-shadow: 0 7px 16px rgba(0,0,0,0.32), 0 0 0 3px rgba(49,130,206,0.45), inset 0 1px 0 rgba(255,255,255,0.55);
+}
+.pn-rank-held.pn-rank-selected, .kn-rank-held.kn-rank-selected, .pk-rank-held.pk-rank-selected {
+	box-shadow: 0 7px 16px rgba(0,0,0,0.32), 0 0 0 3px rgba(56,161,105,0.45), inset 0 1px 0 rgba(255,255,255,0.55);
+}
+/* Gate hover lift on real pointer devices — on iOS :hover sticks after a tap.
+   Exclude the selected pill so its glow ring isn't overwritten on hover. */
 @media (hover: hover) {
-.pn-rank-pill:hover { border-color: #90cdf4; color: #0891b2; background: #ebf4ff; }
+	.pn-rank-pill:hover:not(.pn-rank-selected),
+	.kn-rank-pill:hover:not(.kn-rank-selected),
+	.pk-rank-pill:hover:not(.pk-rank-selected) { box-shadow: 0 2px 6px rgba(0,0,0,0.18); }
 }
-.pn-rank-pill.pn-rank-held { background: #ebf4ff; border-color: #90cdf4; color: #0891b2; }
-.pn-rank-pill.pn-rank-suggested { border-color: #68d391; }
-.pn-rank-pill.pn-rank-selected { background: #2c5282; border-color: #2c5282; color: #fff; }
 /* On phones the 36px pills make the rank grid overly tall — shrink ~30%. */
 @media (max-width: 600px) {
 	.pn-rank-pills-wrap { gap: 5px; }
@@ -2682,13 +2739,8 @@ html[data-theme="dark"] .kn-award-type-btn.kn-active { border-color:#63b3ed; bac
 .kn-award-type-btn:hover:not(.kn-active) { border-color:var(--ork-border-dark); background:var(--ork-bg-secondary); }
 @media (max-width: 400px) { .kn-award-type-btn { font-size:11px; } }
 .kn-rank-pills-wrap { display:flex; flex-wrap:wrap; gap:6px; margin-top:4px; }
-.kn-rank-pill { width:36px; height:36px; border:2px solid #e2e8f0; border-radius:50%; display:flex; align-items:center; justify-content:center; font-size:13px; font-weight:700; cursor:pointer; background:#fff; color:#4a5568; transition:all 0.12s; user-select:none; }
-@media (hover: hover) {
-.kn-rank-pill:hover { border-color: #90cdf4; color: var(--kn-accent-mid, #276749); background: #ebf4ff; }
-}
-.kn-rank-pill.kn-rank-held { background:#ebf4ff; border-color:#90cdf4; color:var(--kn-accent-mid, #276749); }
-.kn-rank-pill.kn-rank-suggested { border-color:#68d391; }
-.kn-rank-pill.kn-rank-selected { background:#2c5282; border-color:#2c5282; color:#fff; }
+.kn-rank-pill { width:36px; height:36px; border:2px solid #e2e8f0; border-radius:50%; display:flex; align-items:center; justify-content:center; font-size:13px; font-weight:700; cursor:pointer; background:#fff; color:#4a5568; transition:transform 0.12s, box-shadow 0.12s, background 0.12s, border-color 0.12s, color 0.12s; user-select:none; position:relative; overflow:hidden; }
+/* held / forward / selected styling is unified in the rank-pill scheme block above */
 /* On phones the 36px pills make the rank grid overly tall — shrink ~30%. */
 @media (max-width: 600px) {
 	.kn-rank-pills-wrap { gap: 5px; }
@@ -3756,10 +3808,8 @@ html[data-theme="dark"] .pk-stat-tip-text::after { border-top-color: #e2e8f0; }
 .pk-award-type-btn:hover:not(.pk-active) { border-color:#cbd5e0; background:#f7fafc; }
 @media (max-width: 400px) { .pk-award-type-btn { font-size:11px; } }
 .pk-rank-pills-wrap { display:flex; flex-wrap:wrap; gap:6px; margin-top:4px; }
-.pk-rank-pill { width:36px; height:36px; border:2px solid #e2e8f0; border-radius:50%; display:flex; align-items:center; justify-content:center; font-size:13px; font-weight:700; cursor:pointer; background:#fff; color:#4a5568; transition:all 0.12s; user-select:none; }
-.pk-rank-pill.pk-rank-held { background:#ebf4ff; border-color:#90cdf4; color:#0891b2; }
-.pk-rank-pill.pk-rank-suggested { border-color:#68d391; }
-.pk-rank-pill.pk-rank-selected { background:#2c5282; border-color:#2c5282; color:#fff; }
+.pk-rank-pill { width:36px; height:36px; border:2px solid #e2e8f0; border-radius:50%; display:flex; align-items:center; justify-content:center; font-size:13px; font-weight:700; cursor:pointer; background:#fff; color:#4a5568; transition:transform 0.12s, box-shadow 0.12s, background 0.12s, border-color 0.12s, color 0.12s; user-select:none; position:relative; overflow:hidden; }
+/* held / forward / selected styling is unified in the rank-pill scheme block above */
 /* On phones the 36px pills make the rank grid overly tall — shrink ~30%. */
 @media (max-width: 600px) {
 	.pk-rank-pills-wrap { gap: 5px; }
@@ -6496,7 +6546,8 @@ html[data-theme="dark"] .pn-stat-number { color: #90cdf4; }
 html[data-theme="dark"] .kn-stat-number { color: #90cdf4; }
 html[data-theme="dark"] .pk-stat-number { color: #90cdf4; }
 
-/* Rank/role pills */
+/* Rank pills — unified dark scheme (colors only; lift/shadow inherited from
+   the theme-agnostic .X-rank-selected rule above). */
 html[data-theme="dark"] .kn-rank-pill,
 html[data-theme="dark"] .pk-rank-pill,
 html[data-theme="dark"] .pn-rank-pill {
@@ -6504,24 +6555,32 @@ html[data-theme="dark"] .pn-rank-pill {
   color: var(--ork-text);
   border-color: var(--ork-border);
 }
-html[data-theme="dark"] .pk-rank-pill.pk-rank-held,
-html[data-theme="dark"] .pn-rank-pill.pn-rank-held {
-  background: rgba(99,179,237,0.15);
-  border-color: #4299e1;
-  color: #90cdf4;
-}
-html[data-theme="dark"] .pk-rank-pill.pk-rank-selected,
-html[data-theme="dark"] .pn-rank-pill.pn-rank-selected {
-  background: #2b6cb0;
-  border-color: #4299e1;
-  color: #fff;
-}
-html[data-theme="dark"] .pk-rank-pill.pk-rank-suggested,
-html[data-theme="dark"] .pn-rank-pill.pn-rank-suggested {
+/* held — already earned (dark green gradient, near-white number) */
+html[data-theme="dark"] .pn-rank-pill.pn-rank-held,
+html[data-theme="dark"] .kn-rank-pill.kn-rank-held,
+html[data-theme="dark"] .pk-rank-pill.pk-rank-held {
+  background: linear-gradient(135deg, #2f6b4f, #1d4733);
   border-color: #48bb78;
+  color: #eafff3;
 }
-@media (hover: hover) {
-html[data-theme="dark"] .pn-rank-pill:hover { background: rgba(99,179,237,0.12); border-color: #63b3ed; color: #90cdf4; }
+/* forward — being granted / recommended (dark blue gradient, near-white number) */
+html[data-theme="dark"] .pn-rank-pill.pn-rank-forward,
+html[data-theme="dark"] .kn-rank-pill.kn-rank-forward,
+html[data-theme="dark"] .pk-rank-pill.pk-rank-forward {
+  background: linear-gradient(135deg, #345083, #23375a);
+  border-color: #4299e1;
+  color: #eaf4ff;
+}
+/* selected — pops up, colored glow ring keyed to the underlying state */
+html[data-theme="dark"] .pn-rank-forward.pn-rank-selected,
+html[data-theme="dark"] .kn-rank-forward.kn-rank-selected,
+html[data-theme="dark"] .pk-rank-forward.pk-rank-selected {
+  box-shadow: 0 7px 18px rgba(0,0,0,0.6), 0 0 0 3px rgba(66,153,225,0.55), inset 0 1px 0 rgba(255,255,255,0.22);
+}
+html[data-theme="dark"] .pn-rank-held.pn-rank-selected,
+html[data-theme="dark"] .kn-rank-held.kn-rank-selected,
+html[data-theme="dark"] .pk-rank-held.pk-rank-selected {
+  box-shadow: 0 7px 18px rgba(0,0,0,0.6), 0 0 0 3px rgba(72,187,120,0.55), inset 0 1px 0 rgba(255,255,255,0.22);
 }
 
 /* Award type toggle (Awards / Officer Titles) */
@@ -7003,18 +7062,10 @@ html[data-theme="dark"] .pk-year-summary:hover,
 html[data-theme="dark"] .pk-year-summary:hover::before {
   color: hsl(var(--pk-hue, 195), var(--pk-sat, 80%), var(--ork-accent-lightness, 65%));
 }
-html[data-theme="dark"] .kn-officer-chip.kn-selected,
-html[data-theme="dark"] .kn-rank-pill.kn-rank-held {
+html[data-theme="dark"] .kn-officer-chip.kn-selected {
   background: rgba(255,255,255,0.07);
   border-color: hsl(var(--kn-hue), var(--kn-sat), var(--ork-accent-lightness, 65%));
   color: hsl(var(--kn-hue), var(--kn-sat), var(--ork-accent-lightness, 65%));
-}
-@media (hover: hover) {
-html[data-theme="dark"] .kn-rank-pill:hover {
-  background: rgba(255,255,255,0.07);
-  border-color: hsl(var(--kn-hue), var(--kn-sat), var(--ork-accent-lightness, 65%));
-  color: hsl(var(--kn-hue), var(--kn-sat), var(--ork-accent-lightness, 65%));
-}
 }
 
 /* ---- Kingdom tab & view button accents ---- */

--- a/system/lib/ork3/class.Award.php
+++ b/system/lib/ork3/class.Award.php
@@ -104,6 +104,40 @@ class Award  extends Ork3 {
 		return $response;
 	}
 
+	/**
+	 * Awards a "Custom Title" may be aliased to: peerage-ladder rungs and other titles.
+	 * Drives the Add Award modal's "Alias of" dropdown on the player, kingdom, and park
+	 * profiles. The list is global (not kingdom-specific), so it is shared across all three.
+	 *
+	 * @return array ['Peerage' => [...], 'Titles' => [...]] of ['AwardId','Name','Peerage'] rows
+	 */
+	public function fetch_custom_title_alias_options() {
+		$sql = "SELECT award_id, name, peerage, is_title
+			FROM " . DB_PREFIX . "award
+			WHERE officer_role = 'none'
+			  AND name <> 'Custom Title'
+			  AND name <> 'Custom Award'
+			  AND (peerage IN ('Page','Lords-Page','Squire','Man-At-Arms','Master','Knight') OR is_title = 1)
+			ORDER BY FIELD(peerage,'Knight','Master','Squire','Man-At-Arms','Lords-Page','Page') DESC, is_title DESC, name ASC";
+		$r = $this->db->query($sql);
+		$peerage = []; $titles = [];
+		if ($r !== false && $r->size() > 0) {
+			while ($r->next()) {
+				$row = [
+					'AwardId' => (int)$r->award_id,
+					'Name'    => $r->name,
+					'Peerage' => $r->peerage,
+				];
+				if (in_array($r->peerage, ['Page','Lords-Page','Squire','Man-At-Arms','Master','Knight'], true)) {
+					$peerage[] = $row;
+				} elseif ((int)$r->is_title === 1) {
+					$titles[] = $row;
+				}
+			}
+		}
+		return ['Peerage' => $peerage, 'Titles' => $titles];
+	}
+
 	public function CreateAward($request) {
 		if (($mundane_id = Ork3::$Lib->authorization->IsAuthorized($request['Token'])) > 0
 				&& Ork3::$Lib->authorization->HasAuthority($mundane_id, AUTH_ADMIN, 0, AUTH_CREATE)) {

--- a/system/lib/ork3/class.Player.php
+++ b/system/lib/ork3/class.Player.php
@@ -341,6 +341,7 @@ class Player extends Ork3 {
 					'ColorPrimary' => $design->color_primary,
 					'ColorAccent' => $design->color_accent,
 						'ColorSecondary' => $design->color_secondary,
+						'HeroGradient' => $design->hero_gradient,
 						'HeroOverlay' => $design->hero_overlay,
 					'NamePrefix' => $design->name_prefix,
 					'NameSuffix' => $design->name_suffix,
@@ -1098,7 +1099,7 @@ class Player extends Ork3 {
 		// what's exposed publicly, so changes there should land in the log.
 		$cosmetic = [
 			'AboutPersona' => 1, 'AboutStory' => 1, 'MilestoneConfig' => 1,
-			'ColorPrimary' => 1, 'ColorAccent' => 1, 'ColorSecondary' => 1, 'HeroOverlay' => 1,
+			'ColorPrimary' => 1, 'ColorAccent' => 1, 'ColorSecondary' => 1, 'HeroGradient' => 1, 'HeroOverlay' => 1,
 			'NameFont' => 1,
 			'PhotoFocusX' => 1, 'PhotoFocusY' => 1, 'PhotoFocusSize' => 1,
 			'ShowBeltline' => 1, 'BeltDisplay' => 1,
@@ -1197,7 +1198,7 @@ class Player extends Ork3 {
 					$_cur = [];
 					if ($_designExisted) {
 						foreach (['about_persona','about_story','color_primary','color_accent','color_secondary',
-								  'hero_overlay','name_prefix','name_suffix','suffix_comma',
+								  'hero_gradient','hero_overlay','name_prefix','name_suffix','suffix_comma',
 								  'photo_focus_x','photo_focus_y','photo_focus_size',
 								  'show_beltline','belt_display','pronunciation_guide',
 								  'show_mundane_first','show_mundane_last','show_email',
@@ -1244,6 +1245,14 @@ class Player extends Ork3 {
 					$design->color_primary = $_pick($request['ColorPrimary'], 'color_primary');
 					$design->color_accent = $_pick($request['ColorAccent'], 'color_accent');
 					$design->color_secondary = $_pick($request['ColorSecondary'], 'color_secondary');
+					// HeroGradient is an Amtpride preset key validated against the keys of
+					// system/lib/ork3/pride_gradients.php. Anything else is coerced to ''.
+					if (array_key_exists('HeroGradient', $request)) {
+						$_prideKeys = array_keys(require __DIR__ . '/pride_gradients.php');
+						$design->hero_gradient = (is_string($request['HeroGradient']) && in_array($request['HeroGradient'], $_prideKeys, true)) ? $request['HeroGradient'] : null;
+					} else {
+						$design->hero_gradient = $_designExisted ? $_cur['hero_gradient'] : null;
+					}
 					$validOverlays = ['low','med','high','vignette'];
 					$design->hero_overlay = (isset($request['HeroOverlay']) && in_array($request['HeroOverlay'], $validOverlays)) ? $request['HeroOverlay'] : ($_designExisted ? $_cur['hero_overlay'] : 'med');
 					$design->name_prefix = $_pick($request['NamePrefix'], 'name_prefix');

--- a/system/lib/ork3/class.Player.php
+++ b/system/lib/ork3/class.Player.php
@@ -1248,7 +1248,8 @@ class Player extends Ork3 {
 					// HeroGradient is an Amtpride preset key validated against the keys of
 					// system/lib/ork3/pride_gradients.php. Anything else is coerced to ''.
 					if (array_key_exists('HeroGradient', $request)) {
-						$_prideKeys = array_keys(require __DIR__ . '/pride_gradients.php');
+						static $_prideKeys = null;
+						if ($_prideKeys === null) { $_prideKeys = array_keys(require __DIR__ . '/pride_gradients.php'); }
 						$design->hero_gradient = (is_string($request['HeroGradient']) && in_array($request['HeroGradient'], $_prideKeys, true)) ? $request['HeroGradient'] : null;
 					} else {
 						$design->hero_gradient = $_designExisted ? $_cur['hero_gradient'] : null;

--- a/system/lib/ork3/class.Player.php
+++ b/system/lib/ork3/class.Player.php
@@ -1246,13 +1246,16 @@ class Player extends Ork3 {
 					$design->color_accent = $_pick($request['ColorAccent'], 'color_accent');
 					$design->color_secondary = $_pick($request['ColorSecondary'], 'color_secondary');
 					// HeroGradient is an Amtpride preset key validated against the keys of
-					// system/lib/ork3/pride_gradients.php. Anything else is coerced to ''.
+					// system/lib/ork3/pride_gradients.php. Anything else is coerced to '' (NOT
+					// null): yapo's update_base() filters SET fields with isset(), which is false
+					// for null, so assigning null would silently omit the column and leave a stale
+					// pride key in the DB. '' is a valid "no flag" sentinel the template treats as empty.
 					if (array_key_exists('HeroGradient', $request)) {
 						static $_prideKeys = null;
 						if ($_prideKeys === null) { $_prideKeys = array_keys(require __DIR__ . '/pride_gradients.php'); }
-						$design->hero_gradient = (is_string($request['HeroGradient']) && in_array($request['HeroGradient'], $_prideKeys, true)) ? $request['HeroGradient'] : null;
+						$design->hero_gradient = (is_string($request['HeroGradient']) && in_array($request['HeroGradient'], $_prideKeys, true)) ? $request['HeroGradient'] : '';
 					} else {
-						$design->hero_gradient = $_designExisted ? $_cur['hero_gradient'] : null;
+						$design->hero_gradient = $_designExisted ? $_cur['hero_gradient'] : '';
 					}
 					$validOverlays = ['low','med','high','vignette'];
 					$design->hero_overlay = (isset($request['HeroOverlay']) && in_array($request['HeroOverlay'], $validOverlays)) ? $request['HeroOverlay'] : ($_designExisted ? $_cur['hero_overlay'] : 'med');

--- a/system/lib/ork3/class.Report.php
+++ b/system/lib/ork3/class.Report.php
@@ -424,13 +424,18 @@ class Report  extends Ork3 {
 
 	public function PlayerAwardRecommendations($request) {
 
-		// Cache key only the SQL filter dimensions — the non-filter params (IncludeKnights,
-		// IncludeMasters, IncludeLadder, LadderMinimum) don't change the response, so keying
-		// on them just bloats the keyspace and breaks bust.
+		// Cache key the SQL filter dimensions PLUS the viewer (RequestedBy): the response
+		// embeds per-viewer fields (ViewerCanSecond, ViewerCanEditReason, and each second's
+		// IsMine), so a viewer-agnostic key would serve one viewer's "can I second this?"
+		// flags to everyone — e.g. a recommender who can't second their own rung would
+		// suppress the +1 for other officers. The non-filter params (IncludeKnights,
+		// IncludeMasters, IncludeLadder, LadderMinimum) don't change the response, so they
+		// stay out of the key.
 		$key = Ork3::$Lib->ghettocache->key([
 			'KingdomId' => (int)($request['KingdomId'] ?? 0),
 			'ParkId'    => (int)($request['ParkId']    ?? 0),
 			'PlayerId'  => (int)($request['PlayerId']  ?? 0),
+			'RequestedBy' => (int)($request['RequestedBy'] ?? 0),
 		]);
 		if (($cache = Ork3::$Lib->ghettocache->get(__CLASS__ . '.' . __FUNCTION__, $key, 300)) !== false)
 			return $cache;

--- a/system/lib/ork3/class.SearchService.php
+++ b/system/lib/ork3/class.SearchService.php
@@ -292,7 +292,7 @@ class SearchService extends Ork3 {
 		return Ork3::$Lib->ghettocache->cache(__CLASS__ . '.' . __FUNCTION__, $key, $r);
 	}
 	public function magic_search($term, $kingdom_id, $park_id) {
-		preg_match('/([a-z0-9]{2,3}):([a-z0-9]{2,3}|[\*]{1})?\s+(.+)/i', $term, $matches);
+		preg_match('/^([a-z0-9]{2,3}):([a-z0-9]{2,3}|[\*]{1})?:?\s+(.+)$/i', $term, $matches);
 
 		$k_id = isset($matches[1]) ? Ork3::$Lib->kingdom->GetKingdomByAbbreviation(array('Abbreviation'=>$matches[1])) : null;
 		$p_id = isset($matches[2]) ? Ork3::$Lib->park->GetParkInKingdomByAbbreviation(array('Abbreviation'=>$matches[2]), $k_id) : null;
@@ -378,6 +378,13 @@ class SearchService extends Ork3 {
 		}
 		$opt[] = "(m.kingdom_id != 15 AND (p.kingdom_id IS NULL OR p.kingdom_id != 15))";
 		$order = $order ?? 'order by m.active DESC, persona';
+		// Relevance ranking: float exact and prefix persona matches to the top so a short,
+		// common token (e.g. "Silent") surfaces its exact match before the row limit truncates
+		// the alphabetical tail. Every search type's $order begins with "order by m.active DESC,".
+		$_rel = mysql_real_escape_string($search);
+		$order = preg_replace('/^order by m\.active DESC,/i',
+			"order by m.active DESC, (`persona` = '{$_rel}') DESC, (`persona` like '{$_rel}%') DESC,",
+			$order);
 		$sql = "select 
 						`mundane_id`, m.`active`, `given_name`, `surname`, `other_name`, concat(`given_name`,' ',`surname`) as `mundane`, `username`, `persona`, p.park_id, k.kingdom_id, 
 						`restricted`, `suspended`, `suspended_at`, `suspended_until`, `waivered`, `company_id`, `penalty_box`, k.name as kingdom_name, p.name as park_name, p.abbreviation as p_abbr, k.abbreviation as k_abbr

--- a/system/lib/ork3/class.SearchService.php
+++ b/system/lib/ork3/class.SearchService.php
@@ -381,7 +381,10 @@ class SearchService extends Ork3 {
 		// Relevance ranking: float exact and prefix persona matches to the top so a short,
 		// common token (e.g. "Silent") surfaces its exact match before the row limit truncates
 		// the alphabetical tail. Every search type's $order begins with "order by m.active DESC,".
-		$_rel = mysql_real_escape_string($search);
+		// Escape for a SQL string literal by doubling single quotes. NOTE: the file-wide
+		// use of mysql_real_escape_string elsewhere is a no-op polyfill (pre-existing,
+		// separate issue) — this one new line does its own proper escaping.
+		$_rel = str_replace("'", "''", (string)$search);
 		$order = preg_replace('/^order by m\.active DESC,/i',
 			"order by m.active DESC, (`persona` = '{$_rel}') DESC, (`persona` like '{$_rel}%') DESC,",
 			$order);

--- a/system/lib/ork3/pride_gradients.php
+++ b/system/lib/ork3/pride_gradients.php
@@ -1,0 +1,28 @@
+<?php
+// Amtpride Nameplate gradient definitions. Each entry maps a preset key to the
+// human-readable flag name and an ordered list of hex color stops that render
+// as a smooth horizontal linear-gradient on the player's hero. Order in this
+// array is the display order in the Amtpride Nameplate subsection of the
+// Design My Profile modal.
+//
+// New flags: append here and (if needed) extend the column width — keys are
+// validated server-side in class.Player.php::UpdatePlayer against the keys
+// of this map.
+
+return [
+	'pride6'      => ['name' => '6-Color Pride',                'colors' => ['#e40303','#ff8c00','#ffed00','#008026','#004dff','#750787']],
+	'progress'    => ['name' => 'Progress Pride',               'colors' => ['#000000','#784f17','#5bcffa','#f5a9b8','#ffffff','#e40303','#ff8c00','#ffed00','#008026','#004dff','#750787']],
+	'gilbert8'    => ['name' => "Gilbert Baker's 1977 8-Color", 'colors' => ['#ff69b4','#e40303','#ff8c00','#ffed00','#008026','#00c0c0','#3f48cc','#750787']],
+	'philly'      => ['name' => 'Philadelphia POC-Inclusive',   'colors' => ['#000000','#784f17','#e40303','#ff8c00','#ffed00','#008026','#004dff','#750787']],
+	'lesbian'     => ['name' => 'Lesbian',                      'colors' => ['#d62900','#ff9b55','#ffffff','#d461a6','#a50062']],
+	'bisexual'    => ['name' => 'Bisexual',                     'colors' => ['#d60270','#9b4f96','#0038a8']],
+	'pansexual'   => ['name' => 'Pansexual',                    'colors' => ['#ff218c','#ffd800','#21b1ff']],
+	'polysexual'  => ['name' => 'Polysexual',                   'colors' => ['#f714ba','#01d66a','#1594f6']],
+	'asexual'     => ['name' => 'Asexual',                      'colors' => ['#000000','#a3a3a3','#ffffff','#800080']],
+	'aromantic'   => ['name' => 'Aromantic',                    'colors' => ['#3da542','#a7d379','#ffffff','#a9a9a9','#000000']],
+	'transgender' => ['name' => 'Transgender',                  'colors' => ['#5bcffa','#f5a9b8','#ffffff','#f5a9b8','#5bcffa']],
+	'nonbinary'   => ['name' => 'Nonbinary',                    'colors' => ['#fcf434','#ffffff','#9c59d1','#2c2c2c']],
+	'genderfluid' => ['name' => 'Genderfluid',                  'colors' => ['#ff75a2','#ffffff','#be18d6','#000000','#333ebd']],
+	'genderqueer' => ['name' => 'Genderqueer',                  'colors' => ['#b57edc','#ffffff','#4a8123']],
+	'intersex'    => ['name' => 'Intersex',                     'colors' => ['#ffd800','#7902aa','#ffd800']],
+];


### PR DESCRIPTION
## Summary
- Adds an **Amtpride Nameplate** subsection to the player profile Design modal with 15 pride-flag preset gradients (6-color, Progress, Gilbert Baker 1977, Philly POC-inclusive, lesbian, bi, pan, poly, ace, aro, trans, nonbinary, genderfluid, genderqueer, intersex).
- New `ork_mundane_design.hero_gradient varchar(32)` column stores the selected preset key; gradient definitions live in `system/lib/ork3/pride_gradients.php` so new flags are a one-line addition.
- When a flag is active it renders as a horizontal multi-stop linear gradient on the hero and overrides the existing custom primary/secondary colors. Suspended state still wins. Pride colors render as-is in light **and** dark mode — they're identity-bearing and shouldn't be tinted.

## Files
- `db-migrations/2026-05-19-mundane-design-hero-gradient.sql` — adds `hero_gradient` column
- `system/lib/ork3/pride_gradients.php` — preset definitions (key → name + color stops)
- `system/lib/ork3/class.Player.php` — load/persist/validate + audit log entry
- `orkui/controller/controller.PlayerAjax.php` — accepts `HeroGradient` POST param
- `orkui/template/revised-frontend/Playernew_index.tpl` — subsection UI, swatch picker, hero render, dark-mode styles

## Test plan
- [ ] Run the migration: `docker exec -i ork3-php8-db mariadb -u root -proot ork < db-migrations/2026-05-19-mundane-design-hero-gradient.sql`
- [ ] Open the Design My Profile modal on a player; expand **Amtpride Nameplate**; pick each flag and confirm the preview updates and saves
- [ ] Confirm picking a flag dims/disables the custom color presets, and clicking the "Clear pride flag" button restores them
- [ ] Reload the player profile and confirm the hero renders the selected gradient
- [ ] Switch to dark mode and confirm the flag colors render unchanged (no tinting), and the subsection chrome (border, hover, selected ring) is legible
- [ ] Confirm a suspended player still shows the red suspended hero regardless of selected flag
- [ ] Submit a bogus `HeroGradient` value via the AJAX endpoint and verify it is rejected/coerced to null

## Miscellaneous fixes
- **Universal search — typographic punctuation folding.** Names stored with typographic characters (e.g. "Wolf's Run" with a curly apostrophe `’` U+2019) were missed by the top-bar universal search, because the `utf8mb4_unicode_ci` collation does not treat them as equal to their ASCII forms. The search now normalizes both the typed query and the compared columns via a `$punctFolds` map (curly single/double quotes, em/en dashes, no-break space, small tilde) across parks, kingdoms, units, and players. Accented letters already match under the column collation and are left untouched. Code-only; no DB changes.
  - `orkui/controller/controller.SearchAjax.php`

- **Award entry — Given By is now cross-kingdom.** The legacy award-entry form (`Award/park/{id}` → `Award_addawards.tpl`) scoped the **Given By** autocomplete to the page's kingdom by passing `kingdom_id` to `SearchService::Player()`, which hard-filters on it. Awards are routinely presented by players from other kingdoms (wars, coronations, etc.), so the giver simply could not be found. Given By now passes `kingdom_id: 0` so the search spans all kingdoms; the existing `(KAbbr:PAbbr)` suffix disambiguates same-named personas. **Given To** stays kingdom-scoped — you record awards for your own members. Code-only; no DB changes.
  - `orkui/template/default/Award_addawards.tpl`


- **Add Award modal — Custom Title surfacing + "Alias of" on all modals.** Two related Custom Title improvements to the Add Award modal across the player, kingdom, and park profiles. (1) "Custom Title" now appears at the very top of the **Achievement Titles** dropdown (in addition to Awards), so it's discoverable where titles live; this also makes the Achievements tab appear even when a kingdom has no other titles. (2) The "Alias of" dropdown — previously player-only — is now on the kingdom and park modals: their change handlers distinguish Custom Title from Custom Award via data attributes, relabel the custom-name field, show the alias dropdown for Custom Title, and submit `AliasAwardId`. The alias-options query was extracted from `controller.Player.php` into a shared `Model_Award::fetch_custom_title_alias_options()` used by all three controllers.
  - `orkui/model/model.Award.php`, `controller.Player.php`, `controller.Kingdom.php`, `controller.Park.php`, `Kingdomnew_index.tpl`, `Parknew_index.tpl`, `revised-frontend/script/revised.js`

- **Player search — relevance ranking + hardened `KD:PK` prefix.** A company "Add Member" search couldn't find a cross-kingdom player ("Silent", GP:SKW) without a prefix. `SearchService::Player()` ordered results purely `active DESC, persona`, so a common token's exact match was alphabetically truncated past the row limit. Added an exact/prefix persona relevance tier to the `ORDER BY` (all search types/callers benefit). Also hardened `magic_search`: anchored the prefix regex (matching the universal search) and made the park separator tolerant of a trailing colon, so `GP:SKW: Silent` no longer mid-string mis-matches as `SKW: Silent`. Code-only; no DB changes.
  - `system/lib/ork3/class.SearchService.php`

- **Household "Add Member" search — filter within park instead of an alphabetical roster.** The Unit add-member/add-manager autocomplete was the last player search still on the legacy `SearchService` + `magic_search` path (tiny `LIMIT 8` per tier, fragile 3-call merge). In large parks the typed name failed to narrow results, so the dropdown showed the park roster A–Z truncated at the limit — users couldn't reach later names (e.g. "Wolf"). Ported it onto the canonical `KingdomAjax/playersearch` endpoint, mirroring the Event RSVP modal (`evPnBuildGroups`): LIKE-based filtering, own-kingdom-first ordering, `LIMIT 15` per tier; tiers *In Park* → *In Kingdom* → *All Players* (deduped, header only when the tier has unseen rows); abbreviation prefix (`nb:ff wolf`) handled server-side. Also hardened: persona rendered via `textContent` (was raw `innerHTML`) and a sequence guard so a slow earlier response can't overwrite a newer keystroke.
  - `orkui/template/default/Unit_index.tpl`


- **Award Recommendation modal — mobile viewport access.** On phones the recommendation / add-award modal had no `max-height`, so the vertically-centered box pushed its header (title + close ✕) off the top and its footer (Submit/Cancel) off the bottom with no way to scroll to either. The base `.pn-modal-box` is now viewport-bounded (`max-height: calc(100dvh - 32px)`, flex column) with a pinned header/footer and an internally-scrolling body — the same pattern the reconcile modal already used; the Kingdom/Park modals already shipped this cap. The rank number buttons also shrink ~30% (36px → 25px) at ≤600px so the rank grid stops dominating the modal. CSS-only; no DB changes.
  - `orkui/template/revised-frontend/style/revised.css`

- **Rank pill selector — unified earned / granted / selected scheme.** Redesigned the rank pills shared by every add-award and recommend surface (player, kingdom, park; add, recommend, edit, reconcile) into one identical scheme driven by a shared painter: earned ranks render green with a faint ✓ watermark, ranks being granted render blue with a faint → watermark, and the chosen rank pops up (blue, ↑ watermark, colored glow ring). Selecting a rank above the player's current rank lights every step forward (right arrows) up to the chosen rank (up arrow). Removes the prior per-profile / Kingdom-green divergence, enlarges and bolds the number for legibility over the watermark, and ships full dark-mode parity. The Rank helper text now explains that green ranks are already awarded and that a higher rank may be suggested. CSS + JS; no DB changes.
  - `orkui/template/revised-frontend/style/revised.css`, `script/revised.js`, `Playernew_index.tpl`, `Kingdomnew_index.tpl`, `Parknew_index.tpl`


- **Mobile nav — fixed top bar clipped on Android Chrome.** The global top bar (`#newmenu`) is `position: fixed; width: 100%`, and the root had no horizontal-overflow guard. Any descendant wider than the viewport makes the page scroll sideways, and on Android Chrome a fixed `width:100%` bar then spans the full *scrollable* width — pushing its right-side controls (Login / View Profile / theme toggle) off the right edge. iOS clamps fixed elements to the visual viewport, so it never reproduced there. Added `overflow-x: hidden; max-width: 100%` to `html, body` so the fixed nav stays pinned to the device width on every platform; both `position: sticky` elements in the app stick within their own scroll containers, so they're unaffected. (Symptom fix — the specific overflowing descendant is still to be pinpointed via a mobile emulator.) CSS-only; no DB changes.
  - `orkui/template/default/style/orkui.css`


- **Park Day edit — description silently truncated.** The park-day edit modal (`Parknew_index.tpl`) lets users enter up to 200 characters, but `ork_parkday.description` was `varchar(50)`. With `sql_mode` empty the DB silently truncated anything past 50 chars on save — no error, the save reported success and the page reloaded, so longer-description edits appeared to do nothing. This was the sibling column missed by `2026-03-29-markdown-description-columns.sql` (which widened the description columns on `ork_park` / `ork_unit` / `ork_event_calendardetail`). Widens the column to `varchar(200)` to match the modal's input limit. Already-truncated existing rows can't be recovered; fixes edits going forward.
  - `db-migrations/2026-05-21-widen-parkday-description.sql`


- **Design modal — live heraldry-overlay preview.** The **Heraldry Overlay Strength** buttons (Low / Medium / High / Vignette) in the Design modal previously only set a hidden field — they had no visible effect on the modal's hero preview, and the preview never rendered the player's heraldry, so all four strengths looked identical until the profile was saved and reloaded. The preview now carries the same blurred heraldry layers the production hero uses, driven by a preview-scoped `--pn-preview-overlay-opacity` var (so the real hero's `--pn-overlay-opacity` is untouched). A small `applyOverlayPreview()` helper sets the opacity / toggles vignette compositing, wired into the button clicks, the Reset button, and modal init so the preview opens reflecting the saved strength. Frontend only; `HeroOverlay` already persists, so no DB or controller changes.
  - `orkui/template/revised-frontend/Playernew_index.tpl`
  - Design spec: `docs/superpowers/specs/2026-05-21-heraldry-overlay-preview-design.md`



- **Award recommendation +1 — recommendations cache now keyed by viewer.** `PlayerAwardRecommendations` embeds per-viewer fields in its response (`ViewerCanSecond`, `ViewerCanEditReason`, and each second's `IsMine`), but the GhettoCache key was keyed only on `KingdomId/ParkId/PlayerId` — it omitted `RequestedBy`. So the first officer to load a player's recommendations after a cache bust had **their** eligibility flags cached and served to every viewer for the 300s TTL. Concretely: a recommender of a ladder rung holds an own-rec for that `(player, award, rank)`, so their computed `ViewerCanSecond` is false for every rec on that rung; when that response was cached and served to another officer, the +1 to second a co-recommendation disappeared — the officer could second one of two recs for the same rung but not the other. Adds `RequestedBy` to the cache key so each viewer gets their own correctly-computed flags (writes already flush memcache, so contaminated entries clear on the next second/withdraw or the TTL). Code-only; no DB changes.
  - `system/lib/ork3/class.Report.php`

- **QA hardening pass.** A two-cycle multi-agent QA review of the branch surfaced and fixed a set of issues across the features above: moved the Custom Title alias-options raw SQL out of the `model` layer into `class.Award` (lib layer) to honor the project's DB-in-lib separation; fixed a `pk`→`kn` CSS-prefix mismatch in the Kingdom recommendation rank pills; restored visible dark-mode hover feedback on rank pills (the prior box-shadow was invisible dark-on-dark); replaced hardcoded inline grays in the new "Alias of" dropdown rows with dark-mode-aware CSS variables; hardened the new search-relevance `ORDER BY` interpolation (the codebase's `mysql_real_escape_string` is a no-op polyfill); collapsed dead-branch hint ternaries; and added a defensive null guard plus missing `name` attributes. Code-only; no DB changes.
  - `system/lib/ork3/class.Award.php`, `class.Player.php`, `class.SearchService.php`, `model.Award.php`, `Playernew_index.tpl`, `Kingdomnew_index.tpl`, `Parknew_index.tpl`, `revised-frontend/script/revised.js`, `style/revised.css`
