### PR TITLE
Bugfixes and Unit Updates May 26

### DIFF
--- a/db-migrations/2026-05-26-add-unit-active.sql
+++ b/db-migrations/2026-05-26-add-unit-active.sql
@@ -1,0 +1,7 @@
+-- Soft-delete / retire support for units (companies & households).
+-- Mirrors the convention already used by ork_park and ork_kingdom
+-- (enum('Active','Retired') NOT NULL DEFAULT 'Active'), NOT the tinyint
+-- pattern on ork_mundane. Retired units are hidden from unit lists and
+-- player search; a kingdom officer (monarchy) restores them.
+ALTER TABLE ork_unit
+  ADD COLUMN `active` enum('Active','Retired') NOT NULL DEFAULT 'Active' AFTER `modified`;

--- a/orkui/controller/controller.Admin.php
+++ b/orkui/controller/controller.Admin.php
@@ -2037,7 +2037,7 @@ class Controller_Admin extends Controller {
 		$bywhom_filter = (int)($this->request->ByWhomId ?? 0);
 		$entity_filter = (int)($this->request->EntityId ?? 0);
 		$entity_type_filter = trim($this->request->EntityType ?? '');
-		if (!in_array($entity_type_filter, ['Player', 'Park', 'Kingdom', 'Event'], true)) $entity_type_filter = '';
+		if (!in_array($entity_type_filter, ['Player', 'Park', 'Kingdom', 'Event', 'Unit'], true)) $entity_type_filter = '';
 
 		global $DB;
 		$where = "da.modified_at >= '" . mysql_real_escape_string($start) . " 00:00:00'"
@@ -2045,9 +2045,9 @@ class Controller_Admin extends Controller {
 		if ($method_filter) $where .= " AND da.method_call = '" . mysql_real_escape_string($method_filter) . "'";
 		if ($bywhom_filter) $where .= " AND da.by_whom_id = {$bywhom_filter}";
 		if ($entity_filter) $where .= " AND da.entity_id  = {$entity_filter}";
-		// Without the entity-type constraint, a pasted ID like #5 would match
-		// Player #5, Park #5, Kingdom #5, etc. all at once. Scope it.
-		if ($entity_type_filter) $where .= " AND da.entity = '" . mysql_real_escape_string($entity_type_filter) . "'";
+		// Only apply entity-type constraint when an entity ID is also set — otherwise
+		// the default EntityType=Player in the URL would silently hide Unit/Park/etc. rows.
+		if ($entity_filter && $entity_type_filter) $where .= " AND da.entity = '" . mysql_real_escape_string($entity_type_filter) . "'";
 
 		$DB->Clear();
 		$cr = $DB->DataSet("SELECT COUNT(*) AS cnt FROM ork_danger_audit da WHERE {$where}");

--- a/orkui/controller/controller.Event.php
+++ b/orkui/controller/controller.Event.php
@@ -34,7 +34,8 @@ class Controller_Event extends Controller {
 	public function index($event_id = null) {
 		$this->data['EventDetails'] = $this->Event->get_event_details($event_id);
 		if ($this->data['EventDetails']['Status']['Status'] != 0) {
-			$this->data['Error'] = $this->data['EventDetails']['Status']['Error'];
+			header('Location: ' . UIR . 'Event/list');
+			exit;
 		}
 		if ($this->request->exists('Admin_event')) {
 			$this->data['Admin_event'] = $this->request->Admin_event->Request;
@@ -213,6 +214,10 @@ class Controller_Event extends Controller {
 
 		$eventInfo = $this->Attendance->get_event_info( $event_id );
 		$info      = $eventInfo[0] ?? [];
+		if (empty($info['EventId'])) {
+			header('Location: ' . UIR . 'Event/list');
+			exit;
+		}
 
 		$this->data['EventInfo']  = $info;
 		$this->data['event_id']   = $event_id;

--- a/orkui/controller/controller.Kingdom.php
+++ b/orkui/controller/controller.Kingdom.php
@@ -386,6 +386,10 @@ class Controller_Kingdom extends Controller {
 		$this->data['park_summary']        = $this->Kingdom->get_park_summary($kingdom_id);
 		$this->data['principalities']      = $this->Kingdom->get_principalities($kingdom_id);
 		$this->data['kingdom_info']        = $this->Kingdom->get_kingdom_shortinfo($kingdom_id);
+		if (empty($this->data['kingdom_info']['Info']['KingdomInfo']['KingdomId'])) {
+			header('Location: ' . UIR);
+			exit;
+		}
 		$this->data['kingdom_officers']    = $this->Kingdom->GetOfficers(['KingdomId' => $kingdom_id, 'Token' => $this->session->token]);
 		$this->data['IsPrinz']             = $this->data['kingdom_info']['Info']['KingdomInfo']['IsPrincipality'];
 

--- a/orkui/controller/controller.KingdomAjax.php
+++ b/orkui/controller/controller.KingdomAjax.php
@@ -781,7 +781,9 @@ class Controller_KingdomAjax extends Controller {
 		}
 
 		$kingdom_id = (int)preg_replace('/[^0-9]/', '', $p ?? '');
-		if (!valid_id($kingdom_id)) {
+		$scope_check = trim($_GET['scope'] ?? 'own');
+		// kingdom_id=0 is valid for scope=all (global search with no kingdom context)
+		if (!valid_id($kingdom_id) && $scope_check !== 'all') {
 			echo json_encode([]);
 			exit;
 		}

--- a/orkui/controller/controller.KingdomAjax.php
+++ b/orkui/controller/controller.KingdomAjax.php
@@ -877,6 +877,21 @@ class Controller_KingdomAjax extends Controller {
 		exit;
 	}
 
+	/* Active kingdoms (sorted by name) for the Move Player cascade dropdowns,
+	   shared by the Kingdom/Park/Player/Admin Move Player modals. */
+	public function getkingdoms($p = null) {
+		header('Content-Type: application/json');
+		if (!isset($this->session->user_id)) { echo json_encode([]); exit; }
+		$r = Ork3::$Lib->kingdom->GetKingdoms(array());
+		$kingdoms = [];
+		foreach ($r['Kingdoms'] ?? [] as $k) {
+			$kingdoms[] = ['KingdomId' => (int)$k['KingdomId'], 'KingdomName' => $k['KingdomName'], 'Abbreviation' => $k['Abbreviation']];
+		}
+		usort($kingdoms, function($a, $b) { return strcasecmp($a['KingdomName'] ?? '', $b['KingdomName'] ?? ''); });
+		echo json_encode(['status' => 0, 'kingdoms' => $kingdoms]);
+		exit;
+	}
+
 	public function suspendplayer($p = null) {
 		header('Content-Type: application/json');
 		if (!isset($this->session->user_id)) {

--- a/orkui/controller/controller.Park.php
+++ b/orkui/controller/controller.Park.php
@@ -78,6 +78,10 @@ class Controller_Park extends Controller
 
 		$this->data['park_days']        = $this->Park->get_park_parkdays( $park_id );
 		$this->data['park_info']        = $this->Park->get_park_details( $park_id );
+		if (empty($this->data['park_info']['ParkInfo']['ParkId'])) {
+			header('Location: ' . UIR);
+			exit;
+		}
 		$this->data['park_weather']     = Ork3::$Lib->weather->for_park( $park_id );
 		$this->data['park_officers']    = $this->Park->GetOfficers(['ParkId' => $park_id, 'Token' => $this->session->token]);
 		$this->data['park_tournaments'] = $this->Reports->get_tournaments( null, null, $park_id );

--- a/orkui/controller/controller.Player.php
+++ b/orkui/controller/controller.Player.php
@@ -203,6 +203,10 @@ class Controller_Player extends Controller {
 		$this->data['AwardOptions'] = $this->Award->fetch_award_option_list($this->session->kingdom_id, 'Awards');
 		$this->data['OfficerOptions'] = $this->Award->fetch_award_option_list($this->session->kingdom_id, 'Officers');
 		$this->data['Player'] = $this->Player->fetch_player($id);
+		if (empty($this->data['Player']['MundaneId'])) {
+			header('Location: ' . UIR);
+			exit;
+		}
 		$this->data['Player']['LastSignInDate']   = $this->Player->get_latest_attendance_date($id);
 		$this->data['Player']['PlayerSinceDate']  = $this->Player->get_earliest_attendance_date($id);
 		// Fallback Park Member Since to earliest attendance at the member park
@@ -318,7 +322,7 @@ class Controller_Player extends Controller {
 							header('Location: ' . UIR . "Login/login/Player/profile/$id");
 						} else {
 							$msg = urlencode(!empty($r['Detail']) ? $r['Detail'] : $r['Error']);
-							header('Location: ' . UIR . "Player/profile/{$id}?rec_error={$msg}");
+							header('Location: ' . UIR . "Player/profile/{$id}&rec_error={$msg}");
 						}
 						exit;
 					case 'deleterecommendation':

--- a/orkui/controller/controller.Search.php
+++ b/orkui/controller/controller.Search.php
@@ -50,17 +50,67 @@ class Controller_Search extends Controller {
 		$kingdom_id = valid_id($_GET['KingdomId'] ?? 0) ? (int)$_GET['KingdomId'] : null;
 		$park_id    = valid_id($_GET['ParkId']    ?? 0) ? (int)$_GET['ParkId']    : null;
 		$is_default = strlen($name) === 0;
-		$result = $this->Unit->get_unit_list([
-			'Name'              => $name,
-			'KingdomId'         => $kingdom_id,
-			'ParkId'            => $park_id,
-			'IncludeCompanies'  => 1,
-			'IncludeHouseHolds' => 1,
-			'IncludeEvents'     => 1,
-			'Limit'             => 250,
-			'OrderBy'           => $is_default ? 'active_member_count DESC' : 'u.name',
-		]);
+		// Retired/deactivated units are hidden unless the "Include Inactive/Retired"
+		// toggle is on (sent as &include=1).
+		$include_retired = !empty($_GET['include']) ? 1 : 0;
+		if ($is_default) {
+			// No search term → ready list of the top 100 units by roster size for the
+			// scope. Two-phase + no attendance subqueries → ~180ms, so this can load
+			// on page open without a minimum-character gate. Activity columns are
+			// computed only once the user searches by name (below).
+			$result = $this->Unit->get_unit_list([
+				'KingdomId'         => $kingdom_id,
+				'ParkId'            => $park_id,
+				'IncludeCompanies'  => 1,
+				'IncludeHouseHolds' => 1,
+				'IncludeEvents'     => 1,
+				'IncludeRetired'    => $include_retired,
+				'TopBySize'         => 1,
+				'Limit'             => 100,
+			]);
+		} else {
+			$result = $this->Unit->get_unit_list([
+				'Name'              => $name,
+				'KingdomId'         => $kingdom_id,
+				'ParkId'            => $park_id,
+				'IncludeCompanies'  => 1,
+				'IncludeHouseHolds' => 1,
+				'IncludeEvents'     => 1,
+				'IncludeRetired'    => $include_retired,
+				'Limit'             => 250,
+				'OrderBy'           => 'u.name',
+			]);
+		}
 		echo json_encode($result['Units'] ?? []);
+		exit;
+	}
+
+	// Lazy companion to the default unit list: given the unit_ids it just rendered,
+	// return { unit_id: active_member_count } (members with a sign-in in the last 12
+	// months). Bounded to the shown units (<=250) so it stays ~1s, and the front-end
+	// fires it after the list is already interactive.
+	public function unitactivity() {
+		header('Content-Type: application/json');
+		$ids = array_values(array_unique(array_filter(array_map('intval', explode(',', $_GET['ids'] ?? '')))));
+		if (empty($ids)) { echo json_encode(new stdClass()); exit; }
+		$ids = array_slice($ids, 0, 250);
+		$cache_key = Ork3::$Lib->ghettocache->key($ids);
+		if (($cache = Ork3::$Lib->ghettocache->get(__CLASS__ . '.unitactivity', $cache_key, 300)) !== false) {
+			echo json_encode($cache, JSON_FORCE_OBJECT); exit;
+		}
+		global $DB;
+		$in = implode(',', $ids);
+		$sql = "select um.unit_id, count(distinct um.mundane_id) as active_count
+				from " . DB_PREFIX . "unit_mundane um
+					join " . DB_PREFIX . "attendance a on a.mundane_id = um.mundane_id and a.date >= date_sub(curdate(), interval 1 year)
+				where um.unit_id in ($in)
+				group by um.unit_id";
+		$DB->Clear();
+		$rs = $DB->DataSet($sql);
+		$out = array();
+		while ($rs->Next()) { $out[(int)$rs->unit_id] = (int)$rs->active_count; }
+		Ork3::$Lib->ghettocache->cache(__CLASS__ . '.unitactivity', $cache_key, $out);
+		echo json_encode($out, JSON_FORCE_OBJECT);
 		exit;
 	}
 	

--- a/orkui/controller/controller.Unit.php
+++ b/orkui/controller/controller.Unit.php
@@ -212,6 +212,10 @@ class Controller_Unit extends Controller {
 
 		$this->data['Unit_heraldryurl'] = $this->Unit->get_heraldry($unit_id);
 		$this->data['Unit'] = $this->Unit->get_unit_details($unit_id);
+		if (empty($this->data['Unit']['Details']['Unit']['UnitId'])) {
+			header('Location: ' . UIR . 'Unit/unitlist');
+			exit;
+		}
 		// Parse scope (kingdom/park) from the unit list session ref for player search scoping
 		$_ref = $this->session->unit_list_ref ?? '';
 		$_scope_kingdom_id = null;
@@ -261,7 +265,9 @@ class Controller_Unit extends Controller {
 			$_pinfo        = Ork3::$Lib->player->player_info($this->session->token);
 			$_home_kingdom = isset($_pinfo['KingdomId']) ? (int)$_pinfo['KingdomId'] : 0;
 			if ($_home_kingdom > 0) {
-				$_can_officer = Ork3::$Lib->authorization->HasAuthority($_uid, AUTH_KINGDOM, $_home_kingdom, AUTH_EDIT);
+				$_home_park    = isset($_pinfo['ParkId']) ? (int)$_pinfo['ParkId'] : 0;
+			$_can_officer = Ork3::$Lib->authorization->HasAuthority($_uid, AUTH_KINGDOM, $_home_kingdom, AUTH_EDIT)
+				|| ($_home_park > 0 && Ork3::$Lib->authorization->HasAuthority($_uid, AUTH_PARK, $_home_park, AUTH_EDIT));
 			}
 		}
 		$this->data['CanOfficerManage'] = $_can_officer;

--- a/orkui/controller/controller.Unit.php
+++ b/orkui/controller/controller.Unit.php
@@ -174,6 +174,31 @@ class Controller_Unit extends Controller {
 						$r = $this->Unit->convert_to_company($unit_id_int);
 					}
 					break;
+				case 'retire_unit':
+					$r = $this->Unit->retire_unit(array(
+						'Token'  => $this->session->token,
+						'UnitId' => $unit_id_int,
+					));
+					break;
+				case 'restore_unit':
+					$r = $this->Unit->restore_unit(array(
+						'Token'  => $this->session->token,
+						'UnitId' => $unit_id_int,
+					));
+					break;
+				case 'claim_unit':
+					$r = $this->Unit->claim_unit(array(
+						'Token'  => $this->session->token,
+						'UnitId' => $unit_id_int,
+					));
+					break;
+				case 'transfer_ownership':
+					$r = $this->Unit->transfer_ownership(array(
+						'Token'     => $this->session->token,
+						'UnitId'    => $unit_id_int,
+						'MundaneId' => (int)$this->request->MundaneId,
+					));
+					break;
 			}
 			if (isset($r)) {
 				if ($r['Status'] == 0) {
@@ -198,6 +223,92 @@ class Controller_Unit extends Controller {
 		$_uid = isset($this->session->user_id) ? (int)$this->session->user_id : 0;
 		$_canEdit = $_uid > 0 && Ork3::$Lib->authorization->HasAuthority($_uid, AUTH_UNIT, (int)$unit_id, AUTH_EDIT);
 		$this->data['CanEdit'] = $_canEdit;
+
+		// ── Retire / Claim / Transfer state ───────────────────────────────
+		// Whether this unit is currently active (vs. retired/soft-deleted).
+		$_unit_active = (($this->data['Unit']['Details']['Unit']['Active'] ?? 'Active') !== 'Retired');
+		$this->data['UnitActive'] = $_unit_active;
+
+		// Manager set = authorization rows scoped to this unit.
+		$_auth_rows   = $this->data['Unit']['Authorizations']['Authorizations'] ?? array();
+		$_manager_ids = array();
+		foreach ($_auth_rows as $_ar) { $_manager_ids[] = (int)$_ar['MundaneId']; }
+		$_manager_ids = array_values(array_unique($_manager_ids));
+		$this->data['ManagerCount'] = count($_manager_ids);
+
+		// Current user's place in the active roster.
+		$_roster   = $this->data['Unit']['Members']['Roster'] ?? array();
+		$_my_role  = null;
+		$_is_member = false;
+		foreach ($_roster as $_rm) {
+			if ($_uid > 0 && (int)$_rm['MundaneId'] === $_uid) {
+				$_is_member = true;
+				$_my_role   = strtolower($_rm['UnitRole'] ?? '');
+			}
+		}
+		$this->data['IsRosterMember'] = $_is_member;
+		$this->data['IsManager']      = $_uid > 0 && in_array($_uid, $_manager_ids, true);
+		$this->data['IsSoleMember']   = $_uid > 0 && count($_roster) === 1 && $_is_member;
+		// Self-claim: no managers exist and the user holds a leadership roster role.
+		$this->data['CanClaim']       = $_uid > 0 && count($_manager_ids) === 0
+			&& in_array($_my_role, array('captain', 'lord', 'organizer'), true);
+
+		// Kingdom-officer (monarchy) authority, evaluated against the user's OWN
+		// home kingdom — matching the KPM bypass in Authorization::add_authorization
+		// so the UI only offers what the service layer will actually permit.
+		$_can_officer = false;
+		if ($_uid > 0) {
+			$_pinfo        = Ork3::$Lib->player->player_info($this->session->token);
+			$_home_kingdom = isset($_pinfo['KingdomId']) ? (int)$_pinfo['KingdomId'] : 0;
+			if ($_home_kingdom > 0) {
+				$_can_officer = Ork3::$Lib->authorization->HasAuthority($_uid, AUTH_KINGDOM, $_home_kingdom, AUTH_EDIT);
+			}
+		}
+		$this->data['CanOfficerManage'] = $_can_officer;
+
+		// The Add-Manager modal is available to unit editors, and to officers only
+		// when the unit is currently unmanaged (their entry point to assign one).
+		$_show_addmgr = $_canEdit || ($_can_officer && count($_manager_ids) === 0);
+		$this->data['ShowAddManager'] = $_show_addmgr;
+
+		// Transfer targets: active members other than the actor, managers first.
+		$_targets = array();
+		foreach ($_roster as $_rm) {
+			$_mid = (int)$_rm['MundaneId'];
+			if ($_mid === $_uid) continue;
+			$_targets[] = array(
+				'MundaneId' => $_mid,
+				'Persona'   => trimlen($_rm['Persona']) > 0 ? $_rm['Persona'] : '(No Persona)',
+				'IsManager' => in_array($_mid, $_manager_ids, true),
+			);
+		}
+		usort($_targets, function($a, $b) {
+			if ($a['IsManager'] !== $b['IsManager']) return $a['IsManager'] ? -1 : 1;
+			return strcasecmp($a['Persona'], $b['Persona']);
+		});
+		$this->data['TransferTargets'] = $_targets;
+
+		// Active, non-manager members — the head-of-list shortcut in Add Manager.
+		$_nonmgr = array();
+		foreach ($_roster as $_rm) {
+			$_mid = (int)$_rm['MundaneId'];
+			if (in_array($_mid, $_manager_ids, true)) continue;
+			$_nonmgr[] = array(
+				'MundaneId' => $_mid,
+				'Persona'   => trimlen($_rm['Persona']) > 0 ? $_rm['Persona'] : '(No Persona)',
+			);
+		}
+		$this->data['NonManagerMembers'] = $_nonmgr;
+
+		// Active kingdoms for the "filter players by" cascade in the add-member/
+		// manager search. Sorted by name for the dropdown.
+		$this->data['FilterKingdoms'] = array();
+		if ($_show_addmgr) {
+			$_kd = Ork3::$Lib->kingdom->GetKingdoms(array());
+			$_kingdoms = array_values($_kd['Kingdoms'] ?? array());
+			usort($_kingdoms, function($a, $b) { return strcasecmp($a['KingdomName'] ?? '', $b['KingdomName'] ?? ''); });
+			$this->data['FilterKingdoms'] = $_kingdoms;
+		}
 		if ($_canEdit) {
 			$this->data['menu']['admin'] = array( 'url' => UIR."Admin/unit/$unit_id", 'display' => 'Admin Panel <i class="fas fa-cog"></i>', 'no-crumb' => 'no-crumb' );
 		}

--- a/orkui/controller/controller.Unit.php
+++ b/orkui/controller/controller.Unit.php
@@ -216,14 +216,6 @@ class Controller_Unit extends Controller {
 			header('Location: ' . UIR . 'Unit/unitlist');
 			exit;
 		}
-		// Parse scope (kingdom/park) from the unit list session ref for player search scoping
-		$_ref = $this->session->unit_list_ref ?? '';
-		$_scope_kingdom_id = null;
-		$_scope_park_id    = null;
-		if (preg_match('/KingdomId=(\d+)/', $_ref, $_m)) $_scope_kingdom_id = (int)$_m[1];
-		if (preg_match('/ParkId=(\d+)/',    $_ref, $_m)) $_scope_park_id    = (int)$_m[1];
-		$this->data['ScopeKingdomId'] = $_scope_kingdom_id;
-		$this->data['ScopeParkId']    = $_scope_park_id;
 		$_uid = isset($this->session->user_id) ? (int)$this->session->user_id : 0;
 		$_canEdit = $_uid > 0 && Ork3::$Lib->authorization->HasAuthority($_uid, AUTH_UNIT, (int)$unit_id, AUTH_EDIT);
 		$this->data['CanEdit'] = $_canEdit;
@@ -261,15 +253,21 @@ class Controller_Unit extends Controller {
 		// home kingdom — matching the KPM bypass in Authorization::add_authorization
 		// so the UI only offers what the service layer will actually permit.
 		$_can_officer = false;
+		$_scope_kingdom_id = null;
+		$_scope_park_id    = null;
 		if ($_uid > 0) {
 			$_pinfo        = Ork3::$Lib->player->player_info($this->session->token);
 			$_home_kingdom = isset($_pinfo['KingdomId']) ? (int)$_pinfo['KingdomId'] : 0;
+			$_home_park    = isset($_pinfo['ParkId'])    ? (int)$_pinfo['ParkId']    : 0;
 			if ($_home_kingdom > 0) {
-				$_home_park    = isset($_pinfo['ParkId']) ? (int)$_pinfo['ParkId'] : 0;
-			$_can_officer = Ork3::$Lib->authorization->HasAuthority($_uid, AUTH_KINGDOM, $_home_kingdom, AUTH_EDIT)
-				|| ($_home_park > 0 && Ork3::$Lib->authorization->HasAuthority($_uid, AUTH_PARK, $_home_park, AUTH_EDIT));
+				$_scope_kingdom_id = $_home_kingdom;
+				$_scope_park_id    = $_home_park > 0 ? $_home_park : null;
+				$_can_officer = Ork3::$Lib->authorization->HasAuthority($_uid, AUTH_KINGDOM, $_home_kingdom, AUTH_EDIT)
+					|| ($_home_park > 0 && Ork3::$Lib->authorization->HasAuthority($_uid, AUTH_PARK, $_home_park, AUTH_EDIT));
 			}
 		}
+		$this->data['ScopeKingdomId']   = $_scope_kingdom_id;
+		$this->data['ScopeParkId']      = $_scope_park_id;
 		$this->data['CanOfficerManage'] = $_can_officer;
 
 		// The Add-Manager modal is available to unit editors, and to officers only

--- a/orkui/model/model.Unit.php
+++ b/orkui/model/model.Unit.php
@@ -74,6 +74,22 @@ class Model_Unit extends Model {
 		logtrace("del_unit_auth()", $request);
 		return $this->Authorization->RemoveAuthorization($request);
 	}
+
+	function retire_unit($request) {
+		return $this->Unit->RetireUnit($request);
+	}
+
+	function restore_unit($request) {
+		return $this->Unit->RestoreUnit($request);
+	}
+
+	function claim_unit($request) {
+		return $this->Unit->ClaimUnit($request);
+	}
+
+	function transfer_ownership($request) {
+		return $this->Unit->TransferOwnership($request);
+	}
 	
 	function get_unit_list($request) {
 		return $this->Report->UnitSummary($request);

--- a/orkui/template/default/Admin_auditlog.tpl
+++ b/orkui/template/default/Admin_auditlog.tpl
@@ -41,6 +41,10 @@ $_actionLabels = [
 	'Kingdom::VacateOfficer'           => 'Officer Vacated',
 	'Authorization::AddAuthorization'  => 'Permission Granted',
 	'Authorization::RemoveAuthorization'=> 'Permission Revoked',
+	'Unit::RetireUnit'                 => 'Unit Retired',
+	'Unit::RestoreUnit'                => 'Unit Restored',
+	'Unit::ClaimUnit'                  => 'Unit Claimed',
+	'Unit::TransferOwnership'          => 'Unit Ownership Transferred',
 ];
 
 // ── JSON helpers (defined early — used in batch collector and render functions) ──
@@ -70,10 +74,10 @@ $_parkIds = []; $_kingdomIds = []; $_mundaneIds = []; $_eventIds = []; $_kawardI
 foreach ($AuditRows as $_lr) {
 	foreach ([$_lr['Parameters'], $_lr['PriorState'], $_lr['PostState']] as $_js) {
 		$_d = @json_decode($_js, true);
-		if (!is_array($_d)) $_d = _jsonExtract($_js ?? '', ['ParkId','park_id','KingdomId','kingdom_id','MundaneId','mundane_id','given_by_id','stripped_from','RecipientId','FromMundaneId','ToMundaneId','event_id','at_park_id','at_kingdom_id','at_event_id','kingdomaward_id','KingdomAwardId','old_kingdom_id','new_kingdom_id','from_park_id','to_park_id','from_kingdom_id','to_kingdom_id']);
+		if (!is_array($_d)) $_d = _jsonExtract($_js ?? '', ['ParkId','park_id','KingdomId','kingdom_id','MundaneId','mundane_id','given_by_id','stripped_from','RecipientId','FromMundaneId','ToMundaneId','event_id','at_park_id','at_kingdom_id','at_event_id','kingdomaward_id','KingdomAwardId','old_kingdom_id','new_kingdom_id','from_park_id','to_park_id','from_kingdom_id','to_kingdom_id','from_mundane_id','to_mundane_id']);
 		foreach (['park_id','at_park_id','ParkId','from_park_id','to_park_id'] as $_k) if (!empty($_d[$_k])) $_parkIds[(int)$_d[$_k]] = true;
 		foreach (['kingdom_id','at_kingdom_id','KingdomId','old_kingdom_id','new_kingdom_id','from_kingdom_id','to_kingdom_id'] as $_k) if (!empty($_d[$_k])) $_kingdomIds[(int)$_d[$_k]] = true;
-		foreach (['mundane_id','given_by_id','given_by','stripped_from','MundaneId','RecipientId','FromMundaneId','ToMundaneId','SuspendedById','recommended_by_id','SupporterMundaneId','supporter_mundane_id'] as $_k) if (!empty($_d[$_k]) && is_numeric($_d[$_k])) $_mundaneIds[(int)$_d[$_k]] = true;
+		foreach (['mundane_id','given_by_id','given_by','stripped_from','MundaneId','RecipientId','FromMundaneId','ToMundaneId','SuspendedById','recommended_by_id','SupporterMundaneId','supporter_mundane_id','from_mundane_id','to_mundane_id'] as $_k) if (!empty($_d[$_k]) && is_numeric($_d[$_k])) $_mundaneIds[(int)$_d[$_k]] = true;
 	// Route entity_id into the correct lookup map based on the audit row's
 	// `entity` column. Defaults to mundane when entity is unset (older rows).
 	if (!empty($_lr['EntityId'])) {
@@ -82,6 +86,7 @@ foreach ($AuditRows as $_lr) {
 			case 'Park':    $_parkIds[$_e]    = true; break;
 			case 'Kingdom': $_kingdomIds[$_e] = true; break;
 			case 'Event':   $_eventIds[$_e]   = true; break;
+			case 'Unit':    $_unitIds[$_e]    = true; break;
 			default:        $_mundaneIds[$_e] = true; break;
 		}
 	}
@@ -157,6 +162,10 @@ if ($_entityInt > 0) {
 	} elseif ($_entityType === 'Event') {
 		$DB->Clear();
 		$_r = $DB->DataSet("SELECT name FROM ork_event WHERE event_id = {$_entityInt}");
+		if ($_r && $_r->Next()) $_entityFilterName = $_r->name;
+	} elseif ($_entityType === 'Unit') {
+		$DB->Clear();
+		$_r = $DB->DataSet("SELECT name FROM ork_unit WHERE unit_id = {$_entityInt}");
 		if ($_r && $_r->Next()) $_entityFilterName = $_r->name;
 	} elseif ($_entityType === '' || $_entityType === 'Player') {
 		$_entityFilterName = $_filterPlayerNames[$_entityInt] ?? '';
@@ -449,6 +458,28 @@ function _auditSummary($method, $params, $prior, $post, $kawardMap = [], $parkMa
 			$_park = $_pid ? ($parkMap[$_pid] ?? 'park #' . $_pid) : 'park';
 			$_verb = $method === 'Park::RetirePark' ? 'Retired' : 'Restored';
 			return $_verb . ' ' . htmlspecialchars($_park);
+		case 'Unit::RetireUnit':
+		case 'Unit::RestoreUnit':
+			$_uid = (int)($p['UnitId'] ?? $a['unit_id'] ?? 0);
+			$_unit = $_uid ? ($unitMap[$_uid] ?? 'unit #' . $_uid) : 'unit';
+			$_verb = $method === 'Unit::RetireUnit' ? 'Retired' : 'Restored';
+			return $_verb . ' ' . htmlspecialchars($_unit);
+		case 'Unit::ClaimUnit':
+			$_uid  = (int)($p['UnitId'] ?? $a['unit_id'] ?? 0);
+			$_mid  = (int)($p['MundaneId'] ?? $a['mundane_id'] ?? 0);
+			$_unit = $_uid ? ($unitMap[$_uid] ?? 'unit #' . $_uid) : 'unit';
+			$_who  = $_mid ? ($mundaneMap[$_mid] ?? 'player #' . $_mid) : '';
+			return 'Claimed ' . htmlspecialchars($_unit) . ($_who ? ' by ' . htmlspecialchars($_who) : '');
+		case 'Unit::TransferOwnership':
+			$_uid  = (int)($p['UnitId'] ?? $a['unit_id'] ?? 0);
+			$_from = (int)($p['FromMundaneId'] ?? $a['from_mundane_id'] ?? 0);
+			$_to   = (int)($p['TargetMundaneId'] ?? $a['to_mundane_id'] ?? 0);
+			$_unit = $_uid ? ($unitMap[$_uid] ?? 'unit #' . $_uid) : 'unit';
+			$_fwho = $_from ? ($mundaneMap[$_from] ?? 'player #' . $_from) : '';
+			$_twho = $_to   ? ($mundaneMap[$_to]   ?? 'player #' . $_to)   : '';
+			return 'Transferred ' . htmlspecialchars($_unit)
+				. ($_fwho ? ' from ' . htmlspecialchars($_fwho) : '')
+				. ($_twho ? ' to '   . htmlspecialchars($_twho) : '');
 		default:
 			return '';
 	}
@@ -1193,6 +1224,44 @@ function _auditDetail($method, $params, $prior, $post, $parkMap, $kingdomMap, $m
 			$html .= '</tbody></table>';
 			return $html;
 
+		case 'Unit::RetireUnit':
+		case 'Unit::RestoreUnit':
+			$_uid     = (int)($p['UnitId'] ?? $a['unit_id'] ?? 0);
+			$_oldAct  = $b['active'] ?? null;
+			$_newAct  = $a['active'] ?? ($method === 'Unit::RetireUnit' ? 'Retired' : 'Active');
+			$html = '<table class="al-diff-table"><tbody>';
+			if ($_uid) $html .= '<tr><td class="al-diff-field">Unit</td><td colspan="2"><a href="' . UIR . 'Unit/index/' . $_uid . '" style="color:var(--rp-accent)">' . htmlspecialchars($unitMap[$_uid] ?? ('unit #' . $_uid)) . '</a></td></tr>';
+			$html .= '<tr><td class="al-diff-field">Action</td><td colspan="2">' . ($method === 'Unit::RetireUnit' ? 'Retired' : 'Restored') . '</td></tr>';
+			if ($_oldAct !== null || $_newAct !== null) {
+				$html .= '<tr class="al-diff-changed">'
+				       . '<td class="al-diff-field">Status</td>'
+				       . '<td class="al-diff-old">' . htmlspecialchars($_oldAct ?? '—') . '</td>'
+				       . '<td class="al-diff-new">' . htmlspecialchars($_newAct ?? '—') . '</td>'
+				       . '</tr>';
+			}
+			$html .= '</tbody></table>';
+			return $html;
+
+		case 'Unit::ClaimUnit':
+			$_uid  = (int)($p['UnitId'] ?? $a['unit_id'] ?? 0);
+			$_mid  = (int)($p['MundaneId'] ?? $a['mundane_id'] ?? 0);
+			$html  = '<table class="al-diff-table"><tbody>';
+			if ($_uid) $html .= '<tr><td class="al-diff-field">Unit</td><td colspan="2"><a href="' . UIR . 'Unit/index/' . $_uid . '" style="color:var(--rp-accent)">' . htmlspecialchars($unitMap[$_uid] ?? ('unit #' . $_uid)) . '</a></td></tr>';
+			if ($_mid) $html .= '<tr><td class="al-diff-field">Claimed By</td><td colspan="2">' . _auditIdLink('player', $_mid, $mundaneMap) . '</td></tr>';
+			$html  .= '</tbody></table>';
+			return $html;
+
+		case 'Unit::TransferOwnership':
+			$_uid  = (int)($p['UnitId'] ?? $a['unit_id'] ?? 0);
+			$_from = (int)($p['FromMundaneId'] ?? $a['from_mundane_id'] ?? 0);
+			$_to   = (int)($p['TargetMundaneId'] ?? $a['to_mundane_id'] ?? 0);
+			$html  = '<table class="al-diff-table"><tbody>';
+			if ($_uid)  $html .= '<tr><td class="al-diff-field">Unit</td><td colspan="2"><a href="' . UIR . 'Unit/index/' . $_uid . '" style="color:var(--rp-accent)">' . htmlspecialchars($unitMap[$_uid] ?? ('unit #' . $_uid)) . '</a></td></tr>';
+			if ($_from) $html .= '<tr><td class="al-diff-field">Previous Manager</td><td colspan="2">' . _auditIdLink('player', $_from, $mundaneMap) . '</td></tr>';
+			if ($_to)   $html .= '<tr><td class="al-diff-field">New Manager</td><td colspan="2">'      . _auditIdLink('player', $_to,   $mundaneMap) . '</td></tr>';
+			$html  .= '</tbody></table>';
+			return $html;
+
 		default:
 			$out = [];
 			if ($prior && $prior !== 'null') $out[] = '<strong>Prior state:</strong><pre class="al-raw-json">' . htmlspecialchars($prior) . '</pre>';
@@ -1398,6 +1467,7 @@ html[data-theme="dark"] .al-table         { color:#e2e8f0; }
 							<option value="Player"  <?=$_etf==='Player'  ? 'selected' : ''?>>Player</option>
 							<option value="Park"    <?=$_etf==='Park'    ? 'selected' : ''?>>Park</option>
 							<option value="Kingdom" <?=$_etf==='Kingdom' ? 'selected' : ''?>>Kingdom</option>
+							<option value="Unit"    <?=$_etf==='Unit'    ? 'selected' : ''?>>Unit</option>
 						</select>
 						<input class="al-form-input al-player-text" id="alEntityText" type="text" autocomplete="off"
 						       placeholder="Search name or paste ID…"
@@ -1480,6 +1550,7 @@ html[data-theme="dark"] .al-table         { color:#e2e8f0; }
 								case 'Park':    $_eMap = $_parkMap;    $_eUrl = UIR . 'Park/profile/';    break;
 								case 'Kingdom': $_eMap = $_kingdomMap; $_eUrl = UIR . 'Kingdom/profile/'; break;
 								case 'Event':   $_eMap = $_eventMap;   $_eUrl = UIR . 'Event/view/';      break;
+								case 'Unit':    $_eMap = $_unitMap;    $_eUrl = UIR . 'Unit/index/';       break;
 								default:        $_eMap = $_mundaneMap; $_eUrl = UIR . 'Player/profile/';  break;
 							}
 							if ($_displayEntityId > 0):
@@ -1605,6 +1676,17 @@ var AL_SCOPES = {
 					}
 					var label = v.Name + (when ? ' (' + when + ')' : '') + (ctx ? ' — ' + ctx : '');
 					return { label: label, value: v.EventId, display: v.Name + (when ? ' (' + when + ')' : '') };
+				}));
+			});
+		}
+	},
+	Unit: {
+		source: function(term, cb) {
+			$.getJSON('../orkservice/Search/SearchService.php', {
+				Action: 'Search/Unit', name: term, limit: 8
+			}, function(data) {
+				cb($.map(data || [], function(v) {
+					return { label: v.Name, value: v.UnitId, display: v.Name };
 				}));
 			});
 		}

--- a/orkui/template/default/Search_unit.tpl
+++ b/orkui/template/default/Search_unit.tpl
@@ -50,6 +50,19 @@ if ($_su_park_id)    $_su_ajax_params .= '&ParkId='    . $_su_park_id;
 .su-search-btn:hover { background: #2f855a; }
 .su-loading { text-align: center; padding: 32px; color: var(--rp-text-muted); font-size: 14px; }
 
+/* Retired (Inactive) Units section */
+.su-retired-header { font-size: 15px; font-weight: 700; color: var(--rp-text, #2d3748); display: flex; align-items: center; gap: 8px; margin: 0 0 4px; }
+.su-retired-header i { color: #c05621; }
+.su-retired-count { font-size: 13px; font-weight: 600; color: var(--rp-text-muted, #718096); }
+.su-retired-note { font-size: 12px; color: var(--rp-text-muted, #718096); margin: 0 0 12px; max-width: 70ch; }
+.su-retired-badge { display: inline-block; padding: 2px 8px; border-radius: 10px; font-size: 10px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.04em; margin-left: 6px; vertical-align: middle; background: #feebc8; color: #9c4221; }
+.su-thumb-retired { opacity: 0.55; filter: grayscale(0.5); }
+#su-retired-table { width: 100%; border-collapse: collapse; }
+#su-retired-table th, #su-retired-table td { padding: 8px 10px; border-bottom: 1px solid var(--rp-border); font-size: 13px; text-align: left; vertical-align: middle; }
+#su-retired-table th { font-size: 11px; text-transform: uppercase; letter-spacing: 0.04em; color: var(--rp-text-muted, #718096); }
+#su-retired-table td:first-child, #su-retired-table th:first-child { width: 50px; padding-right: 4px; }
+html[data-theme="dark"] .su-retired-badge { background: rgba(192,86,33,0.25); color: #f6ad55; }
+
 /* Mobile */
 .rp-table-area { overflow-x: auto; -webkit-overflow-scrolling: touch; }
 @media (max-width: 600px) {
@@ -207,6 +220,16 @@ html[data-theme="dark"] .uc-modal div[style*="background:#ebf8ff"] { background:
 			<tbody></tbody>
 		</table>
 
+		<!-- Retired (Inactive) Units — separate section -->
+		<div id="su-retired-section" style="display:none;margin-top:28px;">
+			<div class="su-retired-header"><i class="fas fa-box-archive"></i> Retired (Inactive) Units <span class="su-retired-count" id="su-retired-count"></span></div>
+			<p class="su-retired-note">These companies &amp; households have been retired and are hidden from the main results. A member of monarchy can reactivate one from its profile.</p>
+			<table id="su-retired-table">
+				<thead><tr><th></th><th>Name</th><th>Total</th><th class="su-col-leaders">Leaders</th><th class="su-col-web" style="text-align:center">Web</th></tr></thead>
+				<tbody></tbody>
+			</table>
+		</div>
+
 	</div>
 </div>
 
@@ -260,6 +283,26 @@ html[data-theme="dark"] .uc-modal div[style*="background:#ebf8ff"] { background:
 		});
 	}
 
+	function retiredRow(u) {
+		var thumb = HERALDRY_BASE + (u.HasHeraldry ? (String(u.UnitId).padStart(5, '0') + '.jpg') : '00000.jpg');
+		var img = '<img class="su-thumb su-thumb-retired" src="' + thumb + '" onerror="this.onerror=null;this.src=\'' + HERALDRY_BASE + '00000.jpg\'" alt="">';
+		var name = '<a class="su-name-link" href="' + UIR_VAL + 'Unit/index/' + u.UnitId + '">' + $('<span>').text(u.Name).html() + '</a>'
+			+ '<span class="su-type-badge ' + badgeClass(u.Type) + '">' + (u.Type || '') + '</span>'
+			+ '<span class="su-retired-badge">Retired</span>';
+		return '<tr><td>' + img + '</td><td>' + name + '</td><td>' + (u.TotalMemberCount || 0) + '</td>'
+			+ '<td class="su-col-leaders">' + $('<span>').text(u.LeaderNames || '').html() + '</td>'
+			+ '<td class="su-col-web" style="text-align:center">' + webCell(u.Url || '') + '</td></tr>';
+	}
+
+	function renderRetired(units) {
+		var $sec = $('#su-retired-section');
+		if (!units.length) { $sec.hide(); $('#su-retired-table tbody').empty(); return; }
+		units.sort(function (a, b) { return (a.Name || '').localeCompare(b.Name || ''); });
+		$('#su-retired-table tbody').html(units.map(retiredRow).join(''));
+		$('#su-retired-count').text('(' + units.length + ')');
+		$sec.show();
+	}
+
 	function updateStats(units) {
 		var oneYear = oneYearAgo.toISOString().slice(0, 10);
 		var active = 0, companies = 0, households = 0;
@@ -281,17 +324,25 @@ html[data-theme="dark"] .uc-modal div[style*="background:#ebf8ff"] { background:
 	function loadData(q) {
 		$('#su-loading').html('<i class="fas fa-spinner fa-spin" style="font-size:22px;display:block;margin-bottom:8px;opacity:0.4;"></i>Loading units…').show();
 		$('#su-table').hide();
+		$('#su-retired-section').hide();
 		var url = AJAX_BASE + '&q=' + encodeURIComponent(q || '') + AJAX_PARAMS;
 		$.getJSON(url, function (units) {
 			$('#su-loading').hide();
-			if (!units || !units.length) {
+			units = units || [];
+			// Retired units render in their own section; the main table shows the rest.
+			var retired = units.filter(function (u) { return u.Active === 'Retired'; });
+			var live    = units.filter(function (u) { return u.Active !== 'Retired'; });
+			renderRetired(retired);
+			if (!live.length) {
 				$('#su-table').hide();
-				$('#su-loading').text('No units found.').show();
 				updateStats([]);
+				if (!retired.length) {
+					$('#su-loading').text('No units found.').show();
+				}
 				return;
 			}
-			updateStats(units);
-			var rows = buildRows(units);
+			updateStats(live);
+			var rows = buildRows(live);
 			if (table) {
 				table.clear().rows.add(rows).draw();
 			} else {
@@ -358,6 +409,7 @@ html[data-theme="dark"] .uc-modal div[style*="background:#ebf8ff"] { background:
 		if (table) { table.destroy(); table = null; }
 		$('#su-table').hide();
 		$('#su-stats-row').hide();
+		$('#su-retired-section').hide();
 		$('#su-loading').html('<i class="fas fa-search" style="font-size:22px;display:block;margin-bottom:8px;opacity:0.3;"></i>Type a name to search companies &amp; households.').show();
 		$('#su-search-input').val('');
 		$('#su-search-clear').hide();

--- a/orkui/template/default/Unit_index.tpl
+++ b/orkui/template/default/Unit_index.tpl
@@ -27,9 +27,33 @@ foreach ($_members as $_m) {
 $_can_edit   = !empty($CanEdit);
 $_err        = $SaveError ?? '';
 $_base_url   = UIR . "Unit/index/$_unit_id";
+// Pre-built <option> list for the "filter players by" kingdom dropdown
+// (shared by the add-member and add-manager search modals).
+$_kingdom_options = '<option value="">All Kingdoms</option>';
+foreach (($FilterKingdoms ?? array()) as $_fk) {
+	$_kingdom_options .= '<option value="' . (int)$_fk['KingdomId'] . '">' . htmlspecialchars($_fk['KingdomName']) . '</option>';
+}
 
 $_type_icon  = $_type === 'Company' ? 'fa-shield-alt' : ($_type === 'Household' ? 'fa-home' : 'fa-users');
 $_hero_color = $_type === 'Company' ? '#1a3654' : ($_type === 'Household' ? '#2d1b54' : '#1a365d');
+
+/* ── Retire / Claim / Transfer state (computed in controller) ── */
+$_type_l        = strtolower($_type);
+$_logged_in     = !empty($LoggedIn);
+$_can_officer   = !empty($CanOfficerManage);
+$_mgr_count     = (int)($ManagerCount ?? 0);
+$_is_manager    = !empty($IsManager);
+$_is_sole       = !empty($IsSoleMember);
+$_can_claim     = !empty($CanClaim);
+$_is_retired    = empty($UnitActive);
+$_show_addmgr   = !empty($ShowAddManager);
+$_transfer_targets = $TransferTargets ?? [];
+$_can_transfer  = count($_transfer_targets) > 0;
+$_nonmgr_members   = $NonManagerMembers ?? [];
+// Retire card: managers/officers always, plus the sole-member exception.
+$_show_retire   = !$_is_retired && ($_can_edit || $_can_officer || $_is_sole);
+// Claim/unmanaged card: any logged-in viewer when the unit has no managers.
+$_show_claim    = !$_is_retired && $_logged_in && $_mgr_count === 0;
 ?>
 <link rel="stylesheet" href="<?=HTTP_TEMPLATE?>revised-frontend/style/revised.css?v=<?=filemtime(DIR_TEMPLATE.'revised-frontend/style/revised.css')?>">
 <link rel="stylesheet" href="https://cdn.datatables.net/1.13.8/css/jquery.dataTables.min.css">
@@ -243,6 +267,9 @@ html:not([data-theme="light"]):not([data-theme="dark"]) .un-hero-name {
 	color: var(--ork-text-lighter);
 	margin-top: 3px;
 }
+/* "Filter players by" cascade (kingdom → park) in the add-member/manager modals */
+.un-filter-field select { width: 100%; }
+.un-filter-park { margin-top: 6px; }
 
 /* ── Player search autocomplete (shared across modals) ───── */
 
@@ -389,6 +416,23 @@ html:not([data-theme="light"]):not([data-theme="dark"]) .un-hero-name {
 	<!-- Sidebar -->
 	<aside class="pn-sidebar">
 
+<?php if ($_is_retired): ?>
+		<div class="pn-card un-retired-card">
+			<h4 style="display:flex;align-items:center;justify-content:space-between;"><span><i class="fas fa-box-archive"></i> Retired</span></h4>
+			<p class="un-card-text">This <?=htmlspecialchars($_type_l)?> has been retired and is hidden from listings and search.</p>
+<?php if ($_can_officer): ?>
+			<form method="post" action="<?=htmlspecialchars($_base_url)?>">
+				<input type="hidden" name="Action" value="restore_unit">
+				<button type="submit" class="pn-btn pn-btn-primary" style="width:100%;">
+					<i class="fas fa-rotate-left"></i> Reactivate This <?=htmlspecialchars($_type)?>
+				</button>
+			</form>
+<?php else: ?>
+			<p class="un-card-text" style="font-style:italic;">A member of monarchy for your park or kingdom can reactivate it.</p>
+<?php endif; ?>
+		</div>
+<?php endif; ?>
+
 <?php if (trimlen($_desc) > 0 || $_can_edit): ?>
 		<div class="pn-card">
 			<h4 style="display:flex;align-items:center;justify-content:space-between;">
@@ -463,6 +507,47 @@ if ($_can_edit && (count($_auths) > 0 || true)):
 		</div>
 <?php endif; ?>
 
+
+<!-- ── Claim / Add-Manager Card (unmanaged units) ───────── -->
+<?php if ($_show_claim): ?>
+		<div class="pn-card un-claim-card">
+<?php if ($_can_claim): ?>
+			<h4 style="display:flex;align-items:center;justify-content:space-between;"><span><i class="fas fa-hand-sparkles"></i> Claim This <?=htmlspecialchars($_type)?></span></h4>
+			<p class="un-card-text">This <?=htmlspecialchars($_type_l)?> has no manager. As a leader of <?=htmlspecialchars($_name)?>, you can take over managing it.</p>
+			<form method="post" action="<?=htmlspecialchars($_base_url)?>">
+				<input type="hidden" name="Action" value="claim_unit">
+				<button type="submit" class="pn-btn pn-btn-primary" style="width:100%;">
+					<i class="fas fa-user-shield"></i> Claim <?=htmlspecialchars($_name)?>
+				</button>
+			</form>
+<?php else: ?>
+			<h4 style="display:flex;align-items:center;justify-content:space-between;"><span><i class="fas fa-user-slash"></i> Unmanaged <?=htmlspecialchars($_type)?></span></h4>
+<?php if (!$_can_officer): ?>
+			<p class="un-card-text">It looks like no players currently have permission to manage this <?=htmlspecialchars($_type_l)?>. If you feel you should be given access to do so, please contact a member of monarchy for your park or kingdom and ask them to transfer the unit to you.</p>
+<?php endif; ?>
+<?php endif; ?>
+<?php if ($_can_officer): ?>
+			<div class="un-card-section">
+				<div class="un-card-subhead"><i class="fas fa-user-plus"></i> Add A Manager</div>
+				<p class="un-card-text">This unit has no managing players. You can add one by clicking the button below. Please be certain the player requesting to claim this unit has a legitimate reason for doing so.</p>
+				<button type="button" class="pn-btn pn-btn-secondary" style="width:100%;" onclick="unOpenModal('un-modal-add-manager')">
+					<i class="fas fa-user-plus"></i> Add A Manager
+				</button>
+			</div>
+<?php endif; ?>
+		</div>
+<?php endif; ?>
+
+<!-- ── Retire Card ──────────────────────────────────────── -->
+<?php if ($_show_retire): ?>
+		<div class="pn-card un-retire-card">
+			<h4 style="display:flex;align-items:center;justify-content:space-between;"><span><i class="fas fa-box-archive"></i> Retire <?=htmlspecialchars($_type)?></span></h4>
+			<p class="un-card-text">If <?=htmlspecialchars($_name)?> is no longer active or has disbanded, you can retire it here.</p>
+			<button type="button" class="pn-btn pn-btn-ghost" style="width:100%;color:#c05621;border-color:#c05621;" onclick="unOpenModal('un-modal-retire')">
+				<i class="fas fa-box-archive"></i> Retire This Unit
+			</button>
+		</div>
+<?php endif; ?>
 	</aside>
 
 	<!-- Main: roster -->
@@ -729,15 +814,21 @@ if ($_can_edit && (count($_auths) > 0 || true)):
 		<form method="post" action="<?=htmlspecialchars($_base_url)?>">
 			<input type="hidden" name="Action" value="add_member">
 			<div class="pn-modal-body">
+				<div class="pn-acct-field un-filter-field">
+					<label>Filter players by</label>
+					<select class="un-filter-kingdom" id="un-am-filter-kingdom"><?=$_kingdom_options?></select>
+					<select class="un-filter-park" id="un-am-filter-park" style="display:none;"><option value="">All Parks</option></select>
+				</div>
 				<div class="pn-acct-field">
 					<label>Player</label>
 					<div class="pn-award-search-bar un-player-search" id="un-am-wrap">
 						<input type="text" class="pn-award-search-input" id="un-am-input"
-							placeholder="Search players…"
+							placeholder="Search any player — all kingdoms…"
 							autocomplete="off">
 						<div class="un-ac-results" id="un-am-results"></div>
 					</div>
 					<input type="hidden" name="MundaneId" id="un-am-mundane-id">
+					<div class="un-field-hint">Searches all players across every kingdom and park. Use the filter above to narrow to a kingdom or park (or type a <code>GP: name</code> / <code>BS:IK name</code> prefix).</div>
 				</div>
 				<div class="pn-acct-field">
 					<label>Role</label>
@@ -800,6 +891,9 @@ if ($_can_edit && (count($_auths) > 0 || true)):
 	</div>
 </div>
 
+<?php endif; /* end $_can_edit modals */ ?>
+
+<?php if ($_show_addmgr): ?>
 <!-- ── Add Manager Modal ──────────────────────────────── -->
 <div class="pn-overlay" id="un-modal-add-manager">
 	<div class="pn-modal-box">
@@ -810,15 +904,34 @@ if ($_can_edit && (count($_auths) > 0 || true)):
 		<form method="post" action="<?=htmlspecialchars($_base_url)?>">
 			<input type="hidden" name="Action" value="addauth">
 			<div class="pn-modal-body">
+<?php if (count($_nonmgr_members) > 0): ?>
+				<div class="pn-acct-field">
+					<label>Existing member <span style="font-weight:400;color:var(--ork-text-lighter);">(quick pick)</span></label>
+					<select id="un-mg-member-pick">
+						<option value="">— Choose a current member —</option>
+<?php foreach ($_nonmgr_members as $_nm): ?>
+						<option value="<?=(int)$_nm['MundaneId']?>"><?=htmlspecialchars($_nm['Persona'])?></option>
+<?php endforeach; ?>
+					</select>
+					<div class="un-field-hint">Promote a current member to manager, or search for any player below.</div>
+				</div>
+				<div class="un-mg-or-divider">or search any player</div>
+<?php endif; ?>
+				<div class="pn-acct-field un-filter-field">
+					<label>Filter players by</label>
+					<select class="un-filter-kingdom" id="un-mg-filter-kingdom"><?=$_kingdom_options?></select>
+					<select class="un-filter-park" id="un-mg-filter-park" style="display:none;"><option value="">All Parks</option></select>
+				</div>
 				<div class="pn-acct-field">
 					<label>Player</label>
 					<div class="pn-award-search-bar un-player-search" id="un-mg-wrap">
 						<input type="text" class="pn-award-search-input" id="un-mg-input"
-							placeholder="Search players…"
+							placeholder="Search any player — all kingdoms…"
 							autocomplete="off">
 						<div class="un-ac-results" id="un-mg-results"></div>
 					</div>
 					<input type="hidden" name="MundaneId" id="un-mg-mundane-id">
+					<div class="un-field-hint">Searches all players across every kingdom and park. Use the filter above to narrow to a kingdom or park (or type a <code>GP: name</code> / <code>BS:IK name</code> prefix).</div>
 					<div class="un-field-hint">Managers can edit unit details and manage members.</div>
 				</div>
 			</div>
@@ -833,6 +946,71 @@ if ($_can_edit && (count($_auths) > 0 || true)):
 	</div>
 </div>
 
+<?php endif; /* end $_show_addmgr */ ?>
+
+<?php if ($_show_retire): ?>
+<!-- ── Retire Modal ─────────────────────────────────────── -->
+<div class="pn-overlay" id="un-modal-retire">
+	<div class="pn-modal-box" style="max-width:460px">
+		<div class="pn-modal-header">
+			<h3 class="pn-modal-title"><i class="fas fa-box-archive" style="margin-right:8px;color:#c05621"></i>Retire <?=htmlspecialchars($_name)?></h3>
+			<button class="pn-modal-close-btn" onclick="unCloseModal('un-modal-retire')">&times;</button>
+		</div>
+<?php if ($_can_transfer): ?>
+		<div class="pn-modal-body">
+			<p style="margin:0 0 14px;color:var(--ork-text);font-size:14px;">
+				Are you sure you want to retire <strong><?=htmlspecialchars($_name)?></strong>? You can alternatively transfer ownership to another member.
+			</p>
+			<form method="post" action="<?=htmlspecialchars($_base_url)?>">
+				<input type="hidden" name="Action" value="transfer_ownership">
+				<div class="pn-acct-field">
+					<label>Transfer ownership to</label>
+					<select name="MundaneId" id="un-transfer-target" required>
+						<option value="">— Select a member —</option>
+<?php
+$_mgr_open = false; $_mem_open = false;
+foreach ($_transfer_targets as $_tt):
+	if ($_tt['IsManager'] && !$_mgr_open) { echo '<optgroup label="Managers">'; $_mgr_open = true; }
+	if (!$_tt['IsManager'] && !$_mem_open) { if ($_mgr_open) echo '</optgroup>'; echo '<optgroup label="Members">'; $_mem_open = true; }
+?>
+						<option value="<?=(int)$_tt['MundaneId']?>"><?=htmlspecialchars($_tt['Persona'])?></option>
+<?php endforeach; if ($_mgr_open || $_mem_open) echo '</optgroup>'; ?>
+					</select>
+					<div class="un-field-hint">The selected member becomes a manager and you step down as owner. The <?=htmlspecialchars($_type_l)?> stays active.</div>
+				</div>
+				<button type="submit" class="pn-btn pn-btn-primary" style="width:100%;">
+					<i class="fas fa-people-arrows"></i> Transfer Ownership
+				</button>
+			</form>
+			<div class="un-mg-or-divider">or retire the <?=htmlspecialchars($_type_l)?></div>
+			<div class="un-retire-note">
+				Retiring hides this <?=htmlspecialchars($_type_l)?> from listings and search. You will need a member of monarchy to reactivate it.
+			</div>
+			<form method="post" action="<?=htmlspecialchars($_base_url)?>">
+				<input type="hidden" name="Action" value="retire_unit">
+				<button type="submit" class="pn-btn pn-btn-ghost" style="width:100%;color:#c05621;border-color:#c05621;">
+					<i class="fas fa-box-archive"></i> Retire This <?=htmlspecialchars($_type)?>
+				</button>
+			</form>
+		</div>
+<?php else: ?>
+		<div class="pn-modal-body">
+			<p style="margin:0 0 14px;color:var(--ork-text);font-size:14px;">
+				Confirm you wish to retire <strong><?=htmlspecialchars($_name)?></strong> here. Please note, you will need a member of monarchy to reactivate a retired <?=htmlspecialchars($_type_l)?>.
+			</p>
+			<form method="post" action="<?=htmlspecialchars($_base_url)?>">
+				<input type="hidden" name="Action" value="retire_unit">
+				<div class="pn-modal-footer" style="padding:0;border:0;">
+					<button type="button" class="pn-btn pn-btn-secondary" onclick="unCloseModal('un-modal-retire')">Cancel</button>
+					<button type="submit" class="pn-btn pn-btn-primary" style="background:#c05621;border-color:#c05621;">
+						<i class="fas fa-box-archive"></i> Retire This <?=htmlspecialchars($_type)?>
+					</button>
+				</div>
+			</form>
+		</div>
+<?php endif; ?>
+	</div>
+</div>
 <?php endif; ?>
 
 <script src="<?= HTTP_TEMPLATE ?>revised-frontend/script/revised.js?v=<?= filemtime(DIR_TEMPLATE . 'revised-frontend/script/revised.js') ?>"></script>
@@ -863,6 +1041,37 @@ $(function () {
 		});
 	}
 });
+
+<?php if ($_can_edit || $_show_addmgr || $_show_retire): ?>
+// ── Shared modal helpers ──────────────────────────────────
+function unOpenModal(id) {
+	var el = document.getElementById(id);
+	if (el) el.classList.add('pn-open');
+}
+function unCloseModal(id) {
+	var el = document.getElementById(id);
+	if (el) el.classList.remove('pn-open');
+}
+/* Close modals on backdrop click */
+document.querySelectorAll('.pn-overlay').forEach(function (overlay) {
+	overlay.addEventListener('click', function (e) {
+		if (e.target === overlay) overlay.classList.remove('pn-open');
+	});
+});
+/* Escape closes whichever modal is open (elements vary by role, so guard) */
+document.addEventListener('keydown', function(e) {
+	if (e.key !== 'Escape') return;
+	var mdHelp  = document.getElementById('un-md-help-overlay');
+	var details = document.getElementById('un-modal-details');
+	if (mdHelp && mdHelp.classList.contains('kn-open')) {
+		mdHelp.classList.remove('kn-open');
+	} else if (details && details.classList.contains('pn-open')) {
+		unCloseDetailsModal();
+	} else {
+		['un-modal-add-member', 'un-modal-edit-member', 'un-modal-add-manager', 'un-modal-retire'].forEach(unCloseModal);
+	}
+}, true);
+<?php endif; ?>
 
 <?php if ($_can_edit): ?>
 // ── Heraldry modal ────────────────────────────────────────
@@ -915,13 +1124,6 @@ function unDoRemoveHeraldry() {
 		.then(function(r) { if (r.ok) window.location.reload(); });
 }
 
-function unOpenModal(id) {
-	document.getElementById(id).classList.add('pn-open');
-}
-function unCloseModal(id) {
-	document.getElementById(id).classList.remove('pn-open');
-}
-
 // ── Details modal dirty tracking ──
 var _unDetailsForm = document.getElementById('un-modal-details') && document.querySelector('#un-modal-details form');
 var _unDetailsOriginals = {};
@@ -967,20 +1169,6 @@ function unCloseDetailsModal() {
 	}
 	unCloseModal('un-modal-details');
 }
-document.addEventListener('keydown', function(e) {
-	if (e.key === 'Escape') {
-		if (document.getElementById('un-md-help-overlay').classList.contains('kn-open')) {
-			document.getElementById('un-md-help-overlay').classList.remove('kn-open');
-		} else if (document.getElementById('un-modal-details').classList.contains('pn-open')) {
-			unCloseDetailsModal();
-		} else {
-			['un-modal-add-member', 'un-modal-edit-member', 'un-modal-add-manager'].forEach(function(id) {
-				unCloseModal(id);
-			});
-		}
-	}
-}, true);
-
 function unConvertType(targetType) {
 	var btn = document.getElementById('un-convert-btn');
 	btn.disabled = true;
@@ -1015,25 +1203,25 @@ function unOpenEditMember(unitMundaneId, role, title) {
 	unOpenModal('un-modal-edit-member');
 }
 
-/* Close modals on backdrop click */
-document.querySelectorAll('.pn-overlay').forEach(function (overlay) {
-	overlay.addEventListener('click', function (e) {
-		if (e.target === overlay) overlay.classList.remove('pn-open');
-	});
-});
+<?php endif; /* end $_can_edit JS */ ?>
 
+<?php if ($_can_edit || $_show_addmgr): ?>
 /* ── Player search factory ──────────────────────────────── */
 var UN_PSEARCH_BASE = '<?=UIR?>KingdomAjax/playersearch/';
 var UN_SCOPE_KID  = <?=(int)($ScopeKingdomId ?? 0)?>;
 var UN_SCOPE_PID  = <?=(int)($ScopeParkId ?? 0)?>;
+var UN_UIR        = '<?=UIR?>';
 
 function initPlayerSearch(cfg) {
-	/* cfg: { inputId, resultsId, hiddenId, parkId, kingdomId } */
+	/* cfg: { inputId, resultsId, hiddenId, parkId, kingdomId, kingdomSelId, parkSelId } */
 	var $input   = document.getElementById(cfg.inputId);
 	var $results = document.getElementById(cfg.resultsId);
 	var $hidden  = document.getElementById(cfg.hiddenId);
 	var debounce, focusIdx = -1, searchSeq = 0;
 	var seen = {};
+	/* "Filter players by" selection (0 = All). When a kingdom is chosen the
+	   search is scoped to it (and optionally a park) instead of going global. */
+	var filterKingdom = 0, filterPark = 0;
 
 	function closeResults() {
 		$results.classList.remove('un-ac-open');
@@ -1082,6 +1270,13 @@ function initPlayerSearch(cfg) {
 			seen[p.MundaneId] = true;
 			$results.appendChild(buildItem(p, ''));
 		});
+	}
+
+	function showEmpty() {
+		var empty = document.createElement('div');
+		empty.className   = 'un-ac-empty';
+		empty.textContent = 'No players found.';
+		$results.appendChild(empty);
 	}
 
 	function runSearch(term) {
@@ -1161,28 +1356,86 @@ function initPlayerSearch(cfg) {
 		}
 	});
 
+	function rerun() {
+		var term = $input.value.trim();
+		if (term.length >= 2) runSearch(term); else closeResults();
+	}
+
+	if ($kSel) {
+		$kSel.addEventListener('change', function () {
+			filterKingdom = parseInt(this.value, 10) || 0;
+			filterPark = 0;
+			if ($pSel) {
+				$pSel.innerHTML = '<option value="">All Parks</option>';
+				if (filterKingdom) {
+					$pSel.style.display = '';
+					fetch(UN_UIR + 'KingdomAjax/kingdom/' + filterKingdom + '/getparks')
+						.then(function (r) { return r.json(); })
+						.then(function (d) {
+							(d.parks || []).forEach(function (pk) {
+								var o = document.createElement('option');
+								o.value = pk.ParkId; o.textContent = pk.Name;
+								$pSel.appendChild(o);
+							});
+						})
+						.catch(function () { /* leave park filter as All Parks on error */ });
+				} else {
+					$pSel.style.display = 'none';
+				}
+			}
+			rerun();
+		});
+	}
+	if ($pSel) {
+		$pSel.addEventListener('change', function () {
+			filterPark = parseInt(this.value, 10) || 0;
+			rerun();
+		});
+	}
+
 	$input.addEventListener('blur', function () {
 		setTimeout(closeResults, 150);
 	});
 }
 
-/* Initialise both search widgets */
-initPlayerSearch({ inputId: 'un-am-input', resultsId: 'un-am-results', hiddenId: 'un-am-mundane-id', parkId: UN_SCOPE_PID, kingdomId: UN_SCOPE_KID });
-initPlayerSearch({ inputId: 'un-mg-input', resultsId: 'un-mg-results', hiddenId: 'un-mg-mundane-id', parkId: UN_SCOPE_PID, kingdomId: UN_SCOPE_KID });
-
-/* Clear search fields when modals close */
+/* Initialise search widgets per available modal */
+<?php if ($_can_edit): ?>
+initPlayerSearch({ inputId: 'un-am-input', resultsId: 'un-am-results', hiddenId: 'un-am-mundane-id', parkId: UN_SCOPE_PID, kingdomId: UN_SCOPE_KID, kingdomSelId: 'un-am-filter-kingdom', parkSelId: 'un-am-filter-park' });
 document.getElementById('un-modal-add-member').addEventListener('transitionend', function () {
 	if (!this.classList.contains('pn-open')) {
 		document.getElementById('un-am-input').value = '';
 		document.getElementById('un-am-mundane-id').value = '';
 	}
 });
+<?php endif; ?>
+<?php if ($_show_addmgr): ?>
+initPlayerSearch({ inputId: 'un-mg-input', resultsId: 'un-mg-results', hiddenId: 'un-mg-mundane-id', parkId: UN_SCOPE_PID, kingdomId: UN_SCOPE_KID, kingdomSelId: 'un-mg-filter-kingdom', parkSelId: 'un-mg-filter-park' });
 document.getElementById('un-modal-add-manager').addEventListener('transitionend', function () {
 	if (!this.classList.contains('pn-open')) {
 		document.getElementById('un-mg-input').value = '';
 		document.getElementById('un-mg-mundane-id').value = '';
+		var pick = document.getElementById('un-mg-member-pick');
+		if (pick) { pick.value = ''; document.getElementById('un-mg-input').disabled = false; }
 	}
 });
+/* Quick-pick: choosing an existing member fills the hidden id and locks search */
+var _unMgPick = document.getElementById('un-mg-member-pick');
+if (_unMgPick) {
+	_unMgPick.addEventListener('change', function () {
+		var input  = document.getElementById('un-mg-input');
+		var hidden = document.getElementById('un-mg-mundane-id');
+		if (this.value) {
+			hidden.value = this.value;
+			input.value  = this.options[this.selectedIndex].text;
+			input.disabled = true;
+		} else {
+			hidden.value = '';
+			input.value  = '';
+			input.disabled = false;
+		}
+	});
+}
+<?php endif; ?>
 <?php endif; ?>
 </script>
 <style>
@@ -1199,5 +1452,69 @@ html[data-theme="dark"] #un-roster-table_wrapper .dataTables_paginate .paginate_
 }
 html[data-theme="dark"] #un-roster-table_wrapper .dataTables_paginate .paginate_button.disabled {
   opacity: 0.4 !important;
+}
+</style>
+<style>
+/* ── Retire / Claim / Restore card elements ─────────────────────── */
+.un-card-text {
+  font-size: 13px;
+  color: var(--ork-text-secondary);
+  line-height: 1.5;
+  margin: 0 0 12px;
+}
+.un-card-section {
+  margin-top: 14px;
+  padding-top: 14px;
+  border-top: 1px solid var(--ork-border, #e2e8f0);
+}
+.un-card-subhead {
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: .04em;
+  color: var(--ork-text-muted);
+  margin: 0 0 8px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  background: none;
+  border: none;
+  padding: 0;
+}
+.un-mg-or-divider {
+  text-align: center;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: .05em;
+  color: var(--ork-text-lighter);
+  margin: 16px 0;
+  position: relative;
+}
+.un-mg-or-divider::before,
+.un-mg-or-divider::after {
+  content: '';
+  position: absolute;
+  top: 50%;
+  width: 34%;
+  height: 1px;
+  background: var(--ork-border, #e2e8f0);
+}
+.un-mg-or-divider::before { left: 0; }
+.un-mg-or-divider::after  { right: 0; }
+.un-retire-note {
+  font-size: 12px;
+  color: var(--ork-text-secondary);
+  background: var(--ork-alert-warning-bg, #fffaf0);
+  border: 1px solid var(--ork-alert-warning-border, #f6e05e);
+  border-radius: 6px;
+  padding: 10px;
+  margin-bottom: 12px;
+  line-height: 1.45;
+}
+.un-retired-card { border-left: 3px solid #c05621; }
+html[data-theme="dark"] .un-retire-note {
+  background: rgba(192, 86, 33, 0.12);
+  border-color: rgba(192, 86, 33, 0.45);
+  color: var(--ork-text-secondary);
 }
 </style>

--- a/orkui/template/default/Unit_index.tpl
+++ b/orkui/template/default/Unit_index.tpl
@@ -1047,6 +1047,19 @@ $(function () {
 function unOpenModal(id) {
 	var el = document.getElementById(id);
 	if (el) el.classList.add('pn-open');
+	var searchMap = {
+		'un-modal-add-member':  { input: 'un-am-input', results: 'un-am-results', hidden: 'un-am-mundane-id' },
+		'un-modal-add-manager': { input: 'un-mg-input', results: 'un-mg-results', hidden: 'un-mg-mundane-id' }
+	};
+	var s = searchMap[id];
+	if (s) {
+		var $i = document.getElementById(s.input),
+		    $r = document.getElementById(s.results),
+		    $h = document.getElementById(s.hidden);
+		if ($i) $i.value = '';
+		if ($h) $h.value = '';
+		if ($r) { $r.innerHTML = ''; $r.classList.remove('un-ac-open'); }
+	}
 }
 function unCloseModal(id) {
 	var el = document.getElementById(id);
@@ -1211,17 +1224,21 @@ var UN_PSEARCH_BASE = '<?=UIR?>KingdomAjax/playersearch/';
 var UN_SCOPE_KID  = <?=(int)($ScopeKingdomId ?? 0)?>;
 var UN_SCOPE_PID  = <?=(int)($ScopeParkId ?? 0)?>;
 var UN_UIR        = '<?=UIR?>';
+var UN_MEMBER_IDS = <?=json_encode(array_values(array_map(function($m){ return (int)$m['MundaneId']; }, $_members)))?>;
+var UN_MEMBER_SET = {}; UN_MEMBER_IDS.forEach(function(id){ UN_MEMBER_SET[id] = true; });
 
 function initPlayerSearch(cfg) {
 	/* cfg: { inputId, resultsId, hiddenId, parkId, kingdomId, kingdomSelId, parkSelId } */
 	var $input   = document.getElementById(cfg.inputId);
 	var $results = document.getElementById(cfg.resultsId);
 	var $hidden  = document.getElementById(cfg.hiddenId);
+	var $kSel    = cfg.kingdomSelId ? document.getElementById(cfg.kingdomSelId) : null;
+	var $pSel    = cfg.parkSelId    ? document.getElementById(cfg.parkSelId)    : null;
 	var debounce, focusIdx = -1, searchSeq = 0;
 	var seen = {};
 	/* "Filter players by" selection (0 = All). When a kingdom is chosen the
 	   search is scoped to it (and optionally a park) instead of going global. */
-	var filterKingdom = 0, filterPark = 0;
+	var filterKingdom = null, filterPark = null;
 
 	function closeResults() {
 		$results.classList.remove('un-ac-open');
@@ -1272,45 +1289,30 @@ function initPlayerSearch(cfg) {
 		});
 	}
 
-	function showEmpty() {
-		var empty = document.createElement('div');
-		empty.className   = 'un-ac-empty';
-		empty.textContent = 'No players found.';
-		$results.appendChild(empty);
-	}
-
 	function runSearch(term) {
-		/* Canonical playersearch endpoint: LIKE-based filtering, own-kingdom-first
-		   ordering, robust scope handling. Mirrors the Event RSVP modal's tiers. */
-		var kid  = cfg.kingdomId || 0;
-		var pid  = cfg.parkId || 0;
+		var kid  = filterKingdom > 0 ? filterKingdom : (cfg.kingdomId || 0);
+		var pid  = filterPark > 0 ? filterPark : 0;
 		var base = UN_PSEARCH_BASE + kid;
 		var q    = '&include_inactive=1&include_suspended=1&q=' + encodeURIComponent(term);
+		// Show home park tier when browsing all kingdoms or the user's own kingdom.
+		var useHomePark = cfg.parkId && (filterKingdom === 0 || filterKingdom === cfg.kingdomId);
 		var groups;
-		// An abbreviation prefix ("nb:ff wolf") makes the server filter by abbreviation
-		// and ignore scope/park_id — show one group so results aren't mislabelled.
-		if (/^[a-z0-9]{2,3}:[a-z0-9*]{0,3}\s+\S/i.test(term)) {
-			groups = [ { label: 'All Players', url: base + '&scope=all' + q } ];
-		} else if (pid > 0 && kid > 0) {
-			groups = [
-				{ label: 'In Park',     url: base + '&scope=own&park_id=' + pid + q },
-				{ label: 'In Kingdom',  url: base + '&scope=own' + q },
-				{ label: 'All Players', url: base + '&scope=exclude' + q }
-			];
-		} else if (kid > 0) {
-			groups = [
-				{ label: 'In Kingdom',  url: base + '&scope=own' + q },
-				{ label: 'All Players', url: base + '&scope=exclude' + q }
-			];
+		if (kid === 0 || /^[a-z0-9]{2,3}:[a-z0-9*]{0,3}\s+\S/i.test(term)) {
+			groups = [ { label: 'All Players', url: UN_PSEARCH_BASE + '0&scope=all' + q } ];
+		} else if (pid > 0) {
+			groups = [ { label: 'In Park', url: base + '&scope=own&park_id=' + pid + q } ];
 		} else {
-			groups = [ { label: 'All Players', url: base + '&scope=all' + q } ];
+			groups = [];
+			if (useHomePark) groups.push({ label: 'In Park', url: base + '&scope=own&park_id=' + cfg.parkId + q });
+			groups.push({ label: 'In Kingdom', url: base + '&scope=own' + q });
+			if (filterKingdom === 0) groups.push({ label: 'All Players', url: base + '&scope=exclude' + q });
 		}
 		var mySeq = ++searchSeq;
 		Promise.all(groups.map(function (g) {
 			return fetch(g.url).then(function (r) { return r.json(); }).catch(function () { return []; });
 		})).then(function (resArr) {
 			if (mySeq !== searchSeq) return; // a newer keystroke superseded this response
-			seen = {};
+			seen = Object.assign({}, UN_MEMBER_SET);
 			$results.innerHTML = '';
 			$hidden.value = '';
 			groups.forEach(function (g, i) { addGroup(g.label, resArr[i] || []); });
@@ -1362,6 +1364,7 @@ function initPlayerSearch(cfg) {
 	}
 
 	if ($kSel) {
+		filterKingdom = parseInt($kSel.value, 10) || 0;
 		$kSel.addEventListener('change', function () {
 			filterKingdom = parseInt(this.value, 10) || 0;
 			filterPark = 0;

--- a/orkui/template/default/Unit_unitlist.tpl
+++ b/orkui/template/default/Unit_unitlist.tpl
@@ -56,7 +56,7 @@ html[data-theme="dark"] .ul-badge-retired { background: #374151; color: #d1d5db;
 	padding: 10px 14px; margin-bottom: 12px; font-size: 13px; color: #854d0e;
 }
 .ul-limit-warn i { color: #ca8a04; margin-top: 2px; flex-shrink: 0; }
-.ul-default-note { background: #ebf8ff; border-color: #bee3f8; color: #2c5282; }
+.ul-default-note { display: flex; background: #ebf8ff; border-color: #bee3f8; color: #2c5282; }
 .ul-default-note i { color: #3182ce; }
 html[data-theme="dark"] .ul-limit-warn { background: var(--ork-bg-secondary); border-color: var(--ork-border); color: var(--ork-text-secondary); }
 html[data-theme="dark"] .ul-default-note { background: var(--ork-bg-secondary); border-color: var(--ork-border); color: var(--ork-text-secondary); }
@@ -206,7 +206,7 @@ html[data-theme="dark"] .uc-modal div[style*="background:#ebf8ff"] { background:
 			<span>Your search has been limited to 250 results. Update your search criteria and click Search again to refine further.</span>
 		</div>
 		<!-- Default top-by-size note -->
-		<div class="ul-limit-warn ul-default-note" id="ul-default-note" style="display:none">
+		<div class="ul-limit-warn ul-default-note" id="ul-default-note">
 			<i class="fas fa-info-circle"></i>
 			<span>Showing the largest companies and households by member size. Search by name above to find other units.</span>
 		</div>
@@ -380,7 +380,7 @@ html[data-theme="dark"] .uc-modal div[style*="background:#ebf8ff"] { background:
 		$('#ul-loading').html('<i class="fas fa-spinner fa-spin" style="font-size:22px;display:block;margin-bottom:8px;opacity:0.4;"></i>Loading units…').show();
 		$('#ul-table').hide();
 		$('#ul-limit-warn').hide();
-		$('#ul-default-note').hide();
+		if (q) $('#ul-default-note').hide();
 
 		var url = AJAX_BASE + '&q=' + encodeURIComponent(q || '');
 		if (KID) url += '&KingdomId=' + KID;

--- a/orkui/template/default/Unit_unitlist.tpl
+++ b/orkui/template/default/Unit_unitlist.tpl
@@ -20,6 +20,10 @@ $_scope_pid  = (int)($ScopeParkId    ?? 0);
 .ul-badge-company   { background: #e0e7ff; color: #3730a3; }
 .ul-badge-household { background: #d1fae5; color: #065f46; }
 .ul-badge-event     { background: #fef3c7; color: #92400e; }
+.ul-badge-inactive  { background: #fee2e2; color: #991b1b; }
+html[data-theme="dark"] .ul-badge-inactive { background: #450a0a; color: #fca5a5; }
+.ul-badge-retired  { background: #e5e7eb; color: #4b5563; }
+html[data-theme="dark"] .ul-badge-retired { background: #374151; color: #d1d5db; }
 .ul-name-link { font-weight: 600; color: var(--rp-accent); text-decoration: none; }
 .ul-name-link:hover { color: var(--rp-accent-mid); text-decoration: underline; }
 #ul-table td:first-child, #ul-table th:first-child { width: 50px; padding-right: 4px; }
@@ -52,6 +56,11 @@ $_scope_pid  = (int)($ScopeParkId    ?? 0);
 	padding: 10px 14px; margin-bottom: 12px; font-size: 13px; color: #854d0e;
 }
 .ul-limit-warn i { color: #ca8a04; margin-top: 2px; flex-shrink: 0; }
+.ul-default-note { background: #ebf8ff; border-color: #bee3f8; color: #2c5282; }
+.ul-default-note i { color: #3182ce; }
+html[data-theme="dark"] .ul-limit-warn { background: var(--ork-bg-secondary); border-color: var(--ork-border); color: var(--ork-text-secondary); }
+html[data-theme="dark"] .ul-default-note { background: var(--ork-bg-secondary); border-color: var(--ork-border); color: var(--ork-text-secondary); }
+html[data-theme="dark"] .ul-default-note i { color: var(--ork-link, #63b3ed); }
 
 .ul-loading { text-align: center; padding: 32px; color: var(--rp-text-muted); font-size: 14px; }
 
@@ -196,6 +205,11 @@ html[data-theme="dark"] .uc-modal div[style*="background:#ebf8ff"] { background:
 			<i class="fas fa-exclamation-triangle"></i>
 			<span>Your search has been limited to 250 results. Update your search criteria and click Search again to refine further.</span>
 		</div>
+		<!-- Default top-by-size note -->
+		<div class="ul-limit-warn ul-default-note" id="ul-default-note" style="display:none">
+			<i class="fas fa-info-circle"></i>
+			<span>Showing the largest companies and households by member size. Search by name above to find other units.</span>
+		</div>
 
 		<!-- Type + activity filter pills -->
 		<div class="rp-filter-pills" style="margin-bottom:14px;">
@@ -203,13 +217,13 @@ html[data-theme="dark"] .uc-modal div[style*="background:#ebf8ff"] { background:
 			<button class="rp-filter-pill" data-type="Company">Companies</button>
 			<button class="rp-filter-pill" data-type="Household">Households</button>
 			<button class="rp-filter-pill" id="ul-pill-inactive" data-inactive="0" style="margin-left:8px;">
-				<i class="fas fa-eye-slash" style="font-size:10px;"></i> Include Inactive
+				<i class="fas fa-eye-slash" style="font-size:10px;"></i> Include Inactive/Retired
 			</button>
 		</div>
 
 		<div id="ul-loading" class="ul-loading">
-			<i class="fas fa-search" style="font-size:22px;display:block;margin-bottom:8px;opacity:0.3;"></i>
-			Type a name to search units.
+			<i class="fas fa-spinner fa-spin" style="font-size:22px;display:block;margin-bottom:8px;opacity:0.4;"></i>
+			Loading units…
 		</div>
 
 		<table id="ul-table" class="dataTable" style="width:100%;display:none">
@@ -245,6 +259,7 @@ html[data-theme="dark"] .uc-modal div[style*="background:#ebf8ff"] { background:
 	var HERALDRY     = <?= json_encode(HTTP_UNIT_HERALDRY) ?>;
 	var UIR_BASE     = <?= json_encode(UIR) ?>;
 	var AJAX_BASE    = <?= json_encode(UIR . 'Search/unitsearch') ?>;
+	var ACTIVITY_BASE = <?= json_encode(UIR . 'Search/unitactivity') ?>;
 	var LIMIT        = 250;
 
 	// Column indices (type + activity cols are always hidden at indices 2,3)
@@ -253,6 +268,8 @@ html[data-theme="dark"] .uc-modal div[style*="background:#ebf8ff"] { background:
 	var ACTIVITY_COL = 3;
 	var SCOPE_COL    = HAS_SCOPE ? 4 : -1;
 	var WEB_COL      = HAS_SCOPE ? 8 : 7;
+	var SIZE_COL     = HAS_SCOPE ? SCOPE_COL : 5;  // member-size column for the default sort
+	var defaultMode  = false;                       // true when showing the no-search top-by-size list
 
 	var includeInactive  = false;
 	var activeTypeFilter = '';
@@ -261,6 +278,11 @@ html[data-theme="dark"] .uc-modal div[style*="background:#ebf8ff"] { background:
 
 	var oneYearAgo = new Date();
 	oneYearAgo.setFullYear(oneYearAgo.getFullYear() - 1);
+	var INACTIVE_BADGE = ' <span class="ul-type-badge ul-badge-inactive">Inactive</span>';
+	// A unit is inactive when no member has signed in within the last 12 months.
+	function isInactive(u) { return !u.LastActivityDate || new Date(u.LastActivityDate) < oneYearAgo; }
+	var RETIRED_BADGE = ' <span class="ul-type-badge ul-badge-retired">Retired</span>';
+	function isRetired(u) { return String(u.Active) === 'Retired'; }
 
 	function badgeClass(type) {
 		if (type === 'Company')  return 'ul-badge-company';
@@ -281,20 +303,24 @@ html[data-theme="dark"] .uc-modal div[style*="background:#ebf8ff"] { background:
 		var nameHtml = '<a class="ul-name-link" href="' + UIR_BASE + 'Unit/index/' + uid + '">'
 			+ $('<span>').text(u.Name || '(Unnamed)').html() + '</a>'
 			+ '<span class="ul-type-badge ' + badgeClass(u.Type) + '">' + (u.Type || '') + '</span>';
+		// In typed-search mode activity is known now; default mode badges after the lazy load.
+		if (isRetired(u)) nameHtml += RETIRED_BADGE;
+		else if (!defaultMode && isInactive(u)) nameHtml += INACTIVE_BADGE;
 
 		var row = [
 			imgHtml,
 			nameHtml,
 			u.Type || '',
-			u.LastActivityDate || '',
+			defaultMode ? '' : (u.LastActivityDate || ''),
 		];
 
 		if (HAS_SCOPE) {
 			row.push(parseInt(u.MemberCount) || 0);
 		}
 
+		// Activity columns aren't computed for the fast default list — show a dash.
 		row.push(
-			parseInt(u.ActiveMemberCount) || 0,
+			defaultMode ? ('<span class="ul-active-cell" data-uid="' + uid + '"><i class="fas fa-spinner fa-spin" style="opacity:.5"></i></span>') : (parseInt(u.ActiveMemberCount) || 0),
 			parseInt(u.TotalMemberCount)  || 0,
 			$('<span>').text(u.LeaderNames || '').html(),
 			webCell(u.Url || '')
@@ -320,14 +346,46 @@ html[data-theme="dark"] .uc-modal div[style*="background:#ebf8ff"] { background:
 		$('#ul-stats-row').show();
 	}
 
+	// Lazy-populate the Active column for the default list once it's on screen.
+	// Works on the DataTables data (all rows), not just the rendered page, so
+	// pagination keeps the resolved counts + Inactive badges.
+	var ACTIVE_DATA_COL = HAS_SCOPE ? 5 : 4;  // index in the row data array
+	function applyActiveCounts(map) {
+		table.rows().every(function () {
+			var d = this.data();
+			var m = String(d[ACTIVE_DATA_COL]).match(/data-uid="(\d+)"/);
+			if (!m) return;                       // already resolved / not a spinner
+			var count = map[m[1]] != null ? map[m[1]] : 0;
+			d[ACTIVE_DATA_COL] = count;
+			if (count === 0 && String(d[1]).indexOf('ul-badge-inactive') === -1
+					&& String(d[1]).indexOf('ul-badge-retired') === -1) {
+				d[1] = d[1] + INACTIVE_BADGE;     // mark the unit inactive (retired already badged)
+			}
+			this.data(d);
+		});
+		table.draw(false);
+	}
+	function loadActiveCounts(units) {
+		var ids = units.map(function (u) { return parseInt(u.UnitId) || 0; }).filter(Boolean);
+		if (!ids.length || !table) return;
+		$.getJSON(ACTIVITY_BASE + '&ids=' + ids.join(','), function (map) {
+			applyActiveCounts(map || {});
+		}).fail(function () {
+			applyActiveCounts({});   // resolve spinners to 0 (and badge them inactive)
+		});
+	}
+
 	function loadData(q) {
+		defaultMode = !q;
 		$('#ul-loading').html('<i class="fas fa-spinner fa-spin" style="font-size:22px;display:block;margin-bottom:8px;opacity:0.4;"></i>Loading units…').show();
 		$('#ul-table').hide();
 		$('#ul-limit-warn').hide();
+		$('#ul-default-note').hide();
 
 		var url = AJAX_BASE + '&q=' + encodeURIComponent(q || '');
 		if (KID) url += '&KingdomId=' + KID;
 		if (PID) url += '&ParkId='    + PID;
+		if (includeInactive) url += '&include=1';
 
 		$.getJSON(url, function (units) {
 			$('#ul-loading').hide();
@@ -343,7 +401,12 @@ html[data-theme="dark"] .uc-modal div[style*="background:#ebf8ff"] { background:
 				$('#ul-limit-warn').css('display', 'flex');
 			}
 
-			updateStats(units);
+			if (defaultMode) {
+				$('#ul-stats-row').hide();
+				$('#ul-default-note').css('display', 'flex');
+			} else {
+				updateStats(units);
+			}
 			var rows = units.map(buildRow);
 
 			if (table) {
@@ -351,7 +414,7 @@ html[data-theme="dark"] .uc-modal div[style*="background:#ebf8ff"] { background:
 			} else {
 				$.fn.dataTable.ext.search.push(function (settings, data) {
 					if (settings.nTable.id !== 'ul-table') return true;
-					if (includeInactive) return true;
+					if (defaultMode || includeInactive) return true;
 					var lastActivity = data[ACTIVITY_COL];
 					if (!lastActivity) return false;
 					return new Date(lastActivity) >= oneYearAgo;
@@ -374,10 +437,10 @@ html[data-theme="dark"] .uc-modal div[style*="background:#ebf8ff"] { background:
 			}
 
 			$('#ul-table').show();
+			table.order(defaultMode ? [[SIZE_COL, 'desc']] : [[1, 'asc']]);
+			table.column(TYPE_COL).search(activeTypeFilter ? '^' + activeTypeFilter + '$' : '', true, false).draw();
 
-			if (activeTypeFilter) {
-				table.column(TYPE_COL).search('^' + activeTypeFilter + '$', true, false).draw();
-			}
+			if (defaultMode) loadActiveCounts(units);
 		}).fail(function () {
 			$('#ul-loading').text('Search failed. Please try again.').show();
 		});
@@ -392,14 +455,10 @@ html[data-theme="dark"] .uc-modal div[style*="background:#ebf8ff"] { background:
 	}
 
 	function clearSearch() {
-		if (table) { table.destroy(); table = null; }
-		$('#ul-table').hide();
-		$('#ul-stats-row').hide();
-		$('#ul-limit-warn').hide();
-		$('#ul-loading').html('<i class="fas fa-search" style="font-size:22px;display:block;margin-bottom:8px;opacity:0.3;"></i>Type a name to search units.').show();
 		$('#ul-search-input').val('');
 		$('#ul-search-clear').hide();
 		currentQuery = '';
+		loadData('');   // back to the default top-by-size list
 	}
 
 	$('#ul-search-input').on('input', function () {
@@ -429,8 +488,13 @@ html[data-theme="dark"] .uc-modal div[style*="background:#ebf8ff"] { background:
 		includeInactive = !includeInactive;
 		$(this).toggleClass('active', includeInactive);
 		$(this).find('i').toggleClass('fa-eye-slash', !includeInactive).toggleClass('fa-eye', includeInactive);
-		if (table) table.draw();
+		// Re-fetch: retired units are a server-side filter (include=1), and the
+		// activity filter (inactive) is applied client-side on redraw.
+		loadData(currentQuery);
 	});
+
+	// Load the default top-by-size list on open (no minimum-character gate).
+	loadData('');
 }());
 </script>
 

--- a/orkui/template/revised-frontend/Admin_index.tpl
+++ b/orkui/template/revised-frontend/Admin_index.tpl
@@ -349,6 +349,9 @@ function _cp_trend($cur, $prev, $fmt = 'number') {
 .cp-field-row { display: grid; grid-template-columns: 1fr 1fr; gap: 10px; }
 .cp-field-ac { position: relative; }
 .cp-field-ac .kn-ac-results { position: absolute; left: 0; right: 0; z-index: 9999; }
+.cp-mp-cascade { display:flex; flex-wrap:wrap; gap:6px; margin-bottom:6px; }
+.cp-mp-cascade-sel { flex:1 1 140px; min-width:0; font-size:12px; padding:6px 8px; border:1px solid #cbd5e0; border-radius:6px; background:#fff; color:#4a5568; }
+html[data-theme="dark"] .cp-mp-cascade-sel { background: var(--ork-input-bg); color: var(--ork-text); border-color: var(--ork-input-border); }
 /* Feedback */
 .cp-feedback { padding: 10px 14px; border-radius: 6px; font-size: 13px; font-weight: 500; margin-bottom: 14px; display: none; }
 .cp-feedback-ok  { background: #c6f6d5; color: #276749; border: 1px solid #9ae6b4; }
@@ -462,15 +465,21 @@ html[data-theme="dark"] .cp-warning { background: #744210; border-color: #975a16
 			<div class="cp-feedback" id="cp-mp-feedback"></div>
 			<div class="cp-field cp-field-ac">
 				<label>Player <span style="color:#e53e3e">*</span></label>
+				<div class="cp-mp-cascade">
+					<select class="cp-mp-cascade-sel" id="cp-mp-pfilter-kingdom" aria-label="Filter players by kingdom"><option value="">All Kingdoms</option></select>
+					<select class="cp-mp-cascade-sel" id="cp-mp-pfilter-park" aria-label="Filter players by park" style="display:none"><option value="">All Parks</option></select>
+				</div>
 				<input type="text" id="cp-mp-player-name" autocomplete="off" placeholder="Search all players…">
 				<input type="hidden" id="cp-mp-player-id">
 				<div class="kn-ac-results" id="cp-mp-player-results"></div>
 			</div>
 			<div class="cp-field cp-field-ac" style="margin-top:12px">
 				<label>New Home Park <span style="color:#e53e3e">*</span></label>
-				<input type="text" id="cp-mp-park-name" autocomplete="off" placeholder="Search all parks…">
+				<div class="cp-mp-cascade">
+					<select class="cp-mp-cascade-sel" id="cp-mp-dfilter-kingdom" aria-label="Destination kingdom"><option value="">Select Kingdom</option></select>
+					<select class="cp-mp-cascade-sel" id="cp-mp-dfilter-park" aria-label="Destination park" style="display:none"><option value="">Select Park</option></select>
+				</div>
 				<input type="hidden" id="cp-mp-park-id">
-				<div class="kn-ac-results" id="cp-mp-park-results"></div>
 			</div>
 		</div>
 		<div class="cp-modal-footer">
@@ -943,6 +952,36 @@ html[data-theme="dark"] .cp-warning { background: #744210; border-color: #975a16
 			}));
 		}).catch(function(){cb([]);});
 	}
+	// Move Player cascade: kingdom-scoped player search (consistent with the
+	// other Move Player modals). revised.js/MpCascade is not loaded on the admin
+	// page, so this is a small self-contained version using the shared endpoints.
+	function cpSearchPlayersInKingdom(q, kingdomId, parkId, cb) {
+		var url = UIR + 'KingdomAjax/playersearch/' + kingdomId + '&scope=own&include_inactive=1'
+			+ (parkId ? '&park_id=' + parkId : '') + '&q=' + encodeURIComponent(q);
+		fetch(url).then(function(r){return r.json();}).then(function(d) {
+			cb((d || []).map(function(p) {
+				var inactive = p.Active === 0 ? ' <span style="color:#e53e3e;font-size:10px;font-weight:600">inactive</span>' : '';
+				return { id: p.MundaneId, label: p.Persona,
+					html: cpEsc(p.Persona) + ' <span style="color:#a0aec0;font-size:11px">(' + cpEsc(p.KAbbr||'') + ' · ' + cpEsc(p.ParkName||'') + ')</span>' + inactive };
+			}));
+		}).catch(function(){cb([]);});
+	}
+	var cpKingdomsCache = null;
+	function cpLoadKingdoms(cb) {
+		if (cpKingdomsCache) { cb(cpKingdomsCache); return; }
+		fetch(UIR + 'KingdomAjax/getkingdoms').then(function(r){return r.json();}).then(function(d){ cpKingdomsCache = (d && d.kingdoms) || []; cb(cpKingdomsCache); }).catch(function(){cb([]);});
+	}
+	function cpWireCascade(kSelId, pSelId, onChange, parkLabel) {
+		var kSel = document.getElementById(kSelId), pSel = document.getElementById(pSelId);
+		if (!kSel || !pSel) return { get: function(){ return { kingdomId:0, parkId:0 }; } };
+		function resetPark(show) { pSel.innerHTML = '<option value="">' + (parkLabel || 'All Parks') + '</option>'; pSel.style.display = show ? '' : 'none'; }
+		function fillParks(kid) { fetch(UIR + 'KingdomAjax/kingdom/' + kid + '/getparks').then(function(r){return r.json();}).then(function(d){ resetPark(true); (d.parks||[]).forEach(function(pk){ var o=document.createElement('option'); o.value=pk.ParkId; o.textContent=pk.Name; pSel.appendChild(o); }); }).catch(function(){}); }
+		cpLoadKingdoms(function(ks){ ks.forEach(function(k){ var o=document.createElement('option'); o.value=k.KingdomId; o.textContent=k.KingdomName; kSel.appendChild(o); }); });
+		resetPark(false);
+		kSel.addEventListener('change', function(){ var kid=parseInt(this.value,10)||0; if(kid) fillParks(kid); else resetPark(false); onChange(); });
+		pSel.addEventListener('change', onChange);
+		return { get: function(){ return { kingdomId: parseInt(kSel.value,10)||0, parkId: parseInt(pSel.value,10)||0 }; } };
+	}
 
 	/* --------------------------------------------------
 	   POST helper
@@ -1008,10 +1047,24 @@ html[data-theme="dark"] .cp-warning { background: #744210; border-color: #975a16
 		var pkid = document.getElementById('cp-mp-park-id').value;
 		document.getElementById('cp-mp-submit').disabled = !(pid && pkid);
 	}
+	var cpMpPlayerCascade = null, cpMpDestCascade = null;
 	cpAc({ inputId:'cp-mp-player-name', hiddenId:'cp-mp-player-id', resultsId:'cp-mp-player-results',
-		fetchFn: function(q, cb) { cpSearchPlayersGlobal(q, cb, true); }, onSelect: cpMpCheck, onClear: cpMpCheck });
-	cpAc({ inputId:'cp-mp-park-name', hiddenId:'cp-mp-park-id', resultsId:'cp-mp-park-results',
-		fetchFn: cpSearchParks, onSelect: cpMpCheck, onClear: cpMpCheck });
+		fetchFn: function(q, cb) {
+			var sel = cpMpPlayerCascade ? cpMpPlayerCascade.get() : { kingdomId:0, parkId:0 };
+			if (sel.kingdomId) cpSearchPlayersInKingdom(q, sel.kingdomId, sel.parkId, cb);
+			else cpSearchPlayersGlobal(q, cb, true);
+		}, onSelect: cpMpCheck, onClear: cpMpCheck });
+	// Destination park is chosen via the Kingdom -> Park cascade below — no free-text park search.
+	// Cascade filters (Kingdom -> Park) for the player and destination searches
+	cpMpPlayerCascade = cpWireCascade('cp-mp-pfilter-kingdom', 'cp-mp-pfilter-park', function() {
+		var inp = document.getElementById('cp-mp-player-name');
+		if (inp && inp.value.trim().length >= 2) inp.dispatchEvent(new Event('input'));
+	});
+	cpMpDestCascade = cpWireCascade('cp-mp-dfilter-kingdom', 'cp-mp-dfilter-park', function() {
+		var sel = cpMpDestCascade.get();
+		document.getElementById('cp-mp-park-id').value = sel.parkId ? sel.parkId : '';
+		cpMpCheck();
+	}, 'Select Park');
 	document.getElementById('cp-mp-submit').addEventListener('click', function() {
 		var playerId = document.getElementById('cp-mp-player-id').value;
 		var parkId   = document.getElementById('cp-mp-park-id').value;
@@ -1024,7 +1077,7 @@ html[data-theme="dark"] .cp-warning { background: #744210; border-color: #975a16
 					'<a href="' + UIR + 'Park/profile/' + parkId + '">View new home park</a> · ' +
 					'<a href="' + UIR + 'Player/profile/' + playerId + '">View player</a>', true);
 				// reset
-				['cp-mp-player-name','cp-mp-park-name'].forEach(function(id){document.getElementById(id).value='';});
+				document.getElementById('cp-mp-player-name').value='';
 				['cp-mp-player-id','cp-mp-park-id'].forEach(function(id){document.getElementById(id).value='';});
 				btn.disabled = true;
 			});

--- a/orkui/template/revised-frontend/Kingdomnew_index.tpl
+++ b/orkui/template/revised-frontend/Kingdomnew_index.tpl
@@ -628,6 +628,7 @@
 							<li><a href="<?= UIR ?>Reports/reeve/Kingdom&id=<?= $kingdom_id ?>">Reeve Qualified</a></li>
 							<li><a href="<?= UIR ?>Reports/corpora/Kingdom&id=<?= $kingdom_id ?>">Corpora Qualified</a></li>
 							<li><a href="<?= UIR ?>Reports/player_status_reconciliation/Kingdom&id=<?= $kingdom_id ?>">Player Status Reconciliation</a></li>
+							<li><a href="<?= UIR ?>Reports/guilds&KingdomId=<?= $kingdom_id ?>"><?= $entityLabel ?> Guilds</a></li>
 							<?php endif; ?>
 							<li><a href="<?= UIR ?>Reports/kingdom_officer_directory&KingdomId=<?= $kingdom_id ?>"><i class="fas fa-crown"></i> Park Officer Directory</a></li>
 						</ul>
@@ -646,8 +647,7 @@
 							<li><a href="<?= UIR ?>Reports/player_awards&Ladder=8&KingdomId=<?= $kingdom_id ?>"><?= $entityLabel ?>-level Awards</a></li>
 							<li><a href="<?= UIR ?>Reports/class_masters&KingdomId=<?= $kingdom_id ?>">Class Masters/Paragons</a></li>
 							<li><a href="<?= UIR ?>Reports/ladder_grid&KingdomId=<?= $kingdom_id ?>">Ladder Award Grid</a></li>
-							<li><a href="<?= UIR ?>Reports/guilds&KingdomId=<?= $kingdom_id ?>"><?= $entityLabel ?> Guilds</a></li>
-							<li><a href="<?= UIR ?>Reports/custom_awards&KingdomId=<?= $kingdom_id ?>">Custom Awards</a></li>
+											<li><a href="<?= UIR ?>Reports/custom_awards&KingdomId=<?= $kingdom_id ?>">Custom Awards</a></li>
 							<li><a href="<?= UIR ?>Reports/beltline_explorer&KingdomId=<?= $kingdom_id ?>"><i class="fas fa-sitemap"></i> Beltline Explorer</a></li>
 							<?php endif; ?>
 						</ul>
@@ -1792,12 +1792,17 @@ var KnConfig = {
 
 <!-- Move Player Modal -->
 <style>
-.kn-mp-toggle { display:flex; background:#edf2f7; border-radius:6px; padding:3px; gap:3px; margin-bottom:14px; }
+.kn-mp-toggle { display:flex; flex-wrap:wrap; gap:6px; margin-bottom:14px; }
 .kn-mp-toggle-btn {
-	flex:1; padding:6px 8px; border:none; border-radius:4px; font-size:11px; font-weight:600;
-	cursor:pointer; background:transparent; color:#718096; transition:background 0.15s,color 0.15s; white-space:nowrap;
+	flex:1 1 auto; min-width:130px; padding:7px 10px; border:1px solid #cbd5e0; border-radius:6px; font-size:12px; font-weight:600;
+	cursor:pointer; background:#fff; color:#4a5568; transition:background 0.15s,color 0.15s,border-color 0.15s; white-space:nowrap;
 }
-.kn-mp-toggle-btn.kn-mp-active { background:#fff; color:#2b6cb0; box-shadow:0 1px 3px rgba(0,0,0,0.1); }
+.kn-mp-toggle-btn:hover { border-color:#a0aec0; }
+.kn-mp-toggle-btn.kn-mp-active { background:#2b6cb0; color:#fff; border-color:#2b6cb0; box-shadow:0 1px 3px rgba(0,0,0,0.15); }
+/* Cascade filter dropdowns (Move Player) */
+.kn-mp-cascade { display:flex; flex-wrap:wrap; gap:6px; margin-bottom:6px; }
+.kn-mp-cascade-sel { flex:1 1 140px; min-width:0; font-size:12px; padding:6px 8px; border:1px solid #cbd5e0; border-radius:6px; background:#fff; color:#4a5568; }
+.kn-mp-cascade-sel:disabled { background:#edf2f7; color:#718096; cursor:not-allowed; }
 #kn-moveplayer-overlay .kn-modal-body { overflow:visible; }
 #kn-moveplayer-overlay .kn-acct-field { position:relative; }
 #kn-moveplayer-overlay .kn-ac-results { position:absolute; left:0; right:0; z-index:9999; }
@@ -1876,9 +1881,11 @@ html[data-theme="dark"] .kn-acct-field input[type="date"],
 html[data-theme="dark"] .kn-acct-field input[type="number"],
 html[data-theme="dark"] .kn-acct-field select,
 html[data-theme="dark"] .kn-acct-field textarea { background: var(--ork-input-bg); border-color: var(--ork-input-border); color: var(--ork-text); }
-html[data-theme="dark"] .kn-mp-toggle { background: var(--ork-bg-secondary); }
-html[data-theme="dark"] .kn-mp-toggle-btn { color: var(--ork-text-muted); }
-html[data-theme="dark"] .kn-mp-toggle-btn.kn-mp-active { background: var(--ork-card-bg); color: var(--ork-link); }
+html[data-theme="dark"] .kn-mp-toggle-btn { background: var(--ork-bg-secondary); color: var(--ork-text-secondary); border-color: var(--ork-border); }
+html[data-theme="dark"] .kn-mp-toggle-btn:hover { border-color: var(--ork-text-muted); }
+html[data-theme="dark"] .kn-mp-toggle-btn.kn-mp-active { background: var(--ork-link); color: #fff; border-color: var(--ork-link); }
+html[data-theme="dark"] .kn-mp-cascade-sel { background: var(--ork-input-bg); color: var(--ork-text); border-color: var(--ork-input-border); }
+html[data-theme="dark"] .kn-mp-cascade-sel:disabled { background: var(--ork-bg-tertiary); color: var(--ork-text-muted); }
 html[data-theme="dark"] #theme_container .kn-reports-grid a { color: var(--ork-link); }
 html[data-theme="dark"] #theme_container .kn-reports-grid a:hover { color: var(--ork-link-bright); }
 html[data-theme="dark"] .kn-map-sidebar-card { background: var(--ork-card-bg); border-color: var(--ork-border); color: var(--ork-text); }
@@ -1913,15 +1920,21 @@ html[data-theme="dark"] .kn-btn-danger { background: #fc8181; color: #1a202c; bo
 			</div>
 			<div class="kn-acct-field">
 				<label id="kn-moveplayer-player-label">Player <span style="color:#e53e3e">*</span></label>
+				<div class="kn-mp-cascade">
+					<select class="kn-mp-cascade-sel" id="kn-mp-pfilter-kingdom" aria-label="Filter players by kingdom"></select>
+					<select class="kn-mp-cascade-sel" id="kn-mp-pfilter-park" aria-label="Filter players by park" style="display:none"></select>
+				</div>
 				<input type="text" id="kn-moveplayer-player-name" autocomplete="off" placeholder="Search players outside this kingdom&hellip;">
 				<input type="hidden" id="kn-moveplayer-player-id">
 				<div class="kn-ac-results" id="kn-moveplayer-player-results"></div>
 			</div>
 			<div class="kn-acct-field" style="margin-top:10px">
 				<label id="kn-moveplayer-park-label">New Home Park <span style="color:#e53e3e">*</span></label>
-				<input type="text" id="kn-moveplayer-park-name" autocomplete="off" placeholder="Search parks in this kingdom&hellip;">
+				<div class="kn-mp-cascade">
+					<select class="kn-mp-cascade-sel" id="kn-mp-dfilter-kingdom" aria-label="Destination kingdom"></select>
+					<select class="kn-mp-cascade-sel" id="kn-mp-dfilter-park" aria-label="Destination park" style="display:none"></select>
+				</div>
 				<input type="hidden" id="kn-moveplayer-park-id">
-				<div class="kn-ac-results" id="kn-moveplayer-park-results"></div>
 			</div>
 		</div>
 		<div class="kn-modal-footer">

--- a/orkui/template/revised-frontend/Parknew_index.tpl
+++ b/orkui/template/revised-frontend/Parknew_index.tpl
@@ -1096,6 +1096,7 @@
 							<li><a href="<?= UIR ?>Reports/reeve&KingdomId=<?= $kingdom_id ?>&ParkId=<?= $park_id ?>">Reeve Qualified</a></li>
 							<li><a href="<?= UIR ?>Reports/corpora&KingdomId=<?= $kingdom_id ?>&ParkId=<?= $park_id ?>">Corpora Qualified</a></li>
 							<li><a href="<?= UIR ?>Reports/player_status_reconciliation/Park&id=<?= $park_id ?>">Player Status Reconciliation</a></li>
+							<li><a href="<?= UIR ?>Reports/guilds&KingdomId=<?= $kingdom_id ?>&ParkId=<?= $park_id ?>">Park Guilds</a></li>
 							<li><a href="<?= UIR ?>Reports/closest_parks&ParkId=<?= $park_id ?>"><i class="fas fa-map-marker-alt"></i> Closest Parks</a></li>
 							<?php endif; ?>
 						</ul>
@@ -1126,8 +1127,7 @@
 							<li><a href="<?= UIR ?>Reports/player_awards&Ladder=0&KingdomId=<?= $kingdom_id ?>&ParkId=<?= $park_id ?>">Player Awards</a></li>
 							<li><a href="<?= UIR ?>Reports/class_masters&KingdomId=<?= $kingdom_id ?>&ParkId=<?= $park_id ?>">Class Masters</a></li>
 							<li><a href="<?= UIR ?>Reports/ladder_grid&KingdomId=<?= $kingdom_id ?>&ParkId=<?= $park_id ?>">Ladder Award Grid</a></li>
-							<li><a href="<?= UIR ?>Reports/guilds&KingdomId=<?= $kingdom_id ?>&ParkId=<?= $park_id ?>">Park Guilds</a></li>
-							<li><a href="<?= UIR ?>Reports/custom_awards&KingdomId=<?= $kingdom_id ?>&ParkId=<?= $park_id ?>">Custom Awards</a></li>
+											<li><a href="<?= UIR ?>Reports/custom_awards&KingdomId=<?= $kingdom_id ?>&ParkId=<?= $park_id ?>">Custom Awards</a></li>
 						</ul>
 					</div>
 					<?php endif; ?>
@@ -1981,12 +1981,16 @@ var PkConfig = {
 
 <!-- Move Player Modal -->
 <style>
-.pk-mp-toggle { display:flex; background:#edf2f7; border-radius:6px; padding:3px; gap:3px; margin-bottom:14px; }
+.pk-mp-toggle { display:flex; flex-wrap:wrap; gap:6px; margin-bottom:14px; }
 .pk-mp-toggle-btn {
-	flex:1; padding:6px 10px; border:none; border-radius:4px; font-size:12px; font-weight:600;
-	cursor:pointer; background:transparent; color:#718096; transition:background 0.15s,color 0.15s;
+	flex:1 1 auto; min-width:130px; padding:7px 10px; border:1px solid #cbd5e0; border-radius:6px; font-size:12px; font-weight:600;
+	cursor:pointer; background:#fff; color:#4a5568; transition:background 0.15s,color 0.15s,border-color 0.15s; white-space:nowrap;
 }
-.pk-mp-toggle-btn.pk-mp-active { background:#fff; color:#2b6cb0; box-shadow:0 1px 3px rgba(0,0,0,0.1); }
+.pk-mp-toggle-btn:hover { border-color:#a0aec0; }
+.pk-mp-toggle-btn.pk-mp-active { background:#2b6cb0; color:#fff; border-color:#2b6cb0; box-shadow:0 1px 3px rgba(0,0,0,0.15); }
+.pk-mp-cascade { display:flex; flex-wrap:wrap; gap:6px; margin-bottom:6px; }
+.pk-mp-cascade-sel { flex:1 1 140px; min-width:0; font-size:12px; padding:6px 8px; border:1px solid #cbd5e0; border-radius:6px; background:#fff; color:#4a5568; }
+.pk-mp-cascade-sel:disabled { background:#edf2f7; color:#718096; cursor:not-allowed; }
 
 /* ===================================================================
    DARK MODE OVERRIDES — Parknew profile
@@ -2024,9 +2028,11 @@ html[data-theme="dark"] .pk-acct-field input[type="date"],
 html[data-theme="dark"] .pk-acct-field input[type="number"],
 html[data-theme="dark"] .pk-acct-field select,
 html[data-theme="dark"] .pk-acct-field textarea { background: var(--ork-input-bg); border-color: var(--ork-input-border); color: var(--ork-text); }
-html[data-theme="dark"] .pk-mp-toggle { background: var(--ork-bg-secondary); }
-html[data-theme="dark"] .pk-mp-toggle-btn { color: var(--ork-text-muted); }
-html[data-theme="dark"] .pk-mp-toggle-btn.pk-mp-active { background: var(--ork-card-bg); color: var(--ork-link); }
+html[data-theme="dark"] .pk-mp-toggle-btn { background: var(--ork-bg-secondary); color: var(--ork-text-secondary); border-color: var(--ork-border); }
+html[data-theme="dark"] .pk-mp-toggle-btn:hover { border-color: var(--ork-text-muted); }
+html[data-theme="dark"] .pk-mp-toggle-btn.pk-mp-active { background: var(--ork-link); color: #fff; border-color: var(--ork-link); }
+html[data-theme="dark"] .pk-mp-cascade-sel { background: var(--ork-input-bg); color: var(--ork-text); border-color: var(--ork-input-border); }
+html[data-theme="dark"] .pk-mp-cascade-sel:disabled { background: var(--ork-bg-tertiary); color: var(--ork-text-muted); }
 html[data-theme="dark"] .pk-officer-item { border-color: var(--ork-border); }
 html[data-theme="dark"] .pk-officer-label { color: var(--ork-text-muted); }
 html[data-theme="dark"] .pk-officer-name { color: var(--ork-text); }
@@ -2073,15 +2079,21 @@ html[data-theme="dark"] .pk-wx-warning { background:#450a0a; color:#fca5a5; bord
 			</div>
 			<div class="pk-acct-field">
 				<label id="pk-moveplayer-player-label">Player <span style="color:#e53e3e">*</span></label>
+				<div class="pk-mp-cascade" id="pk-mp-pfilter-wrap">
+					<select class="pk-mp-cascade-sel" id="pk-mp-pfilter-kingdom" aria-label="Filter players by kingdom"></select>
+					<select class="pk-mp-cascade-sel" id="pk-mp-pfilter-park" aria-label="Filter players by park" style="display:none"></select>
+				</div>
 				<input type="text" id="pk-moveplayer-player-name" autocomplete="off" placeholder="Search by name, or KD:PK name…">
 				<input type="hidden" id="pk-moveplayer-player-id">
 				<div class="pk-ac-results" id="pk-moveplayer-player-results"></div>
 			</div>
 			<div class="pk-acct-field" id="pk-moveplayer-park-section" style="margin-top:10px;display:none">
 				<label>New Home Park <span style="color:#e53e3e">*</span></label>
-				<input type="text" id="pk-moveplayer-park-name" autocomplete="off" placeholder="Search parks…">
+				<div class="pk-mp-cascade">
+					<select class="pk-mp-cascade-sel" id="pk-mp-dfilter-kingdom" aria-label="Destination kingdom"></select>
+					<select class="pk-mp-cascade-sel" id="pk-mp-dfilter-park" aria-label="Destination park" style="display:none"></select>
+				</div>
 				<input type="hidden" id="pk-moveplayer-park-id">
-				<div class="pk-ac-results" id="pk-moveplayer-park-results"></div>
 			</div>
 		</div>
 		<div class="pk-modal-footer">

--- a/orkui/template/revised-frontend/Playernew_index.tpl
+++ b/orkui/template/revised-frontend/Playernew_index.tpl
@@ -456,9 +456,11 @@ html[data-theme="dark"] .pn-suspended-detail { background: #742a2a; color: #feb2
 html[data-theme="dark"] .pn-revoke-all-warning { background: #742a2a; border-color: #9b2c2c; color: #feb2b2; }
 html[data-theme="dark"] .pn-move-warning { background: #744210; border-color: #975a16; color: #fbd38d; }
 html[data-theme="dark"] .pn-mp-player-locked { background: var(--ork-bg-secondary); border-color: var(--ork-border); color: var(--ork-text-secondary); }
-html[data-theme="dark"] .pn-mp-toggle { background: var(--ork-bg-secondary); }
-html[data-theme="dark"] .pn-mp-toggle-btn { color: var(--ork-text-muted); }
-html[data-theme="dark"] .pn-mp-toggle-btn.pn-mp-active { background: var(--ork-card-bg); color: var(--ork-link); }
+html[data-theme="dark"] .pn-mp-toggle-btn { background: var(--ork-bg-secondary); color: var(--ork-text-secondary); border-color: var(--ork-border); }
+html[data-theme="dark"] .pn-mp-toggle-btn:hover { border-color: var(--ork-text-muted); }
+html[data-theme="dark"] .pn-mp-toggle-btn.pn-mp-active { background: var(--ork-link); color: #fff; border-color: var(--ork-link); }
+html[data-theme="dark"] .pn-mp-cascade-sel { background: var(--ork-input-bg); color: var(--ork-text); border-color: var(--ork-input-border); }
+html[data-theme="dark"] .pn-mp-cascade-sel:disabled { background: var(--ork-bg-tertiary); color: var(--ork-text-muted); }
 html[data-theme="dark"] .btn-danger-confirm { background: #fc8181; color: #1a202c; }
 html[data-theme="dark"] .pn-char-count { color: var(--ork-text-muted); }
 html[data-theme="dark"] .pn-revoke-award-name { color: var(--ork-text); }
@@ -4924,9 +4926,13 @@ pnRenderSparkline();
 <!-- Move Player Modal -->
 <?php if ($canEditAdmin): ?>
 <style>
-.pn-mp-toggle { display:flex; background:#edf2f7; border-radius:6px; padding:3px; gap:3px; margin-bottom:14px; }
-.pn-mp-toggle-btn { flex:1; padding:6px 8px; border:none; border-radius:4px; font-size:11px; font-weight:600; cursor:pointer; background:transparent; color:#718096; white-space:nowrap; }
-.pn-mp-toggle-btn.pn-mp-active { background:#fff; color:#2b6cb0; box-shadow:0 1px 3px rgba(0,0,0,0.1); }
+.pn-mp-toggle { display:flex; flex-wrap:wrap; gap:6px; margin-bottom:14px; }
+.pn-mp-toggle-btn { flex:1 1 auto; min-width:130px; padding:7px 10px; border:1px solid #cbd5e0; border-radius:6px; font-size:12px; font-weight:600; cursor:pointer; background:#fff; color:#4a5568; white-space:nowrap; }
+.pn-mp-toggle-btn:hover { border-color:#a0aec0; }
+.pn-mp-toggle-btn.pn-mp-active { background:#2b6cb0; color:#fff; border-color:#2b6cb0; box-shadow:0 1px 3px rgba(0,0,0,0.15); }
+.pn-mp-cascade { display:flex; flex-wrap:wrap; gap:6px; margin-bottom:6px; }
+.pn-mp-cascade-sel { flex:1 1 140px; min-width:0; font-size:12px; padding:6px 8px; border:1px solid #cbd5e0; border-radius:6px; background:#fff; color:#4a5568; }
+.pn-mp-cascade-sel:disabled { background:#edf2f7; color:#718096; cursor:not-allowed; }
 #pn-moveplayer-overlay .pn-modal-body { overflow:visible; }
 #pn-moveplayer-overlay .pn-acct-field { position:relative; }
 .pn-mp-player-locked { background:#f7fafc; border:1px solid #e2e8f0; border-radius:4px; padding:8px 12px; color:#4a5568; font-size:0.95rem; }
@@ -4952,9 +4958,11 @@ pnRenderSparkline();
 			</div>
 			<div class="pn-acct-field">
 				<label id="pn-moveplayer-park-label">New Home Park <span class="required-indicator">*</span></label>
-				<input type="text" id="pn-moveplayer-park-name" placeholder="Search for a park…" autocomplete="off" />
+				<div class="pn-mp-cascade">
+					<select class="pn-mp-cascade-sel" id="pn-mp-dfilter-kingdom" aria-label="Destination kingdom"></select>
+					<select class="pn-mp-cascade-sel" id="pn-mp-dfilter-park" aria-label="Destination park" style="display:none"></select>
+				</div>
 				<input type="hidden" id="pn-moveplayer-park-id" value="" />
-				<div class="pn-ac-results" id="pn-moveplayer-park-results"></div>
 			</div>
 			<div class="pn-move-warning">
 				<i class="fas fa-exclamation-triangle"></i>

--- a/orkui/template/revised-frontend/Playernew_index.tpl
+++ b/orkui/template/revised-frontend/Playernew_index.tpl
@@ -1855,11 +1855,9 @@ html[data-theme="dark"] .pn-cms-line strong { color: var(--ork-text-muted); }
 								if (isset($pnHeldAwardIds[$masterId])) { $hasMaster = true; break; }
 							}
 						}
-						// Dedup key combines rank AND date so historical rows that were never
-						// reconciled past rank=1 (legitimate distinct earnings on different dates)
-						// each count, while true duplicate rows (same rank, same date from old
-						// imports) still collapse.
-						$rankKey = $rank . '|' . ($a['Date'] ?? '');
+						// Dedup key is rank only — two awards at the same rank from different
+						// parks or dates are still the same rank, not two separate levels.
+						$rankKey = $rank;
 						if (!isset($pnLadderProgress[$aid])) {
 							$pnLadderProgress[$aid] = ['Name' => $displayName, 'Short' => $shortName, 'Rank' => $rank,
 								'RankSet' => $rank > 0 ? [$rankKey => true] : [], 'UnrankedCount' => $rank === 0 ? 1 : 0, 'HasMaster' => $hasMaster];

--- a/orkui/template/revised-frontend/script/revised.js
+++ b/orkui/template/revised-frontend/script/revised.js
@@ -46,6 +46,114 @@ function escHtml(str) {
 var AUTOCOMPLETE_DEBOUNCE_MS = 250;
 var AWARD_NOTE_MAX_CHARS     = 400;
 
+/* ===========================================================================
+   Move Player cascade helper
+   Turns a Kingdom <select> + Park <select> pair into a cascading filter:
+   choosing a kingdom loads its parks; selection changes fire onChange so the
+   owning search can re-scope. Used by every Move Player modal (Kingdom, Park,
+   Player, Admin) for both the source-player and destination-park searches.
+   =========================================================================== */
+window.MpCascade = (function () {
+    var kingdomsCache = null, kingdomsPromise = null;
+
+    function loadKingdoms(uir) {
+        if (kingdomsCache) return Promise.resolve(kingdomsCache);
+        if (!kingdomsPromise) {
+            kingdomsPromise = fetch(uir + 'KingdomAjax/getkingdoms')
+                .then(function (r) { return r.json(); })
+                .then(function (d) { kingdomsCache = (d && d.kingdoms) || []; return kingdomsCache; })
+                .catch(function () { kingdomsPromise = null; return []; });
+        }
+        return kingdomsPromise;
+    }
+    function loadParks(uir, kingdomId) {
+        return fetch(uir + 'KingdomAjax/kingdom/' + kingdomId + '/getparks')
+            .then(function (r) { return r.json(); })
+            .then(function (d) { return (d && d.parks) || []; })
+            .catch(function () { return []; });
+    }
+
+    /**
+     * wire(opts) — wires a kingdom/park <select> pair as a cascade.
+     *   opts.uir         base UIR
+     *   opts.kingdomSel  kingdom <select> element
+     *   opts.parkSel     park <select> element
+     *   opts.allLabel    label for the "no filter" kingdom option (default 'All Kingdoms'); null to omit
+     *   opts.parkAllLabel label for the "no filter" park option (default 'All Parks')
+     *   opts.onChange    fn(kingdomId, parkId) on any selection change
+     * returns { get(), reset(), lockTo(kingdomId, name) }
+     */
+    function wire(opts) {
+        var kSel = opts.kingdomSel, pSel = opts.parkSel, uir = opts.uir;
+        var allLabel     = (opts.allLabel === undefined) ? 'All Kingdoms' : opts.allLabel;
+        var parkAllLabel = opts.parkAllLabel || 'All Parks';
+
+        function fire() {
+            if (opts.onChange) opts.onChange(parseInt(kSel.value, 10) || 0, parseInt(pSel.value, 10) || 0);
+        }
+        function resetPark(show) {
+            pSel.innerHTML = '<option value="">' + escHtml(parkAllLabel) + '</option>';
+            pSel.style.display = show ? '' : 'none';
+        }
+        function fillParks(kingdomId) {
+            return loadParks(uir, kingdomId).then(function (parks) {
+                resetPark(true);
+                parks.forEach(function (pk) {
+                    var o = document.createElement('option');
+                    o.value = pk.ParkId; o.textContent = pk.Name;
+                    pSel.appendChild(o);
+                });
+            });
+        }
+        function populate() {
+            return loadKingdoms(uir).then(function (kingdoms) {
+                kSel.innerHTML = (allLabel !== null ? '<option value="">' + escHtml(allLabel) + '</option>' : '');
+                kingdoms.forEach(function (k) {
+                    var o = document.createElement('option');
+                    o.value = k.KingdomId; o.textContent = k.KingdomName;
+                    kSel.appendChild(o);
+                });
+            });
+        }
+
+        kSel.addEventListener('change', function () {
+            var kid = parseInt(this.value, 10) || 0;
+            if (kid) fillParks(kid).then(fire);
+            else { resetPark(false); fire(); }
+        });
+        pSel.addEventListener('change', fire);
+
+        resetPark(false);
+        populate();
+
+        return {
+            get: function () { return { kingdomId: parseInt(kSel.value, 10) || 0, parkId: parseInt(pSel.value, 10) || 0 }; },
+            reset: function () {
+                kSel.disabled = false;
+                populate().then(function () { kSel.value = ''; resetPark(false); fire(); });
+            },
+            /* Lock the kingdom to a single value (disabled select) but keep the
+               park dropdown usable — used for "within"/"out" where the player
+               must come from the current kingdom. */
+            lockTo: function (kingdomId, name) {
+                function render(nm) {
+                    kSel.innerHTML = '<option value="' + kingdomId + '">' + escHtml(nm || 'This Kingdom') + '</option>';
+                    kSel.value = String(kingdomId);
+                    kSel.disabled = true;
+                    fillParks(kingdomId).then(fire);
+                }
+                if (name) { render(name); return; }
+                loadKingdoms(uir).then(function (ks) {
+                    var f = ks.filter(function (k) { return String(k.KingdomId) === String(kingdomId); })[0];
+                    render(f ? f.KingdomName : null);
+                });
+            }
+        };
+    }
+
+    return { loadKingdoms: loadKingdoms, loadParks: loadParks, wire: wire };
+})();
+
 /* ===========================
    Award descriptions (keyed by base AwardId)
    =========================== */
@@ -8748,7 +8856,9 @@ function setupPronounPicker(cfg) {
                     // SearchService already returns inactive and suspended players; sort
                     // them last and badge them so users can knowingly attribute historical
                     // awards to a now-banned officer during reconciliation.
-                    var url = SEARCH_URL + '?Action=Search%2FPlayer&type=all&search=' + encodeURIComponent(term) + '&kingdom_id=' + PnConfig.kingdomId + '&limit=15';
+                    // Award giver is intentionally global (cross-kingdom): a noble from another kingdom
+                    // can grant an award, so do not scope the giver search by kingdom.
+                    var url = SEARCH_URL + '?Action=Search%2FPlayer&type=all&search=' + encodeURIComponent(term) + '&limit=15';
                     fetch(url).then(function(r) { return r.json(); }).then(function(data) {
                         if (!data || !data.length) {
                             editGbResults.innerHTML = '<div class="pn-ac-no-results">No players found</div>';
@@ -10274,6 +10384,7 @@ function setupAcKeyNav(inputEl, resultsEl, itemSel, focusedClass, selectFn) {
     var PARK_URL  = PnConfig.httpService + 'Search/SearchService.php';
     var MOVE_URL  = PnConfig.uir + 'PlayerAjax/player/' + PnConfig.playerId + '/moveplayer';
     var pnmpMode  = 'within';
+    var pnDestCascade = null;
     var mpParkTimer;
 
     function gid(id) { return document.getElementById(id); }
@@ -10307,6 +10418,12 @@ function setupAcKeyNav(inputEl, resultsEl, itemSel, focusedClass, selectFn) {
         if (parkResults) parkResults.classList.remove('pn-ac-open');
         var btn = gid('pn-move-submit');
         if (btn) btn.disabled = true;
+        // Destination cascade: locked to the player's kingdom for 'within',
+        // free to pick any kingdom for 'out'.
+        if (pnDestCascade) {
+            if (mode === 'within') pnDestCascade.lockTo(PnConfig.kingdomId);
+            else pnDestCascade.reset();
+        }
     }
 
     function closeMovePlayer() {
@@ -10339,6 +10456,22 @@ function setupAcKeyNav(inputEl, resultsEl, itemSel, focusedClass, selectFn) {
             if (btn) btn.addEventListener('click', function() { setMode(m); });
         });
 
+        // Destination cascade (Kingdom -> Park)
+        if (gid('pn-mp-dfilter-kingdom')) {
+            pnDestCascade = MpCascade.wire({
+                uir: PnConfig.uir,
+                kingdomSel: gid('pn-mp-dfilter-kingdom'),
+                parkSel: gid('pn-mp-dfilter-park'),
+                allLabel: 'Select Kingdom',
+                parkAllLabel: 'Select Park',
+                onChange: function(kingdomId, parkId) {
+                    var btn = gid('pn-move-submit');
+                    gid('pn-moveplayer-park-id').value = parkId ? parkId : '';
+                    if (btn) btn.disabled = !parkId;
+                }
+            });
+        }
+
         // Close handlers
         $(document).on('click', '#pn-moveplayer-close-btn, #pn-move-cancel', function() { closeMovePlayer(); });
         $(document).on('click', '#pn-moveplayer-overlay', function(e) {
@@ -10369,7 +10502,10 @@ function setupAcKeyNav(inputEl, resultsEl, itemSel, focusedClass, selectFn) {
                 clearTimeout(mpParkTimer);
                 mpParkTimer = setTimeout(function() {
                     var params = { Action: 'Search/Park', name: term, limit: 12 };
-                    if (pnmpMode === 'within') {
+                    var dsel = pnDestCascade ? pnDestCascade.get() : { kingdomId: 0, parkId: 0 };
+                    if (dsel.kingdomId) {
+                        params.kingdom_id = dsel.kingdomId;
+                    } else if (pnmpMode === 'within') {
                         params.kingdom_id = PnConfig.kingdomId;
                     } else {
                         params.exclude_kingdom_id = PnConfig.kingdomId;
@@ -10691,10 +10827,12 @@ window.pnCloseUnitCreateModal = function() {
 
     var MOVE_URL    = KnConfig.uir + 'KingdomAjax/kingdom/' + KnConfig.kingdomId + '/moveplayer';
     var PSEARCH_URL = KnConfig.uir + 'KingdomAjax/playersearch/' + KnConfig.kingdomId;
+    var PSEARCH_BASE = KnConfig.uir + 'KingdomAjax/playersearch/';
     var PARK_URL    = KnConfig.httpService + 'Search/SearchService.php';
 
     // Modes: 'in' | 'within' | 'out'
     var knmpMode = 'in';
+    var knmpPlayerCascade = null, knmpDestCascade = null;
 
     function gid(id) { return document.getElementById(id); }
 
@@ -10725,33 +10863,39 @@ window.pnCloseUnitCreateModal = function() {
             if (btn) btn.classList.toggle('kn-mp-active', m === mode);
         });
         var playerInput = gid('kn-moveplayer-player-name');
-        var parkInput   = gid('kn-moveplayer-park-name');
         var playerLabel = gid('kn-moveplayer-player-label');
         var parkLabel   = gid('kn-moveplayer-park-label');
         if (mode === 'in') {
             playerInput.placeholder = 'Search by name, or KD:PK name\u2026';
-            parkInput.placeholder   = 'Search parks in this kingdom\u2026';
             if (playerLabel) playerLabel.innerHTML = 'Player (outside kingdom) <span style="color:#e53e3e">*</span>';
             if (parkLabel)   parkLabel.innerHTML   = 'Destination Park (in kingdom) <span style="color:#e53e3e">*</span>';
         } else if (mode === 'within') {
             playerInput.placeholder = 'Search kingdom members\u2026';
-            parkInput.placeholder   = 'Search parks in this kingdom\u2026';
             if (playerLabel) playerLabel.innerHTML = 'Player <span style="color:#e53e3e">*</span>';
             if (parkLabel)   parkLabel.innerHTML   = 'New Home Park <span style="color:#e53e3e">*</span>';
         } else {
             playerInput.placeholder = 'Search kingdom members\u2026';
-            parkInput.placeholder   = 'Search parks outside this kingdom\u2026';
             if (playerLabel) playerLabel.innerHTML = 'Player <span style="color:#e53e3e">*</span>';
             if (parkLabel)   parkLabel.innerHTML   = 'Destination Park (outside kingdom) <span style="color:#e53e3e">*</span>';
         }
         // Reset fields
         playerInput.value = '';
-        parkInput.value   = '';
         gid('kn-moveplayer-player-id').value = '';
         gid('kn-moveplayer-park-id').value   = '';
         gid('kn-moveplayer-player-results').classList.remove('kn-ac-open');
-        gid('kn-moveplayer-park-results').classList.remove('kn-ac-open');
         gid('kn-moveplayer-feedback').style.display = 'none';
+        // Source-player cascade: free for 'in' (search other kingdoms), locked to
+        // the current kingdom for 'within'/'out' (park dropdown stays usable).
+        if (knmpPlayerCascade) {
+            if (mode === 'in') knmpPlayerCascade.reset();
+            else knmpPlayerCascade.lockTo(KnConfig.kingdomId, KnConfig.kingdomName);
+        }
+        // Destination cascade: free for 'out' (pick target kingdom), locked to the
+        // current kingdom otherwise (destination park is in-kingdom).
+        if (knmpDestCascade) {
+            if (mode === 'out') knmpDestCascade.reset();
+            else knmpDestCascade.lockTo(KnConfig.kingdomId, KnConfig.kingdomName);
+        }
         knmpCheckSubmit();
     }
 
@@ -10784,28 +10928,60 @@ window.pnCloseUnitCreateModal = function() {
             if (btn) btn.addEventListener('click', function() { setMode(m); });
         });
 
-        // Player autocomplete
+        // Cascade filters (Kingdom -> Park) for source player and destination park
+        knmpPlayerCascade = MpCascade.wire({
+            uir: KnConfig.uir,
+            kingdomSel: gid('kn-mp-pfilter-kingdom'),
+            parkSel: gid('kn-mp-pfilter-park'),
+            onChange: function() { knmpDoPlayerSearch(); }
+        });
+        knmpDestCascade = MpCascade.wire({
+            uir: KnConfig.uir,
+            kingdomSel: gid('kn-mp-dfilter-kingdom'),
+            parkSel: gid('kn-mp-dfilter-park'),
+            allLabel: 'Select Kingdom',
+            parkAllLabel: 'Select Park',
+            onChange: function(kingdomId, parkId) {
+                gid('kn-moveplayer-park-id').value = parkId ? parkId : '';
+                knmpCheckSubmit();
+            }
+        });
+
+        // Player autocomplete (scoped by mode + cascade filter)
+        function knmpPlayerUrl(term) {
+            var sel = knmpPlayerCascade ? knmpPlayerCascade.get() : { kingdomId: 0, parkId: 0 };
+            var kid, scope;
+            if (knmpMode === 'in') {
+                if (sel.kingdomId) { kid = sel.kingdomId; scope = 'own'; }   // a specific other kingdom
+                else { kid = KnConfig.kingdomId; scope = 'exclude'; }        // all kingdoms except this one
+            } else {
+                kid = KnConfig.kingdomId; scope = 'own';                     // within/out: locked to this kingdom
+            }
+            return PSEARCH_BASE + kid + '&scope=' + scope + '&include_inactive=1'
+                + (sel.parkId ? '&park_id=' + sel.parkId : '')
+                + '&q=' + encodeURIComponent(term);
+        }
+        function knmpDoPlayerSearch() {
+            var term = gid('kn-moveplayer-player-name').value.trim();
+            var el = gid('kn-moveplayer-player-results');
+            if (term.length < 2) { el.classList.remove('kn-ac-open'); return; }
+            fetch(knmpPlayerUrl(term))
+                .then(function(r) { return r.json(); })
+                .then(function(data) {
+                    el.innerHTML = (data && data.length)
+                        ? data.map(function(p) {
+                            var inactive = p.Active === 0 ? ' <span style="color:#e53e3e;font-size:10px;font-weight:600">inactive</span>' : '';
+                            return '<div class="kn-ac-item" data-id="' + p.MundaneId + '" data-name="' + encodeURIComponent(p.Persona) + '">'
+                                + escHtml(p.Persona) + ' <span style="color:#a0aec0;font-size:11px">(' + escHtml(p.KAbbr || '') + ':' + escHtml(p.PAbbr || '') + ')</span>' + inactive + '</div>';
+                        }).join('')
+                        : '<div class="kn-ac-item" style="color:#a0aec0;cursor:default">No players found</div>';
+                    el.classList.add('kn-ac-open');
+                }).catch(function(err) { if (err.name !== 'AbortError') console.warn('[revised.js] fetch failed:', err); });
+        }
         gid('kn-moveplayer-player-name').addEventListener('input', function() {
             gid('kn-moveplayer-player-id').value = '';
             clearTimeout(mpPlayerTimer);
-            var term = this.value.trim();
-            if (term.length < 2) { gid('kn-moveplayer-player-results').classList.remove('kn-ac-open'); return; }
-            mpPlayerTimer = setTimeout(function() {
-                var scope = (knmpMode === 'in') ? 'exclude' : 'own';
-                fetch(PSEARCH_URL + '&scope=' + scope + '&include_inactive=1&q=' + encodeURIComponent(term))
-                    .then(function(r) { return r.json(); })
-                    .then(function(data) {
-                        var el = gid('kn-moveplayer-player-results');
-                        el.innerHTML = (data && data.length)
-                            ? data.map(function(p) {
-                                var inactive = p.Active === 0 ? ' <span style="color:#e53e3e;font-size:10px;font-weight:600">inactive</span>' : '';
-                                return '<div class="kn-ac-item" data-id="' + p.MundaneId + '" data-name="' + encodeURIComponent(p.Persona) + '">'
-                                    + escHtml(p.Persona) + ' <span style="color:#a0aec0;font-size:11px">(' + escHtml(p.KAbbr || '') + ':' + escHtml(p.PAbbr || '') + ')</span>' + inactive + '</div>';
-                            }).join('')
-                            : '<div class="kn-ac-item" style="color:#a0aec0;cursor:default">No players found</div>';
-                        el.classList.add('kn-ac-open');
-                    }).catch(function(err) { if (err.name !== 'AbortError') console.warn('[revised.js] fetch failed:', err); });
-            }, AUTOCOMPLETE_DEBOUNCE_MS);
+            mpPlayerTimer = setTimeout(knmpDoPlayerSearch, AUTOCOMPLETE_DEBOUNCE_MS);
         });
         gid('kn-moveplayer-player-results').addEventListener('click', function(e) {
             var item = e.target.closest('.kn-ac-item[data-id]');
@@ -10820,44 +10996,7 @@ window.pnCloseUnitCreateModal = function() {
         });
         setupAcKeyNav(gid('kn-moveplayer-player-name'), gid('kn-moveplayer-player-results'), '.kn-ac-item[data-id]', 'kn-ac-focused', function(item) { item.click(); });
 
-        // Park autocomplete
-        gid('kn-moveplayer-park-name').addEventListener('input', function() {
-            gid('kn-moveplayer-park-id').value = '';
-            clearTimeout(mpParkTimer);
-            var term = this.value.trim();
-            if (term.length < 2) { gid('kn-moveplayer-park-results').classList.remove('kn-ac-open'); return; }
-            mpParkTimer = setTimeout(function() {
-                var params = { Action: 'Search/Park', name: term, limit: 10 };
-                if (knmpMode === 'in' || knmpMode === 'within') {
-                    params.kingdom_id = KnConfig.kingdomId;
-                } else {
-                    params.exclude_kingdom_id = KnConfig.kingdomId;
-                }
-                $.getJSON(PARK_URL, params, function(data) {
-                    var el = gid('kn-moveplayer-park-results');
-                    el.innerHTML = (data && data.length)
-                        ? data.map(function(pk) {
-                            var sub = pk.KingdomName ? ' <span style="color:#a0aec0;font-size:11px">(' + escHtml(pk.KingdomName) + ')</span>' : '';
-                            return '<div class="kn-ac-item" data-id="' + pk.ParkId + '" data-name="' + encodeURIComponent(pk.Name) + '">'
-                                + escHtml(pk.Name) + sub + '</div>';
-                        }).join('')
-                        : '<div class="kn-ac-item" style="color:#a0aec0;cursor:default">No parks found</div>';
-                    el.classList.add('kn-ac-open');
-                });
-            }, AUTOCOMPLETE_DEBOUNCE_MS);
-        });
-        gid('kn-moveplayer-park-results').addEventListener('click', function(e) {
-            var item = e.target.closest('.kn-ac-item[data-id]');
-            if (!item) return;
-            gid('kn-moveplayer-park-name').value = decodeURIComponent(item.dataset.name);
-            gid('kn-moveplayer-park-id').value   = item.dataset.id;
-            this.classList.remove('kn-ac-open');
-            knmpCheckSubmit();
-        });
-        gid('kn-moveplayer-park-name').addEventListener('input', function() {
-            if (!this.value.trim()) { gid('kn-moveplayer-park-id').value = ''; knmpCheckSubmit(); }
-        });
-        setupAcKeyNav(gid('kn-moveplayer-park-name'), gid('kn-moveplayer-park-results'), '.kn-ac-item[data-id]', 'kn-ac-focused', function(item) { item.click(); });
+        // Destination park is chosen via the Kingdom -> Park cascade (knmpDestCascade) — no free-text park search.
 
         gid('kn-moveplayer-submit').addEventListener('click', function() {
             var mundaneId = gid('kn-moveplayer-player-id').value;
@@ -11200,7 +11339,9 @@ window.pnCloseUnitCreateModal = function() {
     var MOVE_URL        = PkConfig.uir + 'ParkAjax/park/' + PkConfig.parkId + '/moveplayer';
     var PSEARCH_EXCLUDE = PkConfig.uir + 'ParkAjax/park/' + PkConfig.parkId + '/playersearch&scope=exclude&include_inactive=1&q=';
     var PSEARCH_OWN     = PkConfig.uir + 'ParkAjax/park/' + PkConfig.parkId + '/playersearch&scope=own&include_inactive=1&q=';
+    var KPSEARCH_BASE   = PkConfig.uir + 'KingdomAjax/playersearch/';
 
+    var pkPlayerCascade = null, pkDestCascade = null;
     var mpPlayerId = 0, mpParkId = 0;
     var mpPlayerTimer = null, mpParkTimer = null;
     var mpMode = 'in'; // 'in' = Transfer Into Your Park, 'out' = Transfer to New Park
@@ -11248,12 +11389,16 @@ window.pnCloseUnitCreateModal = function() {
         var fb = gid('pk-moveplayer-feedback');
         if (fb) { fb.style.display = 'none'; fb.textContent = ''; }
 
+        var pfilterWrap = gid('pk-mp-pfilter-wrap');
         if (mode === 'in') {
             if (btnIn)  btnIn.classList.add('pk-mp-active');
             if (btnOut) btnOut.classList.remove('pk-mp-active');
             if (parkSection) parkSection.style.display = 'none';
             if (playerInput) playerInput.placeholder = 'Search by name, or KD:PK name\u2026';
             mpParkId = PkConfig.parkId;
+            // Source player can come from anywhere: show the free cascade filter.
+            if (pfilterWrap) pfilterWrap.style.display = '';
+            if (pkPlayerCascade) pkPlayerCascade.reset();
         } else {
             if (btnOut) btnOut.classList.add('pk-mp-active');
             if (btnIn)  btnIn.classList.remove('pk-mp-active');
@@ -11264,6 +11409,10 @@ window.pnCloseUnitCreateModal = function() {
             gid('pk-moveplayer-park-id').value = '';
             closeDropdown('pk-moveplayer-park-results');
             mpParkId = 0;
+            // Player is a member of this park: cascade not useful, hide it.
+            if (pfilterWrap) pfilterWrap.style.display = 'none';
+            // Destination is a new park anywhere: free cascade to pick it.
+            if (pkDestCascade) pkDestCascade.reset();
         }
         pkmpCheckSubmit();
     }
@@ -11275,11 +11424,53 @@ window.pnCloseUnitCreateModal = function() {
         overlay.classList.add('pk-open');
     };
 
+    // Build the player-search URL from mode + cascade filter. For 'in', a chosen
+    // source kingdom routes through KingdomAjax (kingdom-scoped); with no kingdom
+    // it falls back to 'everyone not already in this park'. 'out' = this park's members.
+    function pkmpPlayerUrl(term) {
+        if (mpMode === 'in') {
+            var sel = pkPlayerCascade ? pkPlayerCascade.get() : { kingdomId: 0, parkId: 0 };
+            if (sel.kingdomId) {
+                return KPSEARCH_BASE + sel.kingdomId + '&scope=own&include_inactive=1'
+                    + (sel.parkId ? '&park_id=' + sel.parkId : '') + '&q=' + encodeURIComponent(term);
+            }
+            return PSEARCH_EXCLUDE + encodeURIComponent(term);
+        }
+        return PSEARCH_OWN + encodeURIComponent(term);
+    }
+
     document.addEventListener('DOMContentLoaded', function() {
         var btnIn  = gid('pk-mp-btn-in');
         var btnOut = gid('pk-mp-btn-out');
         if (btnIn)  btnIn.addEventListener('click',  function() { setMode('in');  });
         if (btnOut) btnOut.addEventListener('click', function() { setMode('out'); });
+
+        // Cascade filters (Kingdom -> Park)
+        if (gid('pk-mp-pfilter-kingdom')) {
+            pkPlayerCascade = MpCascade.wire({
+                uir: PkConfig.uir,
+                kingdomSel: gid('pk-mp-pfilter-kingdom'),
+                parkSel: gid('pk-mp-pfilter-park'),
+                onChange: function() {
+                    var inp = gid('pk-moveplayer-player-name');
+                    if (inp && inp.value.trim().length >= 2) inp.dispatchEvent(new Event('input'));
+                }
+            });
+        }
+        if (gid('pk-mp-dfilter-kingdom')) {
+            pkDestCascade = MpCascade.wire({
+                uir: PkConfig.uir,
+                kingdomSel: gid('pk-mp-dfilter-kingdom'),
+                parkSel: gid('pk-mp-dfilter-park'),
+                allLabel: 'Select Kingdom',
+                parkAllLabel: 'Select Park',
+                onChange: function(kingdomId, parkId) {
+                    mpParkId = parkId ? parkId : 0;
+                    gid('pk-moveplayer-park-id').value = parkId ? parkId : '';
+                    pkmpCheckSubmit();
+                }
+            });
+        }
 
         // Player autocomplete
         var playerInput = gid('pk-moveplayer-player-name');
@@ -11291,9 +11482,9 @@ window.pnCloseUnitCreateModal = function() {
                 pkmpCheckSubmit();
                 var term = this.value.trim();
                 if (term.length < 2) { closeDropdown('pk-moveplayer-player-results'); return; }
-                var searchUrl = (mpMode === 'in') ? PSEARCH_EXCLUDE : PSEARCH_OWN;
+                var searchUrl = pkmpPlayerUrl(term);
                 mpPlayerTimer = setTimeout(function() {
-                    fetch(searchUrl + encodeURIComponent(term))
+                    fetch(searchUrl)
                         .then(function(r) { return r.json(); })
                         .then(function(results) {
                             var res = gid('pk-moveplayer-player-results');
@@ -11347,7 +11538,10 @@ window.pnCloseUnitCreateModal = function() {
                 var term = this.value.trim();
                 if (term.length < 2) { closeDropdown('pk-moveplayer-park-results'); return; }
                 mpParkTimer = setTimeout(function() {
-                    $.getJSON(PkConfig.httpService + 'Search/SearchService.php', { Action: 'Search/Park', name: term, limit: 8 }, function(data) {
+                    var pkParams = { Action: 'Search/Park', name: term, limit: 8 };
+                    var dsel = pkDestCascade ? pkDestCascade.get() : { kingdomId: 0, parkId: 0 };
+                    if (dsel.kingdomId) pkParams.kingdom_id = dsel.kingdomId;
+                    $.getJSON(PkConfig.httpService + 'Search/SearchService.php', pkParams, function(data) {
                         var res = gid('pk-moveplayer-park-results');
                         if (!res) return;
                         res.innerHTML = '';
@@ -11399,7 +11593,6 @@ window.pnCloseUnitCreateModal = function() {
                         gid('pk-moveplayer-player-id').value = '';
                         if (mpMode === 'out') {
                             mpParkId = 0;
-                            gid('pk-moveplayer-park-name').value = '';
                             gid('pk-moveplayer-park-id').value = '';
                         }
                         pkmpCheckSubmit();

--- a/system/lib/ork3/class.Authorization.php
+++ b/system/lib/ork3/class.Authorization.php
@@ -214,7 +214,8 @@ class Authorization extends Ork3
 				} else if ($type == AUTH_UNIT) {
 					$mundane = Ork3::$Lib->player->player_info($requester_id);
 
-					if ($this->HasAuthority($requester_id, AUTH_KINGDOM, $mundane['KingdomId'], AUTH_EDIT)) {
+					if ($this->HasAuthority($requester_id, AUTH_KINGDOM, $mundane['KingdomId'], AUTH_EDIT) ||
+						$this->HasAuthority($requester_id, AUTH_PARK, $mundane['ParkId'], AUTH_EDIT)) {
 						logtrace("RemoveAuthorization(): KPM Unit Bypass: ", $requester_id);
 						$response = $this->remove_auth_h($request);
 					}
@@ -617,7 +618,8 @@ class Authorization extends Ork3
 		} else if (AUTH_UNIT == $request['Type']) {
 			$mundane = Ork3::$Lib->player->player_info($requester_id);
 
-			if ($this->HasAuthority($requester_id, AUTH_KINGDOM, $mundane['KingdomId'], AUTH_EDIT)) {
+			if ($this->HasAuthority($requester_id, AUTH_KINGDOM, $mundane['KingdomId'], AUTH_EDIT) ||
+				$this->HasAuthority($requester_id, AUTH_PARK, $mundane['ParkId'], AUTH_EDIT)) {
 				$this->log->Write('Authorization:KPM Unit Bypass', $requester_id, LOG_ADD, $request);
 				$response = $this->add_auth_h($request);
 				return $response;

--- a/system/lib/ork3/class.Player.php
+++ b/system/lib/ork3/class.Player.php
@@ -792,7 +792,7 @@ class Player extends Ork3 {
 	//     needs invalidating.
 	// Pass kingdom_id/park_id when the caller already knows them (e.g.
 	// merge/delete after the row is gone); otherwise we look them up.
-	private function bust_player_award_recs_cache($mundane_id, $kingdom_id = null, $park_id = null) {
+	private function bust_player_award_recs_cache($mundane_id, $kingdom_id = null, $park_id = null, $viewer_id = null) {
 		if (!valid_id($mundane_id)) return;
 		if ($kingdom_id === null || $park_id === null) {
 			$info = $this->player_info($mundane_id);
@@ -803,12 +803,19 @@ class Player extends Ork3 {
 		$kid = (int)$kingdom_id;
 		$pid = (int)$park_id;
 		$mid = (int)$mundane_id;
+		// Bust viewer-agnostic keys (used by kingdom/park-scoped views).
 		$keys = [['KingdomId' => 0, 'ParkId' => 0, 'PlayerId' => $mid]];
-		if ($kid > 0) $keys[] = ['KingdomId' => $kid, 'ParkId' => 0,   'PlayerId' => 0];
-		if ($pid > 0) $keys[] = ['KingdomId' => 0,    'ParkId' => $pid,'PlayerId' => 0];
+		if ($kid > 0) $keys[] = ['KingdomId' => $kid, 'ParkId' => 0,    'PlayerId' => 0];
+		if ($pid > 0) $keys[] = ['KingdomId' => 0,    'ParkId' => $pid, 'PlayerId' => 0];
 		foreach ($keys as $kd) {
 			Ork3::$Lib->ghettocache->bust('Report.PlayerAwardRecommendations',
 				Ork3::$Lib->ghettocache->key($kd));
+		}
+		// PlayerAwardRecommendations cache key also includes RequestedBy (viewer), so bust the
+		// viewer-specific entry when the caller knows who will be loading the tab next.
+		if ($viewer_id !== null && valid_id((int)$viewer_id)) {
+			Ork3::$Lib->ghettocache->bust('Report.PlayerAwardRecommendations',
+				Ork3::$Lib->ghettocache->key(['KingdomId' => 0, 'ParkId' => 0, 'PlayerId' => $mid, 'RequestedBy' => (int)$viewer_id]));
 		}
 		Ork3::$Lib->ghettocache->bust('Model_Player.fetch_player_details',
 			Ork3::$Lib->ghettocache->key(['MundaneId' => $mid]));
@@ -2354,7 +2361,7 @@ class Player extends Ork3 {
 			$awardRec->recommended_by_id = $mundane_id;
 			$awardRec->reason = $request['Reason'];
 			$awardRec->save();
-			$this->bust_player_award_recs_cache($request['MundaneId']);
+			$this->bust_player_award_recs_cache($request['MundaneId'], null, null, $mundane_id);
 			return Success('Recommendation Added!');
 		} else {
 			return NoAuthorization();

--- a/system/lib/ork3/class.Player.php
+++ b/system/lib/ork3/class.Player.php
@@ -1984,6 +1984,9 @@ class Player extends Ork3 {
 				}
 				Ork3::$Lib->dangeraudit->audit(__CLASS__ . "::" . __FUNCTION__, $request, 'Player', $_audit_mundane, $_audit_prior, $_audit_after);
 
+				Ork3::$Lib->ghettocache->bust('Model_Player.fetch_player_details',
+					Ork3::$Lib->ghettocache->key(['MundaneId' => (int)$_audit_mundane]));
+
 				return Success($set_awards_id);
 			} else {
 				return InvalidParamter();
@@ -2062,6 +2065,9 @@ class Player extends Ork3 {
 					$_audit_after = $this->get_award($awards);
 				}
 				Ork3::$Lib->dangeraudit->audit(__CLASS__ . "::" . __FUNCTION__, $request, 'Player', $_audit_mundane, $_audit_prior, $_audit_after);
+
+				Ork3::$Lib->ghettocache->bust('Model_Player.fetch_player_details',
+					Ork3::$Lib->ghettocache->key(['MundaneId' => (int)$_audit_mundane]));
 
 				return Success($set_awards_id);
 			} else {

--- a/system/lib/ork3/class.Report.php
+++ b/system/lib/ork3/class.Report.php
@@ -823,6 +823,8 @@ class Report  extends Ork3 {
 		if (valid_id($request['IncludeHouseHolds'])) $households = " or u.type = 'Household' ";
 		if (valid_id($request['IncludeEvents'])) $events = " or u.type = 'Event' ";
 		if (valid_id($request['ActiveOnly'])) $active_only = " and um.active = 'Active' ";
+		// Hide retired units from listings unless explicitly requested.
+		$unit_active = valid_id($request['IncludeRetired']) ? '' : " and u.active = 'Active' ";
 		if (valid_id($request['KingdomId'])) $activity_scope = " and a.kingdom_id = '$request[KingdomId]'";
 		elseif (valid_id($request['ParkId'])) $activity_scope = " and a.park_id = '$request[ParkId]'";
 
@@ -866,7 +868,46 @@ class Report  extends Ork3 {
 			$leader_names_expr        = "(select group_concat(m5.persona order by m5.persona separator ', ') from " . DB_PREFIX . "unit_mundane um5 join " . DB_PREFIX . "mundane m5 on m5.mundane_id = um5.mundane_id where um5.unit_id = u.unit_id and um5.role in ('captain','lord') and um5.active = 'Active')";
 		}
 
-		$sql = "select u.*, m.*, u.has_heraldry, count(um.mundane_id) as member_count,
+		$top_by_size = !empty($request['TopBySize']);
+		if ($top_by_size) {
+			// Fast default list (no name filter): cheaply pick the top-N units by
+			// roster size for the scope, then attach only the inexpensive detail
+			// columns. The attendance subqueries (last_activity_date /
+			// active_member_count) are deliberately omitted here — they are what made
+			// the unscoped default take ~15s — so this path returns in ~180ms.
+			// Activity detail is computed only on the typed-search path below.
+			$inner_scope_join  = '';
+			$inner_scope_where = '';
+			if (valid_id($request['KingdomId'])) {
+				$inner_scope_join  = "join " . DB_PREFIX . "mundane m on m.mundane_id = um.mundane_id";
+				$inner_scope_where = " and m.kingdom_id = '" . (int)$request['KingdomId'] . "'";
+			} elseif (valid_id($request['ParkId'])) {
+				$inner_scope_join  = "join " . DB_PREFIX . "mundane m on m.mundane_id = um.mundane_id";
+				$inner_scope_where = " and m.park_id = '" . (int)$request['ParkId'] . "'";
+			}
+			$top_n = (isset($request['Limit']) && is_numeric($request['Limit'])) ? (int)$request['Limit'] : 100;
+			// Retired units are excluded unless explicitly requested.
+			$inner_unit_active = valid_id($request['IncludeRetired']) ? '' : " and u.active = 'Active'";
+			$sql = "select u.unit_id, u.type, u.name, u.has_heraldry, u.url, u.active as unit_active, top.sz as member_count,
+						$total_member_count_expr as total_member_count,
+						null as last_activity_date,
+						null as active_member_count,
+						$leader_names_expr as leader_names,
+						null as unit_mundane_id, '' as persona
+					from (
+						select u.unit_id, count(um.mundane_id) sz
+							from " . DB_PREFIX . "unit u
+								join " . DB_PREFIX . "unit_mundane um on um.unit_id = u.unit_id
+								$inner_scope_join
+							where (0 $companies $households $events) $inner_scope_where $inner_unit_active
+							group by u.unit_id
+							order by sz desc
+							limit $top_n
+					) top
+					join " . DB_PREFIX . "unit u on u.unit_id = top.unit_id
+					order by top.sz desc";
+		} else {
+			$sql = "select u.*, m.*, u.has_heraldry, u.active as unit_active, count(um.mundane_id) as member_count,
 					$total_member_count_expr as total_member_count,
 					$last_activity_date_expr as last_activity_date,
 					$active_member_count_expr as active_member_count,
@@ -876,9 +917,10 @@ class Report  extends Ork3 {
 						$um_join
 							left join " . DB_PREFIX . "mundane m on m.mundane_id = um.mundane_id
 						left join " . DB_PREFIX . "event e on e.unit_id = u.unit_id
-					where 1 and (1 $kingdom $park $event_id $active_only_where $name_where) and (0 $companies $households $events)
+					where 1 and (1 $kingdom $park $event_id $active_only_where $name_where $unit_active) and (0 $companies $households $events)
 					group by u.unit_id
 				order by $order_by $limit_clause";
+		}
 		$r = $this->db->query($sql);
 		logtrace("Unit Summary", array($request, $sql));
 		$response = array( 'Status' => Success(), 'Units' => array());
@@ -899,6 +941,7 @@ class Report  extends Ork3 {
 					'LeaderNames'        => $r->leader_names ?? '',
 					'Url'                => $r->url ?? '',
 					'UnitMundaneId'      => $r->unit_mundane_id,
+					'Active'             => $r->unit_active,
 				);
 			}
 		}

--- a/system/lib/ork3/class.SearchService.php
+++ b/system/lib/ork3/class.SearchService.php
@@ -17,6 +17,7 @@ class SearchService extends Ork3 {
    		$limit = min($limit, 50);
 		$unit = new yapo($this->db, DB_PREFIX . 'unit');
 		$unit->clear();
+		$unit->active = 'Active';
 		$unit->like('name', "%$name%");
 		if ($unit->find()) {
 			$r = array();

--- a/system/lib/ork3/class.Unit.php
+++ b/system/lib/ork3/class.Unit.php
@@ -464,8 +464,17 @@ class Unit extends Ork3 {
 		if (!valid_id($request['UnitId']) || !$this->unit->find()) {
 			return InvalidParameter();
 		}
+		$unit_id    = (int)$request['UnitId'];
+		$actor_id   = isset($request['ActorId']) ? (int)$request['ActorId'] : null;
+		$member_ids = array_keys($this->_active_member_roles($unit_id));
 		$this->unit->active = $waffle;
 		$this->unit->save();
+		Ork3::$Lib->dangeraudit->audit('Unit::' . ($waffle === 'Retired' ? 'RetireUnit' : 'RestoreUnit'),
+			$request, 'Unit', $unit_id, $actor_id, ['unit_id' => $unit_id, 'active' => $waffle]);
+		foreach ($member_ids as $mid) {
+			$ck = Ork3::$Lib->ghettocache->key(['MundaneId' => $mid, 'IncludeCompanies' => 1, 'IncludeHouseHolds' => 1, 'IncludeEvents' => 1, 'ActiveOnly' => 1, 'Lightweight' => 1]);
+			Ork3::$Lib->ghettocache->bust('Report.UnitSummary', $ck);
+		}
 		return Success();
 	}
 
@@ -477,14 +486,17 @@ class Unit extends Ork3 {
 		$unit_id  = (int)$request['UnitId'];
 
 		$is_manager = Ork3::$Lib->authorization->HasAuthority($mundane_id, AUTH_UNIT, $unit_id, AUTH_CREATE);
-		$is_officer = $mundane && Ork3::$Lib->authorization->HasAuthority($mundane_id, AUTH_KINGDOM, $mundane['KingdomId'], AUTH_EDIT);
+		$is_officer = $mundane && (
+			Ork3::$Lib->authorization->HasAuthority($mundane_id, AUTH_KINGDOM, $mundane['KingdomId'], AUTH_EDIT) ||
+			Ork3::$Lib->authorization->HasAuthority($mundane_id, AUTH_PARK, $mundane['ParkId'], AUTH_EDIT)
+		);
 		// Sole-member exception: the only remaining active roster member may
 		// retire even without management rights.
 		$members = $this->_active_member_roles($unit_id);
 		$is_sole_member = (count($members) === 1 && isset($members[$mundane_id]));
 
 		if ($is_manager || $is_officer || $is_sole_member) {
-			return $this->WaffleUnit($request, 'Retired');
+			return $this->WaffleUnit($request + ['ActorId' => $mundane_id], 'Retired');
 		}
 		return NoAuthorization();
 	}
@@ -495,8 +507,11 @@ class Unit extends Ork3 {
 		if ($mundane_id === 0) return NoAuthorization();
 		$mundane = Ork3::$Lib->player->player_info($request['Token']);
 		// Reactivation is monarchy-only — mirrors the KPM unit-auth bypass scope.
-		if ($mundane && Ork3::$Lib->authorization->HasAuthority($mundane_id, AUTH_KINGDOM, $mundane['KingdomId'], AUTH_EDIT)) {
-			return $this->WaffleUnit($request, 'Active');
+		if ($mundane && (
+			Ork3::$Lib->authorization->HasAuthority($mundane_id, AUTH_KINGDOM, $mundane['KingdomId'], AUTH_EDIT) ||
+			Ork3::$Lib->authorization->HasAuthority($mundane_id, AUTH_PARK, $mundane['ParkId'], AUTH_EDIT)
+		)) {
+			return $this->WaffleUnit($request + ['ActorId' => $mundane_id], 'Active');
 		}
 		return NoAuthorization();
 	}
@@ -519,6 +534,8 @@ class Unit extends Ork3 {
 			return NoAuthorization('Only a leader of this unit may claim it.');
 		}
 		$this->_grant_unit_manager($mundane_id, $unit_id);
+		Ork3::$Lib->dangeraudit->audit('Unit::ClaimUnit',
+			$request, 'Unit', $unit_id, $mundane_id, ['unit_id' => $unit_id, 'mundane_id' => $mundane_id]);
 		return Success();
 	}
 
@@ -532,7 +549,10 @@ class Unit extends Ork3 {
 		if (!valid_id($target_id)) return InvalidParameter();
 
 		$is_manager = Ork3::$Lib->authorization->HasAuthority($mundane_id, AUTH_UNIT, $unit_id, AUTH_CREATE);
-		$is_officer = $mundane && Ork3::$Lib->authorization->HasAuthority($mundane_id, AUTH_KINGDOM, $mundane['KingdomId'], AUTH_EDIT);
+		$is_officer = $mundane && (
+			Ork3::$Lib->authorization->HasAuthority($mundane_id, AUTH_KINGDOM, $mundane['KingdomId'], AUTH_EDIT) ||
+			Ork3::$Lib->authorization->HasAuthority($mundane_id, AUTH_PARK, $mundane['ParkId'], AUTH_EDIT)
+		);
 		if (!$is_manager && !$is_officer) return NoAuthorization();
 
 		// Grant the target manager rights (skip if they already hold them).
@@ -547,6 +567,9 @@ class Unit extends Ork3 {
 		if ($mundane_id !== $target_id) {
 			$this->_remove_unit_auth_for($mundane_id, $unit_id);
 		}
+		Ork3::$Lib->dangeraudit->audit('Unit::TransferOwnership',
+			$request, 'Unit', $unit_id, $mundane_id,
+			['unit_id' => $unit_id, 'from_mundane_id' => $mundane_id, 'to_mundane_id' => $target_id]);
 		return Success();
 	}
 

--- a/system/lib/ork3/class.Unit.php
+++ b/system/lib/ork3/class.Unit.php
@@ -171,7 +171,8 @@ class Unit extends Ork3 {
 					'Name' => $this->unit->name,
 					'Description' => $this->unit->description,
 					'Url' => $this->unit->url,
-					'History' => $this->unit->history
+					'History' => $this->unit->history,
+					'Active' => $this->unit->active
 				);
 		} else {
 			$response['Status'] = InvalidParameter();
@@ -183,8 +184,11 @@ class Unit extends Ork3 {
 		if (!valid_id($request['MundaneId'])) {
 			return InvalidParameter();
 		}
-		if (($mundane_id = Ork3::$Lib->authorization->IsAuthorized($request['Token'])) > 0
-				&& Ork3::$Lib->authorization->HasAuthority($mundane_id, AUTH_UNIT, $request['UnitId'], AUTH_CREATE)) {
+		$mundane_id = Ork3::$Lib->authorization->IsAuthorized($request['Token']);
+		$mundane = $mundane_id > 0 ? Ork3::$Lib->player->player_info($request['Token']) : null;
+		if ($mundane_id > 0
+				&& (Ork3::$Lib->authorization->HasAuthority($mundane_id, AUTH_UNIT, $request['UnitId'], AUTH_CREATE)
+				    || ($mundane && Ork3::$Lib->authorization->HasAuthority($mundane_id, AUTH_KINGDOM, $mundane['KingdomId'], AUTH_EDIT)))) {
 			logtrace("AddMember", $request);
 			return $this->add_member_h($request);
 		}
@@ -396,6 +400,154 @@ class Unit extends Ork3 {
 		} else {
 			return InvalidParameter('Unit not found.');
 		}
+	}
+
+	/* ── Retire / Restore / Claim / Transfer ───────────────────────
+	 * Soft-delete support for units (see 2026-05-26-add-unit-active migration).
+	 * Retired units are hidden from unit lists and player search; only a
+	 * kingdom officer (monarchy) can restore them. */
+
+	private function _unit_manager_ids($unit_id) {
+		$auth = new yapo($this->db, DB_PREFIX . 'authorization');
+		$auth->clear();
+		$auth->unit_id = $unit_id;
+		$ids = array();
+		if (valid_id($unit_id) && $auth->find()) {
+			do { $ids[] = (int)$auth->mundane_id; } while ($auth->next());
+		}
+		return array_values(array_unique($ids));
+	}
+
+	private function _active_member_roles($unit_id) {
+		$this->members->clear();
+		$this->members->unit_id = $unit_id;
+		$this->members->active = 'Active';
+		$roles = array();
+		if (valid_id($unit_id) && $this->members->find()) {
+			do { $roles[(int)$this->members->mundane_id] = $this->members->role; } while ($this->members->next());
+		}
+		return $roles;
+	}
+
+	private function _remove_unit_auth_for($mundane_id, $unit_id) {
+		$auths = Ork3::$Lib->authorization->GetAuthorizations(array('MundaneId' => $mundane_id));
+		foreach ($auths['Authorizations'] as $auth) {
+			if ($auth['Type'] == AUTH_UNIT && $auth['Id'] == $unit_id) {
+				Ork3::$Lib->authorization->remove_auth_h(array('AuthorizationId' => $auth['AuthorizationId']));
+			}
+		}
+	}
+
+	// Grant unit-manager authority via the raw helper (callers below have
+	// already done their own permission checks, so we bypass add_authorization's
+	// HasAuthority gate — a claimant has no authority yet by definition). Audited
+	// to the grantee so the change surfaces on their player audit history.
+	private function _grant_unit_manager($grantee_id, $unit_id) {
+		$r = Ork3::$Lib->authorization->add_auth_h(array('MundaneId' => $grantee_id, 'Type' => AUTH_UNIT, 'Id' => $unit_id, 'Role' => AUTH_CREATE));
+		Ork3::$Lib->dangeraudit->audit('Authorization::AddAuthorization',
+			array('MundaneId' => $grantee_id, 'Type' => AUTH_UNIT, 'Id' => $unit_id, 'Role' => AUTH_CREATE),
+			'Player', $grantee_id, null, array(
+				'authorization_id' => (int)($r['Detail'] ?? 0),
+				'mundane_id'       => $grantee_id,
+				'park_id'          => 0,
+				'kingdom_id'       => 0,
+				'event_id'         => 0,
+				'unit_id'          => $unit_id,
+				'role'             => AUTH_CREATE,
+			));
+		return $r;
+	}
+
+	public function WaffleUnit($request, $waffle) {
+		$this->unit->clear();
+		$this->unit->unit_id = $request['UnitId'];
+		if (!valid_id($request['UnitId']) || !$this->unit->find()) {
+			return InvalidParameter();
+		}
+		$this->unit->active = $waffle;
+		$this->unit->save();
+		return Success();
+	}
+
+	public function RetireUnit($request) {
+		logtrace('RetireUnit', $request);
+		$mundane_id = Ork3::$Lib->authorization->IsAuthorized($request['Token']);
+		if ($mundane_id === 0) return NoAuthorization();
+		$mundane  = Ork3::$Lib->player->player_info($request['Token']);
+		$unit_id  = (int)$request['UnitId'];
+
+		$is_manager = Ork3::$Lib->authorization->HasAuthority($mundane_id, AUTH_UNIT, $unit_id, AUTH_CREATE);
+		$is_officer = $mundane && Ork3::$Lib->authorization->HasAuthority($mundane_id, AUTH_KINGDOM, $mundane['KingdomId'], AUTH_EDIT);
+		// Sole-member exception: the only remaining active roster member may
+		// retire even without management rights.
+		$members = $this->_active_member_roles($unit_id);
+		$is_sole_member = (count($members) === 1 && isset($members[$mundane_id]));
+
+		if ($is_manager || $is_officer || $is_sole_member) {
+			return $this->WaffleUnit($request, 'Retired');
+		}
+		return NoAuthorization();
+	}
+
+	public function RestoreUnit($request) {
+		logtrace('RestoreUnit', $request);
+		$mundane_id = Ork3::$Lib->authorization->IsAuthorized($request['Token']);
+		if ($mundane_id === 0) return NoAuthorization();
+		$mundane = Ork3::$Lib->player->player_info($request['Token']);
+		// Reactivation is monarchy-only — mirrors the KPM unit-auth bypass scope.
+		if ($mundane && Ork3::$Lib->authorization->HasAuthority($mundane_id, AUTH_KINGDOM, $mundane['KingdomId'], AUTH_EDIT)) {
+			return $this->WaffleUnit($request, 'Active');
+		}
+		return NoAuthorization();
+	}
+
+	public function ClaimUnit($request) {
+		logtrace('ClaimUnit', $request);
+		$mundane_id = Ork3::$Lib->authorization->IsAuthorized($request['Token']);
+		if ($mundane_id === 0) return NoAuthorization();
+		$unit_id = (int)$request['UnitId'];
+
+		// Only claimable when the unit currently has no managers.
+		if (count($this->_unit_manager_ids($unit_id)) > 0) {
+			return NoAuthorization('This unit already has a manager.');
+		}
+		// Claimant must be an active roster member holding a leadership role
+		// (captain / lord / organizer) — plain members cannot self-claim.
+		$members = $this->_active_member_roles($unit_id);
+		$role = isset($members[$mundane_id]) ? strtolower($members[$mundane_id]) : null;
+		if (!in_array($role, array('captain', 'lord', 'organizer'), true)) {
+			return NoAuthorization('Only a leader of this unit may claim it.');
+		}
+		$this->_grant_unit_manager($mundane_id, $unit_id);
+		return Success();
+	}
+
+	public function TransferOwnership($request) {
+		logtrace('TransferOwnership', $request);
+		$mundane_id = Ork3::$Lib->authorization->IsAuthorized($request['Token']);
+		if ($mundane_id === 0) return NoAuthorization();
+		$mundane   = Ork3::$Lib->player->player_info($request['Token']);
+		$unit_id   = (int)$request['UnitId'];
+		$target_id = (int)$request['MundaneId'];
+		if (!valid_id($target_id)) return InvalidParameter();
+
+		$is_manager = Ork3::$Lib->authorization->HasAuthority($mundane_id, AUTH_UNIT, $unit_id, AUTH_CREATE);
+		$is_officer = $mundane && Ork3::$Lib->authorization->HasAuthority($mundane_id, AUTH_KINGDOM, $mundane['KingdomId'], AUTH_EDIT);
+		if (!$is_manager && !$is_officer) return NoAuthorization();
+
+		// Grant the target manager rights (skip if they already hold them).
+		if (!in_array($target_id, $this->_unit_manager_ids($unit_id), true)) {
+			$this->_grant_unit_manager($target_id, $unit_id);
+		}
+		// Ensure the new owner is on the active roster (no-op / preserves role if
+		// they already are a member).
+		$this->add_member_h(array('UnitId' => $unit_id, 'MundaneId' => $target_id, 'Role' => 'member', 'Title' => '', 'Active' => 'Active'));
+		// Acting manager steps down. Officers performing the transfer have no unit
+		// auth row, so this is a no-op for them.
+		if ($mundane_id !== $target_id) {
+			$this->_remove_unit_auth_for($mundane_id, $unit_id);
+		}
+		return Success();
 	}
 
 }


### PR DESCRIPTION
## Summary
A bundle of bugfixes plus a new unit management capability.

### Unit management (new)
- **Retire / restore / claim / transfer-ownership** flows for companies & households (controller actions → model pass-throughs → `class.Unit` service methods).
- Soft-delete via new `ork_unit.active enum('Active','Retired')` column — migration `db-migrations/2026-05-26-add-unit-active.sql`. Mirrors the `ork_park`/`ork_kingdom` convention.
- Retired units are hidden from unit lists and search unless an "include inactive/retired" toggle is on; on the search page they render in a separate **Retired (Inactive) Units** section.
- Unit profile gains retire / claim / add-manager / transfer cards. Kingdom-officer (monarchy) bypass is evaluated against the user's home kingdom to match what the service layer actually permits.

### Unit list / search
- Default (no search term) list uses the fast **top-100-by-size** path; a lazy `Search/unitactivity` endpoint backfills active-member counts after the list is interactive (cached 300s).
- Player **filter cascade (kingdom → park)** in the add-member / add-manager search modals.
- New `KingdomAjax/getkingdoms` endpoint feeding the Move Player cascade dropdowns.

### Search scoping fixes
- Award **"Given By" (giver)** search is intentionally global/unscoped — an award can be granted by someone from another kingdom. Recipient search stays kingdom-scoped.

### Reports
- Moved the **Guilds** report link from the *Awards* group to the *Players* group on both Kingdom and Park profiles.

## Notes
- Requires running the migration `db-migrations/2026-05-26-add-unit-active.sql` before deploy.