### PR TITLE
Enhancement: Misc Improvements 06-05

### DIFF
--- a/orkui/controller/controller.Reports.php
+++ b/orkui/controller/controller.Reports.php
@@ -1311,6 +1311,17 @@ class Controller_Reports extends Controller {
 		exit;
 	}
 
+	public function release_utilization($params = null) {
+		$_uid = isset($this->session->user_id) ? (int)$this->session->user_id : 0;
+		$_isOrkAdmin = $_uid > 0 && Ork3::$Lib->authorization->HasAuthority($_uid, AUTH_ADMIN, 0, AUTH_ADMIN);
+		if (!$_isOrkAdmin) { header('Location: ' . UIR); exit; }
+
+		$result = $this->Reports->ReleaseFeatureUtilization();
+		$this->data['Report'] = $result;
+		$this->data['page_title'] = 'Release Feature Utilization';
+		$this->template = 'Reports_release_utilization.tpl';
+	}
+
 }
 
 ?>

--- a/orkui/model/model.Reports.php
+++ b/orkui/model/model.Reports.php
@@ -7,6 +7,10 @@ class Model_Reports extends Model {
 		$this->Report = new APIModel('Report');
 	}
 
+	function ReleaseFeatureUtilization() {
+		return $this->Report->ReleaseFeatureUtilization();
+	}
+
 	function get_tournaments($limit=10, $kingdom_id=null, $park_id=null, $event_id=null, $event_calendardetail_id=null) {
 		return $this->Report->TournamentReport(array(
 			'KingdomId' => $kingdom_id,

--- a/orkui/template/default/Admin_index.tpl
+++ b/orkui/template/default/Admin_index.tpl
@@ -32,5 +32,6 @@
 		<li><a href='<?=UIR ?>Unit/unitlist'>Companies and Households</a></li>
 		<li><a href='<?=UIR ?>Admin/topparks'>Top Parks by Attendance</a></li>
 		<li><a href='<?=UIR ?>Admin/new_player_attendance'>New Player Attendance</a></li>
+		<li><a href='<?=UIR ?>Reports/release_utilization'>Release Feature Utilization</a></li>
 	</ul>
 </div>

--- a/orkui/template/default/Reports_release_utilization.tpl
+++ b/orkui/template/default/Reports_release_utilization.tpl
@@ -1,0 +1,485 @@
+<?php
+/* ─────────────────────────────────────────────────────────────────────────
+   Release Feature Utilization — exec-facing adoption dashboard.
+   Renders generically from the $Report contract (see Report::ReleaseFeatureUtilization()).
+   Dark mode is driven by the shared --rp-* variables in reports.css plus the
+   Highcharts dark-detection pattern copied from Admin_newplayerattendance.tpl.
+   ───────────────────────────────────────────────────────────────────────── */
+
+$Report   = (isset($Report) && is_array($Report)) ? $Report : [];
+$releases = (isset($Report['releases']) && is_array($Report['releases'])) ? $Report['releases'] : [];
+$totals   = (isset($Report['totals'])   && is_array($Report['totals']))   ? $Report['totals']   : [];
+$genAt    = $Report['generated_at'] ?? date('Y-m-d H:i:s');
+
+/* Collect every chart spec so we can emit one JS init block at the end. */
+$_rfu_charts = [];
+
+/* Friendly date formatter for release dates ("2026-05-13" -> "May 13, 2026"). */
+$rfu_fmt_date = static function ($d) {
+	if (empty($d)) {
+		return '';
+	}
+	$ts = strtotime($d);
+	return $ts ? date('M j, Y', $ts) : htmlspecialchars($d);
+};
+?>
+<link rel="stylesheet" href="<?=HTTP_TEMPLATE?>default/style/reports.css?v=<?=filemtime(__DIR__.'/style/reports.css')?>">
+
+<style>
+/* ── Layout shell ── */
+.rfu-shell { display:flex; gap:22px; align-items:flex-start; }
+.rfu-nav   { position:sticky; top:14px; flex:0 0 218px; align-self:flex-start; }
+.rfu-main  { flex:1 1 auto; min-width:0; }
+
+/* ── Jump nav ── */
+.rfu-nav-card {
+	background: var(--rp-bg-table, #fff);
+	border: 1px solid var(--rp-border);
+	border-radius: 10px;
+	overflow: hidden;
+}
+.rfu-nav-head {
+	font-size: 11px; font-weight: 800; letter-spacing: .06em; text-transform: uppercase;
+	color: var(--rp-text-muted);
+	padding: 11px 14px 9px;
+	border-bottom: 1px solid var(--rp-border);
+	background: var(--rp-bg-light);
+}
+.rfu-nav-link {
+	display: block; text-decoration: none;
+	padding: 10px 14px;
+	border-left: 3px solid transparent;
+	color: var(--rp-text-body);
+	transition: background .12s, border-color .12s, color .12s;
+}
+.rfu-nav-link + .rfu-nav-link { border-top: 1px solid var(--rp-border); }
+.rfu-nav-link:hover { background: var(--rp-bg-light); border-left-color: var(--rp-accent-mid); }
+.rfu-nav-link.is-active { background: var(--rp-bg-light); border-left-color: var(--rp-accent); }
+.rfu-nav-ver  { font-weight: 800; font-size: 12.5px; color: var(--rp-accent); letter-spacing: .02em; }
+.rfu-nav-name { font-size: 13px; font-weight: 700; color: var(--rp-text); }
+.rfu-nav-date { font-size: 11px; color: var(--rp-text-muted); margin-top: 1px; }
+
+/* ── Totals strip ── */
+.rfu-totals {
+	display: flex; flex-wrap: wrap; gap: 0;
+	border: 1px solid var(--rp-border);
+	border-radius: 10px;
+	background: var(--rp-bg-table, #fff);
+	overflow: hidden;
+	margin-bottom: 22px;
+}
+.rfu-total {
+	flex: 1 1 0; min-width: 150px;
+	padding: 14px 18px;
+	border-right: 1px solid var(--rp-border);
+}
+.rfu-total:last-child { border-right: none; }
+.rfu-total-num   { font-size: 26px; font-weight: 800; color: var(--rp-text); line-height: 1.1; letter-spacing: -.01em; }
+.rfu-total-label { font-size: 11px; font-weight: 700; letter-spacing: .05em; text-transform: uppercase; color: var(--rp-text-muted); margin-top: 3px; }
+
+/* ── Release section ── */
+.rfu-release { margin-bottom: 30px; scroll-margin-top: 14px; }
+.rfu-release-head {
+	display: flex; align-items: baseline; flex-wrap: wrap; gap: 10px;
+	padding-bottom: 10px; margin-bottom: 16px;
+	border-bottom: 2px solid var(--rp-border);
+}
+.rfu-pill {
+	display: inline-flex; align-items: center; gap: 6px;
+	background: var(--rp-accent); color: #fff;
+	font-weight: 800; font-size: 13px; letter-spacing: .02em;
+	padding: 4px 11px; border-radius: 999px;
+	/* defeat orkui.css h1-h6 gray box */
+	border: none; text-shadow: none;
+}
+.rfu-release-name {
+	font-size: 20px; font-weight: 800; color: var(--rp-text); margin: 0;
+	/* defeat orkui.css h1-h6 gray box */
+	background: transparent; border: none; padding: 0; border-radius: 0; text-shadow: none;
+}
+.rfu-release-date { font-size: 12.5px; color: var(--rp-text-muted); font-weight: 600; }
+.rfu-release-blurb { width: 100%; font-size: 13.5px; color: var(--rp-text-body); line-height: 1.5; margin-top: 2px; }
+
+/* ── Feature card ── */
+.rfu-card {
+	background: var(--rp-bg-table, #fff);
+	border: 1px solid var(--rp-border);
+	border-radius: 12px;
+	padding: 18px 20px 20px;
+	margin-bottom: 16px;
+}
+.rfu-card-title {
+	font-size: 15.5px; font-weight: 800; color: var(--rp-text); margin: 0 0 2px;
+	/* defeat orkui.css h1-h6 gray box */
+	background: transparent; border: none; padding: 0; border-radius: 0; text-shadow: none;
+}
+.rfu-card-desc { font-size: 13px; color: var(--rp-text-muted); line-height: 1.5; margin: 0 0 16px; }
+
+/* ── KPI tiles ── */
+.rfu-kpis {
+	display: grid;
+	grid-template-columns: repeat(auto-fill, minmax(190px, 1fr));
+	gap: 12px;
+	margin-bottom: 8px;
+}
+.rfu-kpi {
+	position: relative;
+	background: var(--rp-bg-light);
+	border: 1px solid var(--rp-border);
+	border-radius: 10px;
+	padding: 13px 14px 14px;
+}
+.rfu-kpi-value { font-size: 27px; font-weight: 800; color: var(--rp-text); line-height: 1.05; letter-spacing: -.01em; }
+.rfu-kpi-label {
+	display: flex; align-items: center; gap: 5px;
+	font-size: 12px; font-weight: 600; color: var(--rp-text-body); margin-top: 4px; line-height: 1.35;
+}
+.rfu-kpi-pct { font-size: 11.5px; font-weight: 700; color: var(--rp-accent); margin-top: 9px; }
+.rfu-bar { height: 5px; border-radius: 999px; background: var(--rp-border); margin-top: 5px; overflow: hidden; }
+.rfu-bar-fill { height: 100%; border-radius: 999px; background: var(--rp-accent); }
+
+/* ── Before/after delta pill (themed for light + dark) ── */
+.rfu-delta {
+	display: inline-flex; align-items: center; gap: 4px;
+	margin-top: 8px;
+	padding: 2px 8px; border-radius: 999px;
+	font-size: 11.5px; font-weight: 800; letter-spacing: .01em; line-height: 1.4;
+	/* defeat any inherited heading styling */
+	border: 1px solid transparent; text-shadow: none;
+}
+.rfu-delta-up   { background: #dcfce7; color: #15803d; border-color: #bbf7d0; }
+.rfu-delta-down { background: #fee2e2; color: #b91c1c; border-color: #fecaca; }
+.rfu-delta-flat { background: var(--rp-bg-light); color: var(--rp-text-muted); border-color: var(--rp-border); }
+[data-theme="dark"] .rfu-delta-up   { background: rgba(16,185,129,.16);  color: #6ee7b7; border-color: rgba(16,185,129,.35); }
+[data-theme="dark"] .rfu-delta-down { background: rgba(239,68,68,.16);   color: #fca5a5; border-color: rgba(239,68,68,.35); }
+[data-theme="dark"] .rfu-delta-flat { background: rgba(148,163,184,.14); color: #cbd5e0; border-color: rgba(148,163,184,.3); }
+@media (prefers-color-scheme: dark) {
+	:root:not([data-theme="light"]) .rfu-delta-up   { background: rgba(16,185,129,.16);  color: #6ee7b7; border-color: rgba(16,185,129,.35); }
+	:root:not([data-theme="light"]) .rfu-delta-down { background: rgba(239,68,68,.16);   color: #fca5a5; border-color: rgba(239,68,68,.35); }
+	:root:not([data-theme="light"]) .rfu-delta-flat { background: rgba(148,163,184,.14); color: #cbd5e0; border-color: rgba(148,163,184,.3); }
+}
+
+/* ── Hint (CSS data-tip, no native title) ── */
+.rfu-hint {
+	display: inline-flex; align-items: center; justify-content: center;
+	width: 14px; height: 14px; flex: 0 0 14px;
+	border-radius: 50%; background: var(--rp-border); color: var(--rp-text-muted);
+	font-size: 9px; font-weight: 800; font-style: normal; cursor: help; position: relative;
+}
+.rfu-hint::after {
+	content: attr(data-tip);
+	position: absolute; bottom: 150%; left: 50%; transform: translateX(-50%);
+	white-space: normal; width: max-content; max-width: 220px;
+	background: #1a2035; color: #f1f5f9;
+	font-size: 11px; font-weight: 500; line-height: 1.4; text-align: left;
+	padding: 7px 9px; border-radius: 6px;
+	box-shadow: 0 4px 14px rgba(0,0,0,.35);
+	opacity: 0; visibility: hidden; transition: opacity .12s; z-index: 50; pointer-events: none;
+}
+.rfu-hint:hover::after { opacity: 1; visibility: visible; }
+
+/* ── Charts ── */
+.rfu-charts { margin-top: 18px; display: grid; grid-template-columns: 1fr; gap: 18px; }
+.rfu-chart-title { font-size: 12.5px; font-weight: 700; color: var(--rp-text-body); margin: 0 0 6px; }
+.rfu-chart-empty {
+	display: flex; flex-direction: column; align-items: center; justify-content: center;
+	height: 200px; gap: 8px;
+	border: 1px dashed var(--rp-border); border-radius: 10px;
+	color: var(--rp-text-muted); font-size: 13px;
+}
+.rfu-chart-empty i { font-size: 24px; opacity: .4; }
+
+.rfu-empty-state { padding: 48px 16px; text-align: center; color: var(--rp-text-muted); font-size: 14px; }
+.rfu-empty-state i { font-size: 30px; display: block; margin-bottom: 12px; opacity: .4; }
+
+@media (max-width: 820px) {
+	.rfu-shell { flex-direction: column; }
+	.rfu-nav { position: static; flex-basis: auto; width: 100%; }
+}
+</style>
+
+<div class="rp-root">
+
+	<!-- Header -->
+	<div class="rp-header">
+		<div class="rp-header-left">
+			<div class="rp-header-icon-title">
+				<i class="fas fa-rocket rp-header-icon"></i>
+				<h1 class="rp-header-title">Release Feature Utilization</h1>
+			</div>
+			<div class="rp-header-scope">
+				<span class="rp-scope-chip"><i class="fas fa-clock"></i> Generated <?=htmlspecialchars($genAt)?></span>
+			</div>
+		</div>
+		<div class="rp-header-actions">
+			<button class="rp-btn-ghost" onclick="window.print()"><i class="fas fa-print"></i> Print</button>
+		</div>
+	</div>
+
+	<!-- Context strip -->
+	<div class="rp-context">
+		<i class="fas fa-info-circle rp-context-icon"></i>
+		<span>Adoption metrics for features shipped in each ORK release — how widely the org is actually using what we build.</span>
+	</div>
+
+<?php if (empty($releases)): ?>
+
+	<div class="rfu-empty-state">
+		<i class="fas fa-box-open"></i>
+		No release utilization data is available yet.
+	</div>
+
+<?php else: ?>
+
+	<!-- Totals strip -->
+	<div class="rfu-totals" style="margin-top:20px;">
+		<div class="rfu-total">
+			<div class="rfu-total-num"><?=number_format((int)($totals['active_players'] ?? 0))?></div>
+			<div class="rfu-total-label">Active Players</div>
+		</div>
+		<div class="rfu-total">
+			<div class="rfu-total-num"><?=number_format((int)($totals['players_with_design'] ?? 0))?></div>
+			<div class="rfu-total-label">Players With a Design</div>
+		</div>
+		<div class="rfu-total">
+			<div class="rfu-total-num"><?=number_format((int)($totals['active_recommendations'] ?? 0))?></div>
+			<div class="rfu-total-label">Active Recommendations</div>
+		</div>
+	</div>
+
+	<div class="rfu-shell">
+
+		<!-- Jump nav -->
+		<nav class="rfu-nav">
+			<div class="rfu-nav-card">
+				<div class="rfu-nav-head"><i class="fas fa-list-ul"></i> Releases</div>
+<?php foreach ($releases as $_ri => $_rel): ?>
+<?php $_anchor = 'rfu-rel-' . $_ri; ?>
+				<a class="rfu-nav-link<?=$_ri === 0 ? ' is-active' : ''?>" href="#<?=$_anchor?>" data-rfu-target="<?=$_anchor?>">
+					<div class="rfu-nav-ver"><?=htmlspecialchars($_rel['version'] ?? '')?> <span class="rfu-nav-name"><?=htmlspecialchars($_rel['name'] ?? '')?></span></div>
+					<div class="rfu-nav-date"><?=$rfu_fmt_date($_rel['date'] ?? '')?></div>
+				</a>
+<?php endforeach; ?>
+			</div>
+		</nav>
+
+		<!-- Releases -->
+		<div class="rfu-main">
+<?php foreach ($releases as $_ri => $_rel): ?>
+<?php
+	$_anchor   = 'rfu-rel-' . $_ri;
+	$_features = (isset($_rel['features']) && is_array($_rel['features'])) ? $_rel['features'] : [];
+?>
+			<section class="rfu-release" id="<?=$_anchor?>">
+				<div class="rfu-release-head">
+					<span class="rfu-pill"><i class="fas fa-tag"></i> <?=htmlspecialchars($_rel['version'] ?? '')?></span>
+					<h2 class="rfu-release-name"><?=htmlspecialchars($_rel['name'] ?? '')?></h2>
+<?php if (!empty($_rel['date'])): ?>
+					<span class="rfu-release-date"><i class="far fa-calendar-alt"></i> <?=$rfu_fmt_date($_rel['date'])?></span>
+<?php endif; ?>
+<?php if (!empty($_rel['blurb'])): ?>
+					<div class="rfu-release-blurb"><?=htmlspecialchars($_rel['blurb'])?></div>
+<?php endif; ?>
+				</div>
+
+<?php if (empty($_features)): ?>
+				<div class="rfu-card"><div class="rfu-card-desc" style="margin:0;">No features tracked for this release yet.</div></div>
+<?php else: ?>
+<?php foreach ($_features as $_fi => $_feat): ?>
+<?php
+	$_kpis   = (isset($_feat['kpis'])   && is_array($_feat['kpis']))   ? $_feat['kpis']   : [];
+	$_charts = (isset($_feat['charts']) && is_array($_feat['charts'])) ? $_feat['charts'] : [];
+?>
+				<div class="rfu-card">
+					<h3 class="rfu-card-title"><?=htmlspecialchars($_feat['title'] ?? ($_feat['key'] ?? 'Feature'))?></h3>
+<?php if (!empty($_feat['description'])): ?>
+					<p class="rfu-card-desc"><?=htmlspecialchars($_feat['description'])?></p>
+<?php endif; ?>
+
+<?php if (!empty($_kpis)): ?>
+					<div class="rfu-kpis">
+<?php foreach ($_kpis as $_kpi): ?>
+<?php
+	$_val   = $_kpi['value'] ?? 0;
+	$_pct   = array_key_exists('pct', $_kpi) ? $_kpi['pct'] : null;
+	$_sfx   = (isset($_kpi['suffix']) && $_kpi['suffix'] !== '') ? $_kpi['suffix'] : '';
+	$_plbl  = (isset($_kpi['pctLabel']) && $_kpi['pctLabel'] !== '') ? $_kpi['pctLabel'] : 'of active players';
+	$_hint  = $_kpi['hint'] ?? null;
+	$_delta = (isset($_kpi['delta']) && $_kpi['delta'] !== '') ? $_kpi['delta'] : null;
+	$_ddir  = $_kpi['deltaDir'] ?? null;
+	$_dcls  = ($_ddir === 'up' || $_ddir === 'down') ? $_ddir : 'flat';
+	$_dicon = $_ddir === 'up' ? 'fa-arrow-up' : ($_ddir === 'down' ? 'fa-arrow-down' : 'fa-minus');
+?>
+						<div class="rfu-kpi">
+							<div class="rfu-kpi-value"><?=(is_numeric($_val) ? number_format((float)$_val) : htmlspecialchars((string)$_val)) . htmlspecialchars($_sfx)?></div>
+							<div class="rfu-kpi-label">
+								<span><?=htmlspecialchars($_kpi['label'] ?? '')?></span>
+<?php if ($_hint !== null && $_hint !== ''): ?>
+								<i class="rfu-hint" data-tip="<?=htmlspecialchars($_hint)?>">i</i>
+<?php endif; ?>
+							</div>
+<?php if ($_pct !== null): ?>
+<?php $_pctClamped = max(0, min(100, (float)$_pct)); ?>
+							<div class="rfu-kpi-pct"><?=rtrim(rtrim(number_format((float)$_pct, 1), '0'), '.')?>% <?=htmlspecialchars($_plbl)?></div>
+							<div class="rfu-bar"><div class="rfu-bar-fill" style="width:<?=$_pctClamped?>%;"></div></div>
+<?php endif; ?>
+<?php if ($_delta !== null): ?>
+							<div class="rfu-delta rfu-delta-<?=$_dcls?>"><i class="fas <?=$_dicon?>"></i><?=htmlspecialchars((string)$_delta)?></div>
+<?php endif; ?>
+						</div>
+<?php endforeach; ?>
+					</div>
+<?php endif; ?>
+
+<?php if (!empty($_charts)): ?>
+					<div class="rfu-charts">
+<?php foreach ($_charts as $_chart): ?>
+<?php
+	$_cid = $_chart['id'] ?? ('rfu-chart-' . $_ri . '-' . $_fi . '-' . count($_rfu_charts));
+	/* Determine emptiness for graceful placeholder. */
+	$_type   = $_chart['type'] ?? 'column';
+	$_hasData = false;
+	if ($_type === 'pie') {
+		$_hasData = !empty($_chart['data']) && array_sum(array_map('floatval', $_chart['data'])) > 0;
+	} else {
+		foreach (($_chart['series'] ?? []) as $_s) {
+			if (!empty($_s['data']) && array_sum(array_map('floatval', $_s['data'])) > 0) { $_hasData = true; break; }
+		}
+	}
+	if ($_hasData) {
+		$_rfu_charts[] = $_chart + ['id' => $_cid];
+	}
+?>
+						<div>
+<?php if (!empty($_chart['title'])): ?>
+							<div class="rfu-chart-title"><?=htmlspecialchars($_chart['title'])?></div>
+<?php endif; ?>
+<?php if ($_hasData): ?>
+							<div id="<?=htmlspecialchars($_cid)?>" style="height:320px;"></div>
+<?php else: ?>
+							<div class="rfu-chart-empty"><i class="far fa-chart-bar"></i> No data yet</div>
+<?php endif; ?>
+						</div>
+<?php endforeach; ?>
+					</div>
+<?php endif; ?>
+				</div>
+<?php endforeach; ?>
+<?php endif; ?>
+			</section>
+<?php endforeach; ?>
+		</div><!-- /.rfu-main -->
+
+	</div><!-- /.rfu-shell -->
+
+<?php endif; ?>
+
+</div><!-- /.rp-root -->
+
+<?php if (!empty($_rfu_charts)): ?>
+<script src="https://code.highcharts.com/highcharts.js"></script>
+<script>
+(function () {
+	/* Dark-mode detection — same approach as Admin_newplayerattendance.tpl */
+	function _rfuIsDark() {
+		var a = document.documentElement.getAttribute('data-theme');
+		return a === 'dark' || (!a && window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches);
+	}
+	function _rfuTooltipTheme(dk) {
+		return { backgroundColor: dk ? '#1a2035' : '#fff', borderColor: dk ? '#818cf8' : '#ccc', style: { color: dk ? '#f1f5f9' : '#333' } };
+	}
+
+	/* Palette that reads in both themes. */
+	var RFU_COLORS = ['#6366f1', '#10b981', '#f59e0b', '#ef4444', '#06b6d4', '#a855f7', '#84cc16', '#ec4899'];
+
+	var specs = <?=json_encode(array_values($_rfu_charts))?>;
+	var charts = [];
+
+	function buildOne(spec) {
+		var dk    = _rfuIsDark();
+		var type  = spec.type || 'column';
+		var axisLabel = dk ? '#cbd5e0' : '#333';
+		var axisTitle = dk ? '#a0aec0' : '#666';
+		var gridCol   = dk ? '#2d3748' : '#e6e6e6';
+		var lineCol   = dk ? '#4a5568' : '#ccd6eb';
+
+		var cfg = {
+			chart  : { renderTo: spec.id, type: (type === 'bar' ? 'bar' : (type === 'pie' ? 'pie' : 'column')), backgroundColor: 'transparent', style: { fontFamily: 'inherit' } },
+			title  : { text: null },
+			colors : RFU_COLORS,
+			credits: { enabled: false },
+			tooltip: _rfuTooltipTheme(dk),
+			legend : { enabled: true, itemStyle: { color: axisLabel }, itemHoverStyle: { color: dk ? '#fff' : '#000' } }
+		};
+
+		if (type === 'pie') {
+			var cats = spec.categories || [];
+			var vals = spec.data || [];
+			var pieData = cats.map(function (c, i) { return { name: c, y: Number(vals[i]) || 0 }; });
+			cfg.plotOptions = { pie: {
+				allowPointSelect: true, cursor: 'pointer', borderWidth: 0,
+				dataLabels: { enabled: true, format: '{point.name}: {point.y}', style: { color: axisLabel, textOutline: 'none', fontWeight: '600' } }
+			}};
+			cfg.series = [{ name: spec.title || 'Share', colorByPoint: true, data: pieData }];
+		} else {
+			cfg.xAxis = {
+				categories: spec.categories || [],
+				labels: { style: { fontSize: '11px', color: axisLabel } },
+				lineColor: lineCol, tickColor: lineCol
+			};
+			if (type !== 'bar') { cfg.xAxis.labels.rotation = -25; }
+			cfg.yAxis = {
+				title: { text: null, style: { color: axisTitle } },
+				allowDecimals: false, min: 0,
+				labels: { style: { color: axisTitle } },
+				gridLineColor: gridCol
+			};
+			cfg.plotOptions = { series: { borderWidth: 0 } };
+			cfg.series = (spec.series || []).map(function (s, i) {
+				return { name: s.name, data: (s.data || []).map(Number), color: RFU_COLORS[i % RFU_COLORS.length] };
+			});
+			/* Single-series column/bar: color points individually for visual clarity. */
+			if (cfg.series.length === 1) {
+				cfg.series[0].colorByPoint = true;
+				cfg.legend.enabled = false;
+			}
+		}
+		return new Highcharts.Chart(cfg);
+	}
+
+	function buildAll() {
+		specs.forEach(function (spec) {
+			if (document.getElementById(spec.id)) { charts.push(buildOne(spec)); }
+		});
+	}
+	function rebuildAll() {
+		charts.forEach(function (c) { try { c.destroy(); } catch (e) {} });
+		charts = [];
+		buildAll();
+	}
+
+	buildAll();
+	new MutationObserver(rebuildAll).observe(document.documentElement, { attributeFilter: ['data-theme'] });
+}());
+</script>
+<?php endif; ?>
+
+<script>
+/* Scrollspy for the jump nav (no dependency on chart presence). */
+(function () {
+	var links    = Array.prototype.slice.call(document.querySelectorAll('.rfu-nav-link[data-rfu-target]'));
+	if (!links.length || !('IntersectionObserver' in window)) { return; }
+	var sections = links.map(function (l) { return document.getElementById(l.getAttribute('data-rfu-target')); }).filter(Boolean);
+
+	var io = new IntersectionObserver(function (entries) {
+		entries.forEach(function (e) {
+			if (!e.isIntersecting) { return; }
+			links.forEach(function (l) {
+				l.classList.toggle('is-active', l.getAttribute('data-rfu-target') === e.target.id);
+			});
+		});
+	}, { rootMargin: '-20% 0px -70% 0px', threshold: 0 });
+
+	sections.forEach(function (s) { io.observe(s); });
+}());
+</script>

--- a/orkui/template/default/default.theme
+++ b/orkui/template/default/default.theme
@@ -486,10 +486,22 @@ $downtime_note  = 'ORK downtime to migrate to the Mask 3.5.2 Release';
 			}
 		});
 
-		// Close search dropdown on outside click
+		// Once the user clicks/focuses into the search, lock it open so that mousing
+		// off does NOT collapse it or blur the input. It stays open until an
+		// explicit outside click (below) or Escape.
+		$('#UniversalSearch').on('focus', function() {
+			document.getElementById('nav-search-wrap').classList.add('nav-search-open');
+			document.getElementById('nav-search-toggle').classList.add('active');
+		});
+
+		// Close the search (collapse + clear) only on an actual click OUTSIDE it.
 		$(document).on('click.searchDropdown', function(e) {
 			if (!$(e.target).closest('#nav-search-wrap').length) {
 				$('#nav-search-dropdown').removeClass('nsdd-visible').empty();
+				document.getElementById('nav-search-wrap').classList.remove('nav-search-open');
+				document.getElementById('nav-search-toggle').classList.remove('active');
+				var _inp = document.getElementById('UniversalSearch');
+				if (_inp) { _inp.value = ''; _inp.blur(); }
 			}
 		});
 	});

--- a/orkui/template/revised-frontend/Admin_index.tpl
+++ b/orkui/template/revised-frontend/Admin_index.tpl
@@ -291,6 +291,7 @@ function _cp_trend($cur, $prev, $fmt = 'number') {
 				<li><a href="<?= UIR ?>Admin/new_player_attendance"><i class="fas fa-star"></i><span>New Player Attendance<span class="cp-report-list-desc">First-time attendees by kingdom</span></span></a></li>
 				<li><a href="<?= UIR ?>Admin/auditlog"><i class="fas fa-history"></i><span>Audit Log<span class="cp-report-list-desc">System changes &amp; admin actions</span></span></a></li>
 				<li><a href="<?= UIR ?>Admin/serverhealth"><i class="fas fa-heartbeat"></i><span>Server Health<span class="cp-report-list-desc">PHP-FPM workers, DB metrics &amp; load test</span></span></a></li>
+				<li><a href="<?= UIR ?>Reports/release_utilization"><i class="fas fa-chart-line"></i><span>Release Feature Utilization<span class="cp-report-list-desc">Adoption metrics by release</span></span></a></li>
 			</ul>
 		</div>
 

--- a/system/lib/ork3/class.Report.php
+++ b/system/lib/ork3/class.Report.php
@@ -4116,4 +4116,685 @@ class Report  extends Ork3 {
 		return $out;
 	}
 
+
+	/**
+	 * ReleaseFeatureUtilization
+	 *
+	 * Returns adoption / utilization metrics for recent ORK3 feature releases,
+	 * shaped as a generic releases[] -> features[] -> { kpis[], charts[] } tree
+	 * so the template renders entirely from data (future features = data-only).
+	 *
+	 * @return array See the Reports_release_utilization data contract.
+	 */
+	public function ReleaseFeatureUtilization() {
+		$p = DB_PREFIX;
+
+		// --- denominators -----------------------------------------------------
+		// Active player definition: distinct players with >=1 attendance record
+		// in the rolling 2 years (CURDATE() - 2 years .. now).
+		$activePlayers = $this->_rfuScalar(
+			"SELECT COUNT(DISTINCT mundane_id) AS c FROM `{$p}attendance` WHERE `date` >= DATE_SUB(CURDATE(), INTERVAL 2 YEAR)"
+		);
+		$playersWithDesign = $this->_rfuScalar(
+			"SELECT COUNT(*) AS c FROM `{$p}mundane_design`"
+		);
+		$activeRecommendations = $this->_rfuScalar(
+			"SELECT COUNT(*) AS c FROM `{$p}recommendations` WHERE deleted_at IS NULL"
+		);
+
+		// player-scoped pct helper (null when denom is 0).
+		$denom = $activePlayers;
+		$pct = function ($value) use ($denom) {
+			if ($denom <= 0) {
+				return null;
+			}
+			return round(($value / $denom) * 100, 1);
+		};
+
+		// ====================================================================
+		// RELEASE 3.5.2 — Mask
+		// ====================================================================
+
+		// --- nameplate KPIs (all from ork_mundane_design) --------------------
+		$dColorPrimary = $this->_rfuScalar(
+			"SELECT COUNT(*) AS c FROM `{$p}mundane_design` WHERE color_primary IS NOT NULL AND color_primary <> ''"
+		);
+		$dPrefix = $this->_rfuScalar(
+			"SELECT COUNT(*) AS c FROM `{$p}mundane_design` WHERE name_prefix IS NOT NULL AND name_prefix <> ''"
+		);
+		$dSuffix = $this->_rfuScalar(
+			"SELECT COUNT(*) AS c FROM `{$p}mundane_design` WHERE name_suffix IS NOT NULL AND name_suffix <> ''"
+		);
+		$dGradient = $this->_rfuScalar(
+			"SELECT COUNT(*) AS c FROM `{$p}mundane_design` WHERE hero_gradient IS NOT NULL AND hero_gradient <> ''"
+		);
+		$dFont = $this->_rfuScalar(
+			"SELECT COUNT(*) AS c FROM `{$p}mundane_design` WHERE name_font IS NOT NULL AND name_font <> ''"
+		);
+		$dPronunciation = $this->_rfuScalar(
+			"SELECT COUNT(*) AS c FROM `{$p}mundane_design` WHERE pronunciation_guide IS NOT NULL AND pronunciation_guide <> ''"
+		);
+		$dAbout = $this->_rfuScalar(
+			"SELECT COUNT(*) AS c FROM `{$p}mundane_design`
+			 WHERE (about_persona IS NOT NULL AND about_persona <> '')
+			    OR (about_story IS NOT NULL AND about_story <> '')"
+		);
+
+		// nameplate breakdowns
+		$fontBreak = $this->_rfuBreakdown(
+			"SELECT name_font AS k, COUNT(*) AS c FROM `{$p}mundane_design`
+			 WHERE name_font IS NOT NULL AND name_font <> ''
+			 GROUP BY name_font ORDER BY c DESC, name_font ASC"
+		);
+		$beltBreak = $this->_rfuBreakdown(
+			"SELECT belt_display AS k, COUNT(*) AS c FROM `{$p}mundane_design`
+			 WHERE belt_display IS NOT NULL AND belt_display <> ''
+			 GROUP BY belt_display ORDER BY c DESC, belt_display ASC"
+		);
+		$gradientBreak = $this->_rfuBreakdown(
+			"SELECT hero_gradient AS k, COUNT(*) AS c FROM `{$p}mundane_design`
+			 WHERE hero_gradient IS NOT NULL AND hero_gradient <> ''
+			 GROUP BY hero_gradient ORDER BY c DESC, hero_gradient ASC"
+		);
+
+		$featNameplate = array(
+			'key'         => 'nameplate',
+			'title'       => 'Nameplate & Profile Story',
+			'description' => 'Players personalize their profile masthead with custom colors, prefixes/suffixes, fonts, pronunciation guides and a written persona.',
+			'kpis' => array(
+				$this->_rfuKpi('Custom nameplate color', $dColorPrimary, $denom, $pct($dColorPrimary), 'players with color_primary set'),
+				$this->_rfuKpi('Name prefix', $dPrefix, $denom, $pct($dPrefix), 'players with name_prefix set'),
+				$this->_rfuKpi('Name suffix', $dSuffix, $denom, $pct($dSuffix), 'players with name_suffix set'),
+				$this->_rfuKpi('Pride gradient', $dGradient, $denom, $pct($dGradient), 'players with hero_gradient set'),
+				$this->_rfuKpi('Custom font', $dFont, $denom, $pct($dFont), 'players with name_font set'),
+				$this->_rfuKpi('Pronunciation guide', $dPronunciation, $denom, $pct($dPronunciation), 'players with pronunciation_guide set'),
+				$this->_rfuKpi('Custom About text', $dAbout, $denom, $pct($dAbout), 'players with about_persona or about_story set'),
+				$this->_rfuKpi('Any design row', $playersWithDesign, $denom, $pct($playersWithDesign), 'players with a profile design record'),
+			),
+			'charts' => array(
+				$this->_rfuChartFromBreakdown('rfu-font', 'bar', 'Nameplate font adoption', $fontBreak, 'Players'),
+				$this->_rfuChartFromBreakdown('rfu-belt', 'pie', 'Belt display choice', $beltBreak, 'Players'),
+				$this->_rfuChartFromBreakdown('rfu-gradient', 'bar', 'Pride gradient adoption', $gradientBreak, 'Players'),
+			),
+		);
+
+		// --- accessibility fonts (ork_mundane) -------------------------------
+		$basicFonts = $this->_rfuScalar(
+			"SELECT COUNT(*) AS c FROM `{$p}mundane` WHERE basic_fonts = 1"
+		);
+		$dyslexiaFonts = $this->_rfuScalar(
+			"SELECT COUNT(*) AS c FROM `{$p}mundane` WHERE dyslexia_fonts = 1"
+		);
+		$featViewerFonts = array(
+			'key'         => 'viewer_fonts',
+			'title'       => 'Accessibility Fonts',
+			'description' => 'Readers can swap profile typography for simpler or dyslexia-friendly typefaces.',
+			'kpis' => array(
+				$this->_rfuKpi('Basic fonts enabled', $basicFonts, $denom, $pct($basicFonts), 'players with basic_fonts on'),
+				$this->_rfuKpi('Dyslexia fonts enabled', $dyslexiaFonts, $denom, $pct($dyslexiaFonts), 'players with dyslexia_fonts on'),
+			),
+			'charts' => array(),
+		);
+
+		// --- personal milestones (ork_player_milestones) ---------------------
+		$milestoneTotal = $this->_rfuScalar(
+			"SELECT COUNT(*) AS c FROM `{$p}player_milestones`"
+		);
+		$milestoneUsers = $this->_rfuScalar(
+			"SELECT COUNT(DISTINCT mundane_id) AS c FROM `{$p}player_milestones`"
+		);
+		$milestoneAvg = ($milestoneUsers > 0) ? round($milestoneTotal / $milestoneUsers, 1) : 0;
+		$featMilestones = array(
+			'key'         => 'milestones',
+			'title'       => 'Personal Milestones',
+			'description' => 'Players pin dated, captioned milestones to their profile timeline.',
+			'kpis' => array(
+				$this->_rfuKpi('Total milestones', $milestoneTotal, null, null, 'rows in player milestones'),
+				$this->_rfuKpi('Players using milestones', $milestoneUsers, $denom, $pct($milestoneUsers), 'distinct players with a milestone'),
+				$this->_rfuKpi('Avg per adopting player', $milestoneAvg, null, null, 'milestones / adopting player'),
+			),
+			'charts' => array(),
+		);
+
+		// --- recommendation seconds (ork_recommendation_seconds) -------------
+		$secTotal = $this->_rfuScalar(
+			"SELECT COUNT(*) AS c FROM `{$p}recommendation_seconds` WHERE deleted_at IS NULL"
+		);
+		$secRecs = $this->_rfuScalar(
+			"SELECT COUNT(DISTINCT recommendations_id) AS c FROM `{$p}recommendation_seconds` WHERE deleted_at IS NULL"
+		);
+		$secSupporters = $this->_rfuScalar(
+			"SELECT COUNT(DISTINCT supporter_mundane_id) AS c FROM `{$p}recommendation_seconds` WHERE deleted_at IS NULL"
+		);
+		$secNotes = $this->_rfuScalar(
+			"SELECT COUNT(*) AS c FROM `{$p}recommendation_seconds` WHERE deleted_at IS NULL AND notes IS NOT NULL AND notes <> ''"
+		);
+		$secPctOfRecs = ($activeRecommendations > 0)
+			? round(($secRecs / $activeRecommendations) * 100, 1)
+			: null;
+		$featRecSeconds = array(
+			'key'         => 'rec_seconds',
+			'title'       => 'Recommendation Seconds',
+			'description' => 'Members add weight to an award recommendation by seconding it, optionally with a note.',
+			'kpis' => array(
+				$this->_rfuKpi('Active seconds', $secTotal, null, null, 'non-deleted seconds'),
+				$this->_rfuKpi('Recommendations seconded', $secRecs, null, null, 'distinct recommendations with a second'),
+				$this->_rfuKpi('Unique seconders', $secSupporters, null, null, 'distinct supporting members'),
+				$this->_rfuKpi('Seconds with a note', $secNotes, null, null, 'seconds carrying a written note'),
+				$this->_rfuKpi('Recs with >=1 second', $secRecs, $activeRecommendations, $secPctOfRecs, 'share of active recommendations seconded'),
+			),
+			'charts' => array(),
+		);
+
+		// --- recommendation activity: before vs after Mask -------------------
+		// ork_recommendations.date_recommended (active rows only). Window math per
+		// recon (see _rfuImpact); Mask released 2026-05-13.
+		$maskDate  = '2026-05-13';
+		$recImpact = $this->_rfuImpact('recommendations', 'date_recommended', $maskDate, 'deleted_at IS NULL');
+
+		$featRecActivity = array(
+			'key'         => 'rec_activity',
+			'title'       => 'Recommendation Activity (before vs after)',
+			'description' => 'Monthly award-recommendation submission rate in the 180 days before the 3.5.2 release versus the period since launch (normalized per month).',
+			'kpis' => array(
+				$this->_rfuKpi(
+					'Award recs / month',
+					round($recImpact['afterPerMonth'], 1),
+					null,
+					null,
+					'avg award recommendations per month since 3.5.2 (was ' . $recImpact['beforePerMonth'] . '/mo)',
+					$recImpact['delta'],
+					$recImpact['deltaDir']
+				),
+			),
+			'charts' => array(
+				array(
+					'id'         => 'rfu-impact-mask',
+					'type'       => 'column',
+					'title'      => 'Award recommendations / month: before vs after 3.5.2',
+					'categories' => array('Award recommendations'),
+					'series'     => array(
+						array(
+							'name' => 'Avg/mo before (180d)',
+							'data' => array(round($recImpact['beforePerMonth'], 1)),
+						),
+						array(
+							'name' => 'Avg/mo after',
+							'data' => array(round($recImpact['afterPerMonth'], 1)),
+						),
+					),
+				),
+			),
+		);
+
+		$release352 = array(
+			'version' => '3.5.2',
+			'name'    => 'Mask',
+			'date'    => '2026-05-13',
+			'blurb'   => 'Profile storytelling: custom nameplates, milestones, and recommendation seconds.',
+			'features' => array($featNameplate, $featViewerFonts, $featMilestones, $featRecSeconds, $featRecActivity),
+		);
+
+		// ====================================================================
+		// RELEASE 3.5.1 — Owl
+		// ====================================================================
+
+		// --- event RSVP (ork_event_rsvp) -------------------------------------
+		$rsvpTotal = $this->_rfuScalar(
+			"SELECT COUNT(*) AS c FROM `{$p}event_rsvp`"
+		);
+		$rsvpUsers = $this->_rfuScalar(
+			"SELECT COUNT(DISTINCT mundane_id) AS c FROM `{$p}event_rsvp`"
+		);
+		$rsvpBreak = $this->_rfuBreakdown(
+			"SELECT status AS k, COUNT(*) AS c FROM `{$p}event_rsvp`
+			 WHERE status IS NOT NULL AND status <> ''
+			 GROUP BY status ORDER BY c DESC, status ASC"
+		);
+		$rsvpGoing = $this->_rfuScalar(
+			"SELECT COUNT(*) AS c FROM `{$p}event_rsvp` WHERE status = 'going'"
+		);
+		$rsvpInterested = $this->_rfuScalar(
+			"SELECT COUNT(*) AS c FROM `{$p}event_rsvp` WHERE status = 'interested'"
+		);
+
+		// --- RSVP show rate: 'going' RSVPs to PAST events (event_start <= now)
+		// that have a matching attendance sign-in at the SAME event
+		// (event_id - any instance of the event counts). Join/filter mirror the recon ground-truth.
+		$nowStr = date('Y-m-d H:i:s');
+		$nowStr = preg_replace('/[^0-9: -]/', '', $nowStr);
+		$this->db->Clear();
+		$showGoingPast = 0;
+		$showAttended  = 0;
+		$showRow = $this->db->query(
+			"SELECT COUNT(DISTINCT rsvp.rsvp_id) AS going_past,
+			        COUNT(DISTINCT CASE WHEN att.attendance_id IS NOT NULL THEN rsvp.rsvp_id END) AS going_attended
+			 FROM `{$p}event_rsvp` rsvp
+			 JOIN `{$p}event_calendardetail` cd
+			   ON rsvp.event_calendardetail_id = cd.event_calendardetail_id
+			 LEFT JOIN `{$p}attendance` att
+			   ON att.mundane_id = rsvp.mundane_id
+			  AND att.event_id = cd.event_id
+			 WHERE rsvp.status = 'going'
+			   AND cd.event_start <= '{$nowStr}'"
+		);
+		if ($showRow !== false && $showRow->next()) {
+			$showGoingPast = (int)$showRow->going_past;
+			$showAttended  = (int)$showRow->going_attended;
+		}
+		$showNoShow   = max(0, $showGoingPast - $showAttended);
+		$showRatePct  = ($showGoingPast > 0)
+			? round(100.0 * $showAttended / $showGoingPast, 2)
+			: null;
+
+		$featEventRsvp = array(
+			'key'         => 'event_rsvp',
+			'title'       => 'Event RSVP',
+			'description' => 'Players signal attendance on event pages as going or interested.',
+			'kpis' => array(
+				$this->_rfuKpi('Total RSVPs', $rsvpTotal, null, null, 'rows in event RSVP'),
+				$this->_rfuKpi('Unique RSVPers', $rsvpUsers, $denom, $pct($rsvpUsers), 'distinct players who RSVPed'),
+				$this->_rfuKpi("RSVP'd Going", $rsvpGoing, null, null, "RSVPs with status 'going'"),
+				$this->_rfuKpi("RSVP'd Interested", $rsvpInterested, null, null, "RSVPs with status 'interested'"),
+				$this->_rfuKpi(
+					'RSVP show rate',
+					$showAttended,
+					$showGoingPast,
+					$showRatePct,
+					"'going' RSVPs to past events where the player has any attendance/sign-in at that event (matched on player + event_id)",
+					null,
+					null,
+					"of 'going' RSVPs showed up"
+				),
+			),
+			'charts' => array(
+				$this->_rfuChartFromBreakdown('rfu-rsvp', 'pie', 'RSVP status', $rsvpBreak, 'RSVPs'),
+				array(
+					'id'         => 'rfu-rsvp-show',
+					'type'       => 'pie',
+					'title'      => "Attended vs no-show ('going' RSVPs)",
+					'categories' => array('Attended', 'No-show'),
+					'data'       => array($showAttended, $showNoShow),
+				),
+			),
+		);
+
+		$release351 = array(
+			'version' => '3.5.1',
+			'name'    => 'Owl',
+			'date'    => '2026-04-18',
+			'blurb'   => 'A supercharged Event RSVP tab.',
+			'features' => array($featEventRsvp),
+		);
+
+		// ====================================================================
+		// RELEASE 3.5.0 — Dragon
+		// ====================================================================
+
+		// --- custom About pages (org design tables) --------------------------
+		$aboutKingdom = $this->_rfuScalar(
+			"SELECT COUNT(*) AS c FROM `{$p}kingdom_design` WHERE about_enabled = 1"
+		);
+		$aboutPark = $this->_rfuScalar(
+			"SELECT COUNT(*) AS c FROM `{$p}park_design` WHERE about_enabled = 1"
+		);
+		$aboutUnit = $this->_rfuScalar(
+			"SELECT COUNT(*) AS c FROM `{$p}unit_design` WHERE about_enabled = 1"
+		);
+		$featCustomAbout = array(
+			'key'         => 'custom_about',
+			'title'       => 'Custom About Pages',
+			'description' => 'Kingdoms, parks and units opt into a designed public About page.',
+			'kpis' => array(
+				$this->_rfuKpi('Kingdoms with About', $aboutKingdom, null, null, 'kingdom_design.about_enabled = 1'),
+				$this->_rfuKpi('Parks with About', $aboutPark, null, null, 'park_design.about_enabled = 1'),
+				$this->_rfuKpi('Units with About', $aboutUnit, null, null, 'unit_design.about_enabled = 1'),
+			),
+			'charts' => array(),
+		);
+
+		// --- heraldry adoption -----------------------------------------------
+		$playerHeraldry = $this->_rfuScalar(
+			"SELECT COUNT(*) AS c FROM `{$p}mundane` WHERE has_heraldry = 1"
+		);
+		$eventHeraldry = $this->_rfuScalar(
+			"SELECT COUNT(*) AS c FROM `{$p}event` WHERE has_heraldry = 1"
+		);
+		$eventBanner = $this->_rfuScalar(
+			"SELECT COUNT(*) AS c FROM `{$p}event` WHERE has_banner = 1"
+		);
+		$featHeraldry = array(
+			'key'         => 'heraldry',
+			'title'       => 'Heraldry Adoption',
+			'description' => 'Players and events display custom heraldry and banners.',
+			'kpis' => array(
+				$this->_rfuKpi('Players with heraldry', $playerHeraldry, $denom, $pct($playerHeraldry), 'players with has_heraldry on'),
+				$this->_rfuKpi('Events with heraldry', $eventHeraldry, null, null, 'events with has_heraldry on'),
+				$this->_rfuKpi('Events with a banner', $eventBanner, null, null, 'events with has_banner on'),
+			),
+			'charts' => array(),
+		);
+
+		// --- tournament module -----------------------------------------------
+		$tourTotal = $this->_rfuScalar(
+			"SELECT COUNT(*) AS c FROM `{$p}tournament`"
+		);
+		$bracketTotal = $this->_rfuScalar(
+			"SELECT COUNT(*) AS c FROM `{$p}bracket`"
+		);
+		$tourStatusBreak = $this->_rfuBreakdown(
+			"SELECT status AS k, COUNT(*) AS c FROM `{$p}tournament`
+			 WHERE status IS NOT NULL AND status <> ''
+			 GROUP BY status ORDER BY c DESC, status ASC"
+		);
+		$bracketStyleBreak = $this->_rfuBreakdown(
+			"SELECT style AS k, COUNT(*) AS c FROM `{$p}bracket`
+			 WHERE style IS NOT NULL AND style <> ''
+			 GROUP BY style ORDER BY c DESC, style ASC"
+		);
+		$featTournaments = array(
+			'key'         => 'tournaments',
+			'title'       => 'Tournament Module',
+			'description' => 'Organizers run bracketed tournaments tied to events.',
+			'kpis' => array(
+				$this->_rfuKpi('Total tournaments', $tourTotal, null, null, 'rows in tournament'),
+				$this->_rfuKpi('Total brackets', $bracketTotal, null, null, 'rows in bracket'),
+			),
+			'charts' => array(
+				$this->_rfuChartFromBreakdown('rfu-tour-status', 'pie', 'Tournament status', $tourStatusBreak, 'Tournaments'),
+				$this->_rfuChartFromBreakdown('rfu-bracket-style', 'bar', 'Bracket types', $bracketStyleBreak, 'Brackets'),
+			),
+		);
+
+		// --- weekly recap ----------------------------------------------------
+		$recapWeeks = $this->_rfuScalar(
+			"SELECT COUNT(*) AS c FROM `{$p}weekly_recap`"
+		);
+		$featWeeklyRecap = array(
+			'key'         => 'weekly_recap',
+			'title'       => 'Weekly Recap',
+			'description' => 'Auto-generated weekly digests of kingdom activity.',
+			'kpis' => array(
+				$this->_rfuKpi('Weeks computed', $recapWeeks, null, null, 'rows in weekly recap'),
+			),
+			'charts' => array(),
+		);
+
+		// --- feature awareness (What's New) ----------------------------------
+		$awarenessBreak = $this->_rfuBreakdown(
+			"SELECT version AS k, COUNT(DISTINCT mundane_id) AS c FROM `{$p}whats_new_seen`
+			 WHERE version IS NOT NULL AND version <> ''
+			 GROUP BY version ORDER BY version DESC"
+		);
+		// latest version = max version string; its distinct-player count.
+		$latestVersion = '';
+		$latestSeen = 0;
+		foreach ($awarenessBreak as $row) {
+			if ($latestVersion === '' || strcmp($row['k'], $latestVersion) > 0) {
+				$latestVersion = $row['k'];
+				$latestSeen = (int)$row['c'];
+			}
+		}
+		$featAwareness = array(
+			'key'         => 'awareness',
+			'title'       => 'Feature Awareness (What\'s New)',
+			'description' => 'Players are shown a What\'s New modal each release; this tracks who has seen each version.',
+			'kpis' => array(
+				$this->_rfuKpi(
+					'Saw latest (' . ($latestVersion !== '' ? $latestVersion : 'n/a') . ')',
+					$latestSeen,
+					$denom,
+					$pct($latestSeen),
+					'distinct players who saw the newest What\'s New'
+				),
+			),
+			'charts' => array(
+				$this->_rfuChartFromBreakdown('rfu-awareness', 'bar', 'Players who viewed each What\'s-New version', $awarenessBreak, 'Players'),
+			),
+		);
+
+		// --- activity impact: before vs after the Dragon redesign ------------
+		// Events use ork_event_calendardetail.event_start (the scheduled date);
+		// RSVPs use ork_event_rsvp.modified. Window math per recon (see _rfuImpact).
+		$dragonDate = '2026-04-02';
+		$evtImpact  = $this->_rfuImpact('event_calendardetail', 'event_start', $dragonDate);
+		$rsvpImpact = $this->_rfuImpact('event_rsvp', 'modified', $dragonDate);
+
+		$featActivityImpact = array(
+			'key'         => 'activity_impact',
+			'title'       => 'Activity Impact (before vs after redesign)',
+			'description' => 'Monthly event-creation and RSVP rates in the 180 days before the 3.5.0 redesign versus the period since launch (normalized per month).',
+			'kpis' => array(
+				$this->_rfuKpi(
+					'Events scheduled / month',
+					round($evtImpact['afterPerMonth'], 1),
+					null,
+					null,
+					'avg events scheduled per month since 3.5.0 (was ' . $evtImpact['beforePerMonth'] . '/mo)',
+					$evtImpact['delta'],
+					$evtImpact['deltaDir']
+				),
+				$this->_rfuKpi(
+					'Event RSVPs / month',
+					round($rsvpImpact['afterPerMonth'], 1),
+					null,
+					null,
+					'avg RSVPs per month since 3.5.0 (was ' . $rsvpImpact['beforePerMonth'] . '/mo)',
+					$rsvpImpact['delta'],
+					$rsvpImpact['deltaDir']
+				),
+			),
+			'charts' => array(
+				array(
+					'id'         => 'rfu-impact-dragon',
+					'type'       => 'column',
+					'title'      => 'Monthly activity: before vs after 3.5.0',
+					'categories' => array('Events scheduled', 'Event RSVPs'),
+					'series'     => array(
+						array(
+							'name' => 'Avg/mo before (180d)',
+							'data' => array(
+								round($evtImpact['beforePerMonth'], 1),
+								round($rsvpImpact['beforePerMonth'], 1),
+							),
+						),
+						array(
+							'name' => 'Avg/mo after',
+							'data' => array(
+								round($evtImpact['afterPerMonth'], 1),
+								round($rsvpImpact['afterPerMonth'], 1),
+							),
+						),
+					),
+				),
+			),
+		);
+
+		$release350 = array(
+			'version' => '3.5.0',
+			'name'    => 'Dragon',
+			'date'    => '2026-04-02',
+			'blurb'   => 'The big redesign: new profiles, events, tournaments — plus org-level adoption signals.',
+			'features' => array(
+				$featCustomAbout,
+				$featHeraldry,
+				$featTournaments,
+				$featWeeklyRecap,
+				$featAwareness,
+				$featActivityImpact,
+			),
+		);
+
+		return array(
+			'generated_at' => date('Y-m-d H:i:s'),
+			'totals' => array(
+				'active_players'         => (int)$activePlayers,
+				'players_with_design'    => (int)$playersWithDesign,
+				'active_recommendations' => (int)$activeRecommendations,
+			),
+			'releases' => array($release352, $release351, $release350),
+		);
+	}
+
+	/**
+	 * Run a single-column scalar COUNT-style query and return it as an int.
+	 * The query MUST alias its scalar as `c`. Matches the file's $this->db
+	 * query/next idiom; Clear() first to drop stale PDO bindings.
+	 */
+	private function _rfuScalar($sql) {
+		$this->db->Clear();
+		$r = $this->db->query($sql);
+		if ($r !== false && $r->next()) {
+			return (int)$r->c;
+		}
+		return 0;
+	}
+
+	/**
+	 * Count rows of $table where its date column falls inclusively within
+	 * [$start, $end] (Y-m-d strings), with an optional extra WHERE clause.
+	 * Used for release before/after window math.
+	 */
+	private function _rfuWindowCount($table, $dateCol, $start, $end, $extraWhere = '') {
+		$p = DB_PREFIX;
+		// $start/$end are code-generated Y-m-d strings (date()/strtotime), never
+		// user input, so direct inlining matches this file's date-range idiom.
+		$start = preg_replace('/[^0-9-]/', '', $start);
+		$end   = preg_replace('/[^0-9-]/', '', $end);
+		$where = "`{$dateCol}` >= '{$start} 00:00:00'"
+			. " AND `{$dateCol}` <= '{$end} 23:59:59'";
+		if ($extraWhere !== '') {
+			$where .= ' AND ' . $extraWhere;
+		}
+		return $this->_rfuScalar(
+			"SELECT COUNT(*) AS c FROM `{$p}{$table}` WHERE {$where}"
+		);
+	}
+
+	/**
+	 * Compute a before/after per-month impact bundle for a release, matching the
+	 * recon windowDefinition exactly:
+	 *   BEFORE = [release - 180 days, release - 1 day]  -> 180 / 30.44 months
+	 *   AFTER  = [release, today]                       -> inclusive days / 30.44
+	 * Per-month rate = count / months. Delta% = round((after-before)/before*100).
+	 * Divide-by-zero guarded (delta=null, deltaDir='flat' when before rate is 0).
+	 *
+	 * @return array {beforeCount, afterCount, beforePerMonth, afterPerMonth,
+	 *                deltaPct(int|null), delta(string|null), deltaDir}
+	 */
+	private function _rfuImpact($table, $dateCol, $releaseDate, $extraWhere = '') {
+		$today  = date('Y-m-d');
+		$relTs  = strtotime($releaseDate);
+		$beforeStart = date('Y-m-d', strtotime('-180 days', $relTs));
+		$beforeEnd   = date('Y-m-d', strtotime('-1 day', $relTs));
+
+		$beforeCount = $this->_rfuWindowCount($table, $dateCol, $beforeStart, $beforeEnd, $extraWhere);
+		$afterCount  = $this->_rfuWindowCount($table, $dateCol, $releaseDate, $today, $extraWhere);
+
+		// Inclusive day spans -> month equivalents (30.44 days/month, per recon).
+		$beforeMonths = 180 / 30.44;
+		$afterDays    = (int)round((strtotime($today) - $relTs) / 86400) + 1; // inclusive
+		$afterMonths  = $afterDays / 30.44;
+
+		$beforePerMonth = ($beforeMonths > 0) ? round($beforeCount / $beforeMonths, 1) : 0.0;
+		$afterPerMonth  = ($afterMonths > 0) ? round($afterCount / $afterMonths, 1) : 0.0;
+
+		if ($beforePerMonth > 0) {
+			$deltaPct = (int)round((($afterPerMonth - $beforePerMonth) / $beforePerMonth) * 100);
+			$delta    = ($deltaPct >= 0 ? '+' : '') . $deltaPct . '%';
+			if ($afterPerMonth > $beforePerMonth) {
+				$deltaDir = 'up';
+			} elseif ($afterPerMonth < $beforePerMonth) {
+				$deltaDir = 'down';
+			} else {
+				$deltaDir = 'flat';
+			}
+		} else {
+			$deltaPct = null;
+			$delta    = null;
+			$deltaDir = 'flat';
+		}
+
+		return array(
+			'beforeCount'    => (int)$beforeCount,
+			'afterCount'     => (int)$afterCount,
+			'beforePerMonth' => $beforePerMonth,
+			'afterPerMonth'  => $afterPerMonth,
+			'deltaPct'       => $deltaPct,
+			'delta'          => $delta,
+			'deltaDir'       => $deltaDir,
+		);
+	}
+
+	/**
+	 * Run a "SELECT <label> AS k, COUNT(*) AS c ... GROUP BY ..." query and
+	 * return an ordered array of ['k' => label, 'c' => int count] rows.
+	 */
+	private function _rfuBreakdown($sql) {
+		$this->db->Clear();
+		$out = array();
+		$r = $this->db->query($sql);
+		if ($r !== false && $r->size() > 0) {
+			while ($r->next()) {
+				$out[] = array('k' => (string)$r->k, 'c' => (int)$r->c);
+			}
+		}
+		return $out;
+	}
+
+	/**
+	 * Build one KPI tile entry for the data contract.
+	 *
+	 * @param string|null $delta    Preformatted signed percent string (e.g. '+37%'); null when N/A.
+	 * @param string|null $deltaDir 'up' | 'down' | 'flat' — drives the colored delta pill.
+	 */
+	private function _rfuKpi($label, $value, $denom, $pct, $hint, $delta = null, $deltaDir = null, $pctLabel = null, $suffix = null) {
+		$kpi = array(
+			'label'    => $label,
+			'value'    => $value,
+			'denom'    => ($denom === null) ? null : (int)$denom,
+			'pct'      => ($pct === null) ? null : $pct,
+			'hint'     => ($hint === null) ? null : $hint,
+			'delta'    => ($delta === null) ? null : (string)$delta,
+			'deltaDir' => ($deltaDir === null) ? 'flat' : $deltaDir,
+		);
+		if ($pctLabel !== null && $pctLabel !== '') {
+			$kpi['pctLabel'] = (string)$pctLabel;
+		}
+		if ($suffix !== null && $suffix !== '') {
+			$kpi['suffix'] = (string)$suffix;
+		}
+		return $kpi;
+	}
+
+	/**
+	 * Convert a breakdown array into a chart entry. Always emits a valid chart
+	 * (empty categories/data when the breakdown is empty) so the template can
+	 * render a graceful "No data yet" state.
+	 *
+	 * @param string $type 'column' | 'bar' | 'pie'
+	 */
+	private function _rfuChartFromBreakdown($id, $type, $title, $breakdown, $seriesName = 'Count') {
+		$categories = array();
+		$data = array();
+		foreach ($breakdown as $row) {
+			$categories[] = $row['k'];
+			$data[] = (int)$row['c'];
+		}
+		$chart = array(
+			'id'         => $id,
+			'type'       => $type,
+			'title'      => $title,
+			'categories' => $categories,
+		);
+		if ($type === 'pie') {
+			$chart['data'] = $data;
+		} else {
+			$chart['series'] = array(
+				array('name' => $seriesName, 'data' => $data),
+			);
+		}
+		return $chart;
+	}
+
 }

--- a/system/lib/ork3/pride_gradients.php
+++ b/system/lib/ork3/pride_gradients.php
@@ -19,6 +19,7 @@ return [
 	'pansexual'   => ['name' => 'Pansexual',                    'colors' => ['#ff218c','#ffd800','#21b1ff']],
 	'polysexual'  => ['name' => 'Polysexual',                   'colors' => ['#f714ba','#01d66a','#1594f6']],
 	'asexual'     => ['name' => 'Asexual',                      'colors' => ['#000000','#a3a3a3','#ffffff','#800080']],
+	'demisexual'  => ['name' => 'Demisexual',                   'colors' => ['#000000','#ffffff','#6e0070','#d2d2d2']],
 	'aromantic'   => ['name' => 'Aromantic',                    'colors' => ['#3da542','#a7d379','#ffffff','#a9a9a9','#000000']],
 	'transgender' => ['name' => 'Transgender',                  'colors' => ['#5bcffa','#f5a9b8','#ffffff','#f5a9b8','#5bcffa']],
 	'nonbinary'   => ['name' => 'Nonbinary',                    'colors' => ['#fcf434','#ffffff','#9c59d1','#2c2c2c']],


### PR DESCRIPTION
This branch bundles a few improvements.

---

## 1. Release Feature Utilization report (ORK Admin)

Adds an **ORK-Admin-only** report at `Reports/release_utilization` (linked from the Admin reports sidebar) that measures adoption of each major release's user-facing features. Rendered with Highcharts and fully dark-mode aware.

### What it shows
- **3.5.2 Mask** — nameplate customization (color / prefix / suffix / pride gradient / font / pronunciation / About), accessibility fonts, personal milestones, recommendation seconds, and award-recs before/after.
- **3.5.1 Owl** — Event RSVP "going / interested" KPIs, status pie, and an **event-level RSVP show rate** (going RSVPs matched to an attendance record at the same event).
- **3.5.0 Dragon** — custom About pages, heraldry, tournaments, weekly recap, What's-New awareness, and events/RSVP **before-vs-after** impact charts.

### Design
- All SQL in `Report::ReleaseFeatureUtilization()` behind a generic `releases → features → kpis/charts` data contract, so adding future features is a data-only change (no template churn).
- ORK-Admin gated via `HasAuthority($uid, AUTH_ADMIN, 0, AUTH_ADMIN)`; anonymous access redirects.
- **"Active players" denominator** (drives all percentages) = distinct players with at least one attendance record in the trailing 2 years.

### Metric notes
- "Events scheduled / month" counts `event_calendardetail` rows by `event_start` (there is no event-creation timestamp).
- RSVP show rate matches on player + `event_id` (any instance of the event), `COUNT(DISTINCT rsvp_id)` to avoid double-counting recurring events.

### Files
- `system/lib/ork3/class.Report.php` — `ReleaseFeatureUtilization()` + helpers
- `orkui/controller/controller.Reports.php` — `release_utilization()` action
- `orkui/model/model.Reports.php` — pass-through
- `orkui/template/default/Reports_release_utilization.tpl` — new Highcharts dashboard
- `orkui/template/default/Admin_index.tpl` + `orkui/template/revised-frontend/Admin_index.tpl` — sidebar links

---

## 2. Demisexual pride flag (Amtpride nameplate)

Adds the **Demisexual** preset to the Amtpride Nameplate flag set in `system/lib/ork3/pride_gradients.php` (black / white / purple / grey), grouped with the other ace-spectrum flags. The picker, the JS live-preview, and server-side save-validation all read this single-source map dynamically, so no other changes are required.

---

## 3. Bugfix — Universal Search stays open on mouse-out

The top-bar Universal Search expanded on `:hover`, so clicking into the hover-revealed input never set the persistent `.nav-search-open` class — mousing off then dropped `:hover` and collapsed/blurred the box.

Now focusing the input **locks it open**, and the outside-click handler **fully closes** it (collapse + clear). The search stays open until an explicit click outside it or Escape. Hover-to-reveal and result navigation are unchanged. (`orkui/template/default/default.theme`, JS only.)

---

### Testing
Verified against the live dev DB: lint clean, report renders HTTP 200 as admin with anonymous redirect, every KPI/chart cross-checked to direct DB queries. New pride flag verified present in the gradient map and rendered by the picker's map loop. Universal Search fix confirmed served on the rendered page with no errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)