### PR TITLE
Kingdom & Principality enhancements + fixes (misc 06-03)

### DIFF
--- a/db-migrations/2026-06-03-add-include-principality-in-statistics-config.sql
+++ b/db-migrations/2026-06-03-add-include-principality-in-statistics-config.sql
@@ -1,0 +1,23 @@
+-- Add IncludePrincipalityInStatistics configuration for all existing kingdoms.
+-- Per-kingdom admin toggle: when ON (1), kingdom-scoped statistics, graphs, and
+-- reports fold in data from the kingdom's active child principalities. Defaults
+-- to 0 (OFF). Only surfaces in the Kingdom Administration dialog for kingdoms
+-- that actually have child principalities (gated in the controller).
+-- Kingdoms that already have this key are skipped via the LEFT JOIN guard, so
+-- this migration is re-runnable.
+INSERT INTO ork_configuration (type, var_type, id, `key`, value, user_setting, allowed_values, modified)
+SELECT
+    'Kingdom'                            AS type,
+    'fixed'                              AS var_type,
+    k.kingdom_id                         AS id,
+    'IncludePrincipalityInStatistics'    AS `key`,
+    '0'                                  AS value,
+    1                                    AS user_setting,
+    'null'                               AS allowed_values,
+    NOW()                                AS modified
+FROM ork_kingdom k
+LEFT JOIN ork_configuration c
+    ON  c.type = 'Kingdom'
+    AND c.id   = k.kingdom_id
+    AND c.key  = 'IncludePrincipalityInStatistics'
+WHERE c.configuration_id IS NULL;

--- a/db-migrations/2026-06-03-kingdomaward-is-title-authoritative.sql
+++ b/db-migrations/2026-06-03-kingdomaward-is-title-authoritative.sql
@@ -1,0 +1,9 @@
+-- Make ork_kingdomaward.is_title / title_class the authoritative per-kingdom value.
+-- Historically GetAwardList read ifnull(a.is_title, ka.is_title), so the global award's
+-- value always won and a kingdom could never override (e.g. mark "Master" a title locally).
+-- The read now uses ka.is_title directly; backfill existing rows from the linked system
+-- award so the displayed values are unchanged on deploy, then per-kingdom edits stick.
+UPDATE ork_kingdomaward ka
+  JOIN ork_award a ON a.award_id = ka.award_id
+  SET ka.is_title = a.is_title,
+      ka.title_class = a.title_class;

--- a/docs/superpowers/specs/2026-06-03-include-principality-in-statistics-design.md
+++ b/docs/superpowers/specs/2026-06-03-include-principality-in-statistics-design.md
@@ -1,0 +1,59 @@
+# Include Principality in Statistics — implementation contract
+
+Date: 2026-06-03. This is the SHARED CONTRACT for the workflow agents. Every agent reads this and follows the helper signatures + file ownership EXACTLY so the surfaces integrate.
+
+## Goal
+A per-kingdom admin toggle **"Include Principality in Statistics"** (default OFF). When ON, every kingdom-scoped statistic/graph/report/list for that kingdom folds in its active child principalities' data (attendance, player counts, awards, recs, units, events, map). Independently (NOT gated by the toggle): principality parks always appear in parks dropdowns, and principality members are always included in kingdom-scoped player search. Plus a set of legit bugfixes.
+
+## Storage (mirror existing `AwardRecsPublic` exactly)
+Kingdom settings are EAV rows in `ork_configuration` (`type='Kingdom'`, `id=kingdom_id`, `key`, `value` = JSON string, `user_setting=1`, `var_type='fixed'`). NEW key: **`IncludePrincipalityInStatistics`**, default value `'0'`.
+- Backfill migration for existing kingdoms (mirror `db-migrations/2026-03-06-add-award-recs-public-config.sql` AND the follow-up `2026-03-20-fix-award-recs-public-user-setting.sql` — set `user_setting=1` from the start). Read those two files and mirror.
+- New-kingdom seed: mirror the `AwardRecsPublic` seed in `CreateKingdom` (`class.Kingdom.php` ~342-352) for the new key, default `'0'`.
+- Generic save path already handles it: `setconfig` (controller.KingdomAjax.php:117-143) → `SetKingdomDetails` (class.Kingdom.php:493-534) → `Common::update_config`. NO new endpoint.
+
+## HELPER CONTRACT — implemented in `system/lib/ork3/class.Kingdom.php` (Agent KINGDOM)
+All return `array` of int kingdom ids. Callers build IN-lists via `implode(',', array_map('intval', $ids))`.
+```php
+// Active child-principality kingdom ids of $kingdomId ([] if none). Uses the same
+// criteria as GetPrincipalities (ork_kingdom.parent_kingdom_id = $kingdomId AND active='Active').
+public function GetChildPrincipalityIds($kingdomId)        // => int[]
+
+// [$kingdomId, ...child principality ids] — ALWAYS includes children.
+// Structural scoping (parks dropdown, player search) uses THIS.
+public function GetFamilyKingdomIds($kingdomId)            // => int[]
+
+// True iff the IncludePrincipalityInStatistics config flag for $kingdomId is '1'.
+public function StatsIncludesPrincipalities($kingdomId)    // => bool
+
+// GetFamilyKingdomIds($kingdomId) when StatsIncludesPrincipalities is true AND
+// there are children; otherwise [$kingdomId]. STATS/REPORT scoping uses THIS.
+public function GetStatsKingdomIds($kingdomId)             // => int[]
+```
+Reachable everywhere as `Ork3::$Lib->kingdom->GetStatsKingdomIds($kid)` and via `$this->Kingdom->...` in controllers. A principality (no children) and a childless kingdom both resolve to `[$kid]`, so normal behavior is unchanged — only a parent-with-children-and-flag-on expands.
+
+## Conversion pattern for surfaces
+Replace a hardcoded `<col>.kingdom_id = '<X>'` (or `= <X>`) with `<col>.kingdom_id IN (<list>)` where `<list> = implode(',', GetStatsKingdomIds($KingdomId))` for STATS/reports, or `GetFamilyKingdomIds($KingdomId)` for the always-on structural surfaces. Keep existing dedup logic (DISTINCT-by-week/month/player) — it dedupes across the family automatically because the IN-list widens the park set. Where an `ORDER BY ... CASE WHEN <col>.kingdom_id = <X>` pins the home kingdom, keep that pin on the original `<X>` (so the kingdom's own rows still sort first).
+
+## FILE OWNERSHIP (no two agents touch the same file)
+
+### Phase 1 — Foundation + independent bugfixes (parallel)
+- **MIG** — NEW file `db-migrations/2026-06-03-add-include-principality-in-statistics-config.sql` (backfill all kingdoms, user_setting=1, var_type='fixed', value '0'). Then APPLY it locally: `docker exec -i ork3-php8-db mariadb -u root -proot ork < <file>`. Verify rows exist.
+- **KINGDOM** — `system/lib/ork3/class.Kingdom.php`: implement the 4 helpers above; seed the new config in `CreateKingdom` (mirror AwardRecsPublic); BUGFIX GetParks (a) support an optional `KingdomIds` array param → `WHERE p.kingdom_id IN (...)` (default keeps single-`KingdomId` behavior), (b) remove the dead `is_principality`/`parent_park_id` references (columns don't exist; `ParentParkId`/`ParentOf` always null — drop them); BUGFIX `SetKingdomParent` add cycle prevention (reject if the proposed parent is the kingdom itself OR a descendant of it — walk the parent chain to detect a cycle); BUGFIX `GetPrincipalities` return `Success()` with empty `Principalities` array when none found (not `InvalidParameter`).
+- **AUTH** — `system/lib/ork3/class.Authorization.php`: add a cycle/depth guard to the `parent_kingdom_id` recursion in `HasAuthority` (~830-840) — pass a visited-set or a depth cap so a cyclic `parent_kingdom_id` cannot infinite-recurse. Touch ONLY the traversal block. (NOTE: this file has a local login bypass on lines ~327/330 — DO NOT touch those lines or anything else; only the HasAuthority parent-traversal.)
+- **COMMON** — `system/lib/ork3/common.php`: remove the dead/broken principality branch in `create_officers` (~506-512) that tests the undefined `$for_principality` and misattributes officers to the parent. Principalities are correctly seeded via the standard `create_officers($id,0)` path; just delete the broken branch (keep the normal officer seeding intact).
+- **MODELPRINZ** — `orkui/model/model.Principality.php`: fix `get_officers`/`set_officers` (~38-54) to call the correct Principality lib methods (`GetPrincipalityOfficers`/`SetPrincipalityOfficer`) OR map `PrincipalityId`→`KingdomId`, so they operate on the right id instead of 0.
+- **AWARD** — `system/lib/ork3/class.Award.php` (+ `class.Player.php` if needed): `LookupAward` (~36-45) returns a kingdomaward id even when `find()` fails — add an existence guard so a missing row returns an invalid/zero id; and in `Player::AddAward` (~1742/1779) do not save an award with a zero/invalid `kingdomaward_id` (return InvalidParameter). Prevents orphaned grants.
+
+### Phase 2 — Surfaces (parallel, after Phase 1; build against the helper contract above)
+- **REPORT** — `system/lib/ork3/class.Report.php`: for EVERY kingdom-scoped report/stat method, swap the hardcoded `kingdom_id = $request[KingdomId]` filter to `kingdom_id IN (` + `implode(',', Ork3::$Lib->kingdom->GetStatsKingdomIds($request['KingdomId']))` + `)`. Methods/anchors (verify each): GetKingdomParkAverages (~1452,1457), GetKingdomParkMonthlyAverages (~1495), GetPlayerRoster (~1304,1357), GetActivePlayers (~1801), AttendanceSummary (~954), GetDistinctPlayerStats (~1669), GetMonthlyChartData (~1715), the `_Recap*` helpers (~3838-4096), ClassMasters (~153), PlayerAwards (~278), CrownQualed (~223,238,242), PlayerAwardRecommendations (~441), peerage/knight reports (~362,695), Guilds, UnitSummary (~820,884). Preserve dedup + the home-kingdom ORDER BY pin. Methods that take a `PrincipalityId` already resolve to `[self]` via the helper — leave their behavior intact. Do NOT change non-kingdom-scoped methods.
+- **CTRLKINGDOM** — `orkui/controller/controller.Kingdom.php`: (1) `park_averages_json`/`park_monthly_json` raw SQL (`p.kingdom_id = {$kid}` at ~96,117,133,156 + trend queries) → use `GetStatsKingdomIds($kid)` IN-list so the hero stat cards + footer totals roll up when the flag is on; (2) Events queries (`e.kingdom_id = {$kid}` at ~220,256,488,519,738) → `GetStatsKingdomIds`; (3) the "Parks (N)" hero count: when the flag is on, reflect the family park count; (4) compute `$this->data['HasChildPrincipalities'] = (empty($IsPrinz) && count(child principalities) > 0)` near line 422; (5) when building `$this->data['AdminConfig']` (~645-651), DROP the `IncludePrincipalityInStatistics` row when `!HasChildPrincipalities` so the toggle only shows for kingdoms that have principalities.
+- **CTRLAJAX** — `orkui/controller/controller.KingdomAjax.php`: (1) `playersearch` (~836) — replace `AND m.kingdom_id = {$kid}` with `AND m.kingdom_id IN (` + `implode(',', GetFamilyKingdomIds($kid))` + `)` (ALWAYS family, not toggle-gated); keep the ORDER BY home-kingdom pin on `$kid`. (2) `getparks` dropdown action (~593-600) — return family parks (ALWAYS): call `GetParks(['KingdomIds'=>GetFamilyKingdomIds($kid)])` (the new param from Agent KINGDOM) or union per-id. Do NOT change `getkingdoms`.
+- **ADMINUI** — `orkui/template/revised-frontend/script/revised.js`: in `buildConfig()` (~4486-4576) add a branch for `cfg.Key === 'IncludePrincipalityInStatistics'` rendering a checkbox whose `.value` is `'1'`/`'0'` (so the existing `wireConfig` collector + `setconfig` persist it unchanged); set `inp.dataset.configId = cfg.ConfigurationId`. Add the help text to the `keyHints` map (~4500-4505) keyed `'IncludePrincipalityInStatistics'`: "When looking at statistics, graphs, and reports, include relevant metrics from Principality(ies) such as attendance and player counts." (renders as the existing `.kn-cfg-hint` `(?)` data-hint tooltip — dark-mode safe; do NOT use native title=). Add a human label "Include Principality in Statistics".
+
+### Phase 3 — Verify
+Lint every changed PHP file (`docker exec ork3-php8-app php -l <path>`), `node --check` revised.js, confirm the migration applied, and report any method the REPORT agent could not convert.
+
+## Out of scope / notes
+- Don't merge principality parks into the kingdom's MAIN park tile list — they keep their separate "Principalities" sections (already built); the toggle only affects AGGREGATE stats/reports/counts.
+- Empty promote/demote stubs in class.Principality.php and the retire-cascade are NOT in this pass.
+- class.Authorization.php cannot be committed via the pre-commit hook; that's handled separately by the human — agents just edit it.

--- a/docs/superpowers/specs/2026-06-03-kingdom-principalities-in-parks-tab-design.md
+++ b/docs/superpowers/specs/2026-06-03-kingdom-principalities-in-parks-tab-design.md
@@ -1,0 +1,73 @@
+# Kingdom page: fold Principalities into the Parks tab
+
+Date: 2026-06-03
+Status: Approved (design), ready for implementation
+
+## Goal
+On the Kingdom profile page (Kingdomnew), remove the standalone **Principalities** tab and present principalities inside the **Parks** tab: below the kingdom's own parks, show each principality (heraldry + name + external-link icon linking to the Pr profile) with that principality's parks beneath it — in both the tile view and the list/table view. On the kingdom **Map**, draw principality parks with a distinct related pin color + a legend.
+
+## Key files
+- Controller: `orkui/controller/controller.Kingdom.php` — `profile()` (line 373); data loads at 388-416.
+- Template: `orkui/template/revised-frontend/Kingdomnew_index.tpl`
+- JS: `orkui/template/revised-frontend/script/revised.js` (+ inline `<script>` in the template, averages fill at ~2030-2086)
+- CSS: `orkui/template/revised-frontend/style/revised.css`
+
+## Existing mechanics reused
+- `park_averages_json/{id}` (controller line 63) is scoped to a single kingdom id and works for **any** kingdom row — a principality is a kingdom row, so calling it per principality returns full Avg/Wk · Avg/Mo · Total Players · Total Members for that Pr's parks. **No new stats backend.**
+- Kingdom park tiles/rows carry `data-park-id` + spinner placeholders (`.kn-avgwk-tile/.kn-avgmo-tile/.kn-avgwk-row/.kn-avgmo-row/.kn-tp-row/.kn-tm-row`); the inline averages fill (template ~2030-2086) populates them. Pr park tiles/rows use identical markup.
+- Map locations are built server-data → template loop (`$knMapLocations`, template ~45-62) → `KnConfig.mapLocations` → `knInitMap` marker loop in revised.js (~2571-2616), current pin: bg `#8B1A1A`, border `#B8860B`, glyph `#FFD700`.
+- `knSetParksView('tiles'|'list')` (revised.js ~2818) toggles `#kn-parks-tiles` vs `#kn-parks-list-view`.
+
+## Integration contract (all surfaces build against this)
+
+### Backend → template data (added in `profile()`)
+- `$this->data['principality_parks']`: ordered array, one entry per principality that has ≥1 park OR always (render even with 0 parks is acceptable; skip principalities with 0 parks). Each entry:
+  ```php
+  [ 'KingdomId' => int, 'Name' => string,
+    'parks' => array of get_park_summary(prId)['KingdomParkAveragesSummary'] rows
+               (fields: ParkId, ParkName, Title, HasHeraldry, AttendanceCount) ]
+  ```
+- `$this->data['prinz_map_parks']`: array, one entry per principality:
+  ```php
+  [ 'KingdomId' => int, 'Name' => string,
+    'parks' => GetParks(prId)['Parks'] filtered to Active=='Active'
+               (same row shape as $map_parks: Name, Location, City, Province, HasHeraldry, Directions, Description, ParkId) ]
+  ```
+- Source: iterate `$this->data['principalities']['Principalities']` (fields `KingdomId`, `Name`). Only when `!$IsPrinz`. Cost scales with # principalities (usually 0).
+
+### Template → JS DOM contract
+- Tile view: container `#kn-prinz-tile-sections` placed immediately AFTER `#kn-parks-tiles`. Inside, per principality a `<section class="kn-prinz-section" data-prinz-id="{prId}">` with:
+  - header `<a class="kn-prinz-head" href="{UIR}Kingdom/profile/{prId}"> <img class="kn-prinz-heraldry"> <span class="kn-prinz-name">{Name}</span> <i class="fas fa-external-link-alt kn-prinz-extlink"></i> </a>`
+  - a `.kn-park-tiles` grid of `.kn-park-tile` anchors identical to kingdom park tiles (data-park-id, heraldry img, name, type, two `.kn-park-tile-stat` blocks with `.kn-avgwk-tile`/`.kn-avgmo-tile` spinners).
+- List view: container `#kn-prinz-tables` placed immediately AFTER `#kn-parks-list-view`. Inside, per principality a `<div class="kn-prinz-table-wrap" data-prinz-id="{prId}">` with the same header anchor, then a `<table class="kn-table kn-sortable">` mirroring the kingdom table columns (Park, Type, Avg/Wk, Avg/Mo, Total Players, Total Members — NO edit column), rows with `data-park-id` + the `.kn-avgwk-row/.kn-avgmo-row/.kn-tp-row/.kn-tm-row` cells, and a `<tfoot>` total row with per-section ids: `#kn-prinz-{prId}-avgwk`, `-avgmo`, `-tp`, `-tm`.
+- Both Pr containers render whenever `principality_parks` is non-empty, INDEPENDENT of the kingdom's own `parkList` count (handle the kingdom-has-no-parks case).
+- Heraldry URL for a Pr (kingdom heraldry): `HTTP_KINGDOM_HERALDRY . Common::resolve_image_ext(DIR_KINGDOM_HERALDRY, sprintf("%04d", $prId))` with `onerror` fallback to `HTTP_KINGDOM_HERALDRY.'0000.jpg'`.
+- Park heraldry/type/link identical to kingdom park tiles (`Park/profile/{ParkId}`, `%05d` heraldry, `00000.jpg` fallback).
+- Remove the Principalities tab `<li data-kntab="principalities">` (~266-271) and its panel `#kn-tab-principalities` (~592-607).
+
+### Template map data
+- Extend the `$knMapLocations` builder (~45-62): after the kingdom loop, loop `$prinz_map_parks`; for each park build the same location object PLUS `'prinz' => true`, `'prName' => {Name}`, `'prId' => {KingdomId}`.
+
+### JS contract
+- Refactor the inline averages fill into `function knFillAverages(data, opts)` where `opts = { scope: Element|null (default document), footer: {avgwk, avgmo, tp, tm} element-ids or null, statCards: bool }`. Kingdom call: `scope=null, footer={kn-total-*}, statCards=true` (unchanged behavior). Per-Pr call: fetch `park_averages_json/{prId}`, `scope = the section/table-wrap for that prId, footer = {kn-prinz-{prId}-*}, statCards=false`. Scope the tile/row `querySelector` lookups to `scope` so Pr fills never touch kingdom elements (park ids are globally unique, but scoping keeps totals correct).
+- Drive per-Pr fetches from a server-emitted list `KnConfig.principalityIds = [prId, ...]` (add to the KnConfig block ~928).
+- `knSetParksView`: when showing tiles, also `show(#kn-prinz-tile-sections)` + `hide(#kn-prinz-tables)`; when list, the inverse.
+- `knInitMap` marker loop: if `loc.prinz`, PinElement bg `#2C5F8B` (steel blue), keep border `#B8860B` + glyph `#FFD700`. Add a small map legend (two swatches: Kingdom = red, Principality = steel blue) into the map sidebar/overlay. In `knRenderMapSidebar`, if `loc.prinz`, show a line like "Principality: {prName}".
+
+### CSS contract (dark-mode aware — use existing theme tokens; verify in dark mode)
+Add styles for: `.kn-prinz-section`, `.kn-prinz-head` (flex, heraldry 28-32px, name weight, hover), `.kn-prinz-heraldry`, `.kn-prinz-name`, `.kn-prinz-extlink` (muted, hints external nav), `.kn-prinz-table-wrap`, section spacing/divider, and a `— PRINCIPALITIES —` group label. Mirror existing `.kn-park-tile`/`.kn-table` look. No native tooltips; if a tip is wanted use the `data-tip` pattern.
+
+## Edge cases
+- Kingdom is itself a principality (`$IsPrinz`) → no Pr section/data (already gated).
+- Kingdom with principalities but no own parks → Pr sections still render; kingdom "No parks found" handled.
+- A principality with 0 active parks → skip it (don't render an empty section).
+- `data-park-id` uniqueness across kingdom + Prs holds (park ids global) — scope fills anyway.
+
+## Verification
+Local kingdom 6 → principality 29 (has parks). Load `Kingdom/profile/6` in Chrome (after implementation):
+1. No standalone Principalities tab; Parks tab shows kingdom parks then a Principalities area.
+2. Tile view: grouped Pr section(s) with heraldry + name + ext-link icon, Pr park tiles, stats fill in.
+3. List view: separate Pr table(s) with own totals footer; stats fill.
+4. Toggle tiles/list switches both kingdom and Pr blocks.
+5. Map: Pr parks render as steel-blue pins + legend; sidebar shows Pr name; link-out navigates to the Pr profile.
+6. Dark-mode walkthrough of all new surfaces.

--- a/orkui/controller/controller.Kingdom.php
+++ b/orkui/controller/controller.Kingdom.php
@@ -277,6 +277,50 @@ class Controller_Kingdom extends Controller {
 		exit();
 	}
 
+	// Lazy-loaded body of the kingdom profile Recommendations tab. Called by JS
+	// the first time the tab is activated; returns raw HTML for the tab's inner
+	// container (NOT a full page). Auth+visibility rules mirror profile().
+	public function recommendations_panel($kingdom_id = null) {
+		session_write_close();
+		$kingdom_id = (int)preg_replace('/[^0-9]/', '', (string)$kingdom_id);
+		if ($kingdom_id <= 0) { http_response_code(400); exit; }
+		$this->load_model('Reports');
+
+		$uid = isset($this->session->user_id) ? (int)$this->session->user_id : 0;
+		$isOrkAdmin = $uid > 0 && Ork3::$Lib->authorization->HasAuthority($uid, AUTH_ADMIN, 0, AUTH_ADMIN);
+		$canManageKingdom = $isOrkAdmin
+			|| ($uid > 0 && Ork3::$Lib->authorization->HasAuthority($uid, AUTH_KINGDOM, $kingdom_id, AUTH_CREATE));
+
+		$knConfigs  = Common::get_configs($kingdom_id, CFG_KINGDOM);
+		$recsPublic = isset($knConfigs['AwardRecsPublic'])
+			? (bool)(int)$knConfigs['AwardRecsPublic']['Value']
+			: true;
+
+		$AwardRecommendations = [];
+		if ($recsPublic || $canManageKingdom) {
+			$recs = $this->Reports->recommended_awards(['KingdomId' => $kingdom_id, 'ParkId' => 0, 'PlayerId' => 0, 'RequestedBy' => $uid]);
+			$AwardRecommendations = is_array($recs) ? $recs : [];
+		} elseif ($uid > 0) {
+			$recs = $this->Reports->recommended_awards(['KingdomId' => $kingdom_id, 'ParkId' => 0, 'PlayerId' => 0, 'RequestedBy' => $uid]);
+			$allRecs = is_array($recs) ? $recs : [];
+			$AwardRecommendations = array_values(array_filter($allRecs, function($r) use ($uid) {
+				return (int)$r['RecommendedById'] === $uid;
+			}));
+		} else {
+			http_response_code(403); exit;
+		}
+
+		// Variables the partial template expects in scope:
+		$IsLoggedIn       = $uid > 0;
+		$CanManageKingdom = $canManageKingdom;
+		$kingdom_name     = $this->Kingdom->get_kingdom_name($kingdom_id);
+
+		header('Content-Type: text/html; charset=utf-8');
+		header('X-Recs-Count: ' . count($AwardRecommendations)); // JS uses this for the tab badge
+		include DIR_TEMPLATE . 'revised-frontend/Kingdomnew_recommendations_panel.tpl';
+		exit();
+	}
+
 	public function players_json($kingdom_id = null) {
 		session_write_close(); // release session lock so navigation is not blocked
 		$kingdom_id = preg_replace('/[^0-9]/', '', $kingdom_id);
@@ -622,22 +666,43 @@ class Controller_Kingdom extends Controller {
 			: true;
 		$this->data['AwardRecsPublic'] = $recsPublic;
 
+		// Recommendations tab visibility is a permissions decision; the rows themselves
+		// are lazy-loaded by JS calling Controller_Kingdom::recommendations_panel().
+		// Inlining the rows here was rendering thousands of <tr>s and stalling the
+		// browser's DOMContentLoaded for 1+ second on busy kingdoms.
 		$this->data['AwardRecommendations'] = [];
+		$this->data['AwardRecommendationsCount'] = 0;
 		$canManageKingdom = $this->data['CanManageKingdom'] ?? false;
 		if ($recsPublic || $canManageKingdom) {
 			$this->data['ShowRecsTab'] = true;
-			$recs = $this->Reports->recommended_awards(['KingdomId' => $kingdom_id, 'ParkId' => 0, 'PlayerId' => 0, 'RequestedBy' => $uid]);
-			$this->data['AwardRecommendations'] = is_array($recs) ? $recs : [];
+			$this->data['AwardRecommendationsCount'] = $this->Reports->recommended_awards_count(['KingdomId' => $kingdom_id]);
 		} elseif ($uid > 0) {
-			$recs = $this->Reports->recommended_awards(['KingdomId' => $kingdom_id, 'ParkId' => 0, 'PlayerId' => 0, 'RequestedBy' => $uid]);
-			$allRecs = is_array($recs) ? $recs : [];
-			$myRecs = array_values(array_filter($allRecs, function($r) use ($uid) {
-				return (int)$r['RecommendedById'] === $uid;
-			}));
-			$this->data['AwardRecommendations'] = $myRecs;
-			$this->data['ShowRecsTab'] = !empty($myRecs);
+			// Logged-in non-admin on a private-recs kingdom — tab is shown only if
+			// the user has their own recs. Cheap COUNT query, no row hydration.
+			$n = $this->Reports->recommended_awards_count(['KingdomId' => $kingdom_id, 'RecommendedBy' => $uid]);
+			$this->data['AwardRecommendationsCount'] = $n;
+			$this->data['ShowRecsTab'] = $n > 0;
 		} else {
 			$this->data['ShowRecsTab'] = false;
+		}
+
+		// Players tab badge — cheap COUNT so the page shows "Players (N)" on first
+		// paint without waiting for players_json (which builds full rosters).
+		$_pcCacheKey = Ork3::$Lib->ghettocache->key(['KingdomId' => (int)$kingdom_id]);
+		$_pcCached = Ork3::$Lib->ghettocache->get(__CLASS__ . '.player_count', $_pcCacheKey, 600);
+		if ($_pcCached !== false) {
+			$this->data['PlayerCount'] = (int)$_pcCached;
+		} else {
+			global $DB;
+			$_kid = (int)$kingdom_id;
+			$DB->Clear();
+			$_pcResult = $DB->DataSet("SELECT COUNT(*) AS n
+				FROM " . DB_PREFIX . "mundane m
+				INNER JOIN " . DB_PREFIX . "park p ON p.park_id = m.park_id AND p.kingdom_id = {$_kid}
+				WHERE m.suspended = 0 AND m.active = 1");
+			$_pcN = ($_pcResult && $_pcResult->Next()) ? (int)$_pcResult->n : 0;
+			$this->data['PlayerCount'] = $_pcN;
+			Ork3::$Lib->ghettocache->cache(__CLASS__ . '.player_count', $_pcCacheKey, $_pcN);
 		}
 
 		$this->data['ParkTitleId_options'] = [];

--- a/orkui/controller/controller.Kingdom.php
+++ b/orkui/controller/controller.Kingdom.php
@@ -414,6 +414,43 @@ class Controller_Kingdom extends Controller {
 		$this->data['map_parks'] = is_array($rawParks['Parks'])
 			? array_values(array_filter($rawParks['Parks'], function($p) { return $p['Active'] == 'Active'; }))
 			: [];
+
+		// Child-principality parks for the Parks tab (tile/list) and the kingdom map.
+		// Only when this kingdom is NOT itself a principality; both keys always set.
+		$this->data['principality_parks'] = [];
+		$this->data['prinz_map_parks']    = [];
+		if (empty($this->data['IsPrinz']) && is_array($this->data['principalities']['Principalities'] ?? null)) {
+			foreach ($this->data['principalities']['Principalities'] as $pr) {
+				$prId = (int)($pr['KingdomId'] ?? 0);
+				if ($prId <= 0) continue;
+				$prName = $pr['Name'] ?? '';
+
+				$prSummary = $this->Kingdom->get_park_summary($prId);
+				$prParks   = is_array($prSummary['KingdomParkAveragesSummary'] ?? null)
+					? $prSummary['KingdomParkAveragesSummary']
+					: [];
+				if (!empty($prParks)) {
+					$this->data['principality_parks'][] = [
+						'KingdomId' => $prId,
+						'Name'      => $prName,
+						'parks'     => $prParks,
+					];
+				}
+
+				$prRawParks = $this->Kingdom->GetParks(['KingdomId' => $prId]);
+				$prMapParks = is_array($prRawParks['Parks'] ?? null)
+					? array_values(array_filter($prRawParks['Parks'], function($p) { return $p['Active'] == 'Active'; }))
+					: [];
+				if (!empty($prMapParks)) {
+					$this->data['prinz_map_parks'][] = [
+						'KingdomId' => $prId,
+						'Name'      => $prName,
+						'parks'     => $prMapParks,
+					];
+				}
+			}
+		}
+
 		$this->data['park_edit_lookup'] = [];
 		if (is_array($rawParks['Parks'])) {
 			foreach ($rawParks['Parks'] as $p) {

--- a/orkui/controller/controller.Kingdom.php
+++ b/orkui/controller/controller.Kingdom.php
@@ -75,6 +75,7 @@ class Controller_Kingdom extends Controller {
 		$wkStart  = date('Y-m-d', strtotime('-6 month'));
 		$wkEnd    = date('Y-m-d');
 		$wkCount  = max(1, (int)ceil((strtotime($wkEnd) - strtotime($wkStart)) / (7 * 86400)));
+		$statsKids = implode(',', array_map('intval', $this->Kingdom->GetStatsKingdomIds($kid)));
 		$weekly  = $this->Report->GetKingdomParkAverages(['KingdomId' => $kingdom_id, 'AverageMonths' => 6]);
 		$monthly = $this->Report->GetKingdomParkMonthlyAverages(['KingdomId' => $kingdom_id]);
 		$result  = array();
@@ -93,7 +94,7 @@ class Controller_Kingdom extends Controller {
 				COUNT(DISTINCT a.mundane_id) AS total_players,
 				COUNT(DISTINCT CASE WHEN m.park_id = a.park_id THEN a.mundane_id END) AS total_members
 			FROM ork_attendance a
-			INNER JOIN ork_park p  ON p.park_id  = a.park_id  AND p.kingdom_id = {$kid}
+			INNER JOIN ork_park p  ON p.park_id  = a.park_id  AND p.kingdom_id IN ({$statsKids})
 			INNER JOIN ork_mundane m ON m.mundane_id = a.mundane_id AND m.suspended = 0 AND m.active = 1
 			WHERE a.date >= DATE_SUB(CURDATE(), INTERVAL 12 MONTH) AND a.mundane_id > 0
 			GROUP BY a.park_id";
@@ -114,7 +115,7 @@ class Controller_Kingdom extends Controller {
 		// across the whole kingdom — avoids double-counting players who attend multiple parks in one week
 		$knSql = "SELECT COUNT(*) AS katt FROM (
 				SELECT a.mundane_id FROM " . DB_PREFIX . "attendance a
-				INNER JOIN " . DB_PREFIX . "park p ON p.park_id = a.park_id AND p.kingdom_id = {$kid}
+				INNER JOIN " . DB_PREFIX . "park p ON p.park_id = a.park_id AND p.kingdom_id IN ({$statsKids})
 				WHERE a.date >= '{$wkStart}'
 					AND a.mundane_id > 0
 				GROUP BY a.date_year, a.date_week3, a.mundane_id
@@ -130,7 +131,7 @@ class Controller_Kingdom extends Controller {
 		$knMoSql = "SELECT AVG(monthly_unique) AS kmo FROM (
 				SELECT a.date_year, a.date_month, COUNT(DISTINCT a.mundane_id) AS monthly_unique
 				FROM " . DB_PREFIX . "attendance a
-				INNER JOIN " . DB_PREFIX . "park p ON p.park_id = a.park_id AND p.kingdom_id = {$kid}
+				INNER JOIN " . DB_PREFIX . "park p ON p.park_id = a.park_id AND p.kingdom_id IN ({$statsKids})
 				WHERE a.date >= DATE_SUB(CURDATE(), INTERVAL 12 MONTH)
 					AND a.mundane_id > 0
 				GROUP BY a.date_year, a.date_month
@@ -153,13 +154,13 @@ class Controller_Kingdom extends Controller {
 				 LEFT JOIN (
 				     SELECT a.mundane_id, a.park_id
 				     FROM ork_attendance a
-				     INNER JOIN " . DB_PREFIX . "park pk ON pk.park_id = a.park_id AND pk.kingdom_id = {$kid}
+				     INNER JOIN " . DB_PREFIX . "park pk ON pk.park_id = a.park_id AND pk.kingdom_id IN ({$statsKids})
 				     WHERE a.date >= DATE_SUB(CURDATE(), INTERVAL 12 MONTH)
 				       AND a.date <  DATE_SUB(CURDATE(), INTERVAL 6 MONTH)
 				       AND a.mundane_id > 0
 				     GROUP BY date_year, date_week3, mundane_id, a.park_id
 				 ) mw ON p.park_id = mw.park_id
-				 WHERE p.kingdom_id = {$kid} AND p.active = 'Active'
+				 WHERE p.kingdom_id IN ({$statsKids}) AND p.active = 'Active'
 				 GROUP BY p.park_id"
 			);
 			if ($prevWkResult) {
@@ -176,7 +177,7 @@ class Controller_Kingdom extends Controller {
 				     SELECT a.date_year, a.date_month, a.park_id,
 				            COUNT(DISTINCT a.mundane_id) AS monthly_unique
 				     FROM ork_attendance a
-				     INNER JOIN ork_park p ON p.park_id = a.park_id AND p.kingdom_id = {$kid}
+				     INNER JOIN ork_park p ON p.park_id = a.park_id AND p.kingdom_id IN ({$statsKids})
 				     WHERE a.date >= DATE_SUB(CURDATE(), INTERVAL 24 MONTH)
 				       AND a.date <  DATE_SUB(CURDATE(), INTERVAL 12 MONTH)
 				       AND a.mundane_id > 0
@@ -200,6 +201,7 @@ class Controller_Kingdom extends Controller {
 	public function events_more($kingdom_id = null) {
 		$kingdom_id = preg_replace('/[^0-9]/', '', $kingdom_id);
 		$kid = (int)$kingdom_id;
+		$statsEvtKids = implode(',', array_map('intval', $this->Kingdom->GetStatsKingdomIds($kid)));
 		$window = isset($_GET['window']) ? (int)$_GET['window'] : 1;
 		if ($window < 1) $window = 1;
 		if ($window > 10) $window = 10;
@@ -217,7 +219,7 @@ class Controller_Kingdom extends Controller {
 			JOIN ork_event_calendardetail cd ON cd.event_id = e.event_id
 			    AND cd.event_start >  DATE_ADD(NOW(), INTERVAL {$startMonths} MONTH)
 			    AND cd.event_start <= DATE_ADD(NOW(), INTERVAL {$endMonths} MONTH)
-			WHERE e.kingdom_id = {$kid}
+			WHERE e.kingdom_id IN ({$statsEvtKids})
 			ORDER BY cd.event_start, p.name, e.name";
 		$DB->Clear();
 		$evtResult = $DB->DataSet($evtSql);
@@ -253,7 +255,7 @@ class Controller_Kingdom extends Controller {
 			$_more = $DB->DataSet(
 				"SELECT 1 FROM ork_event_calendardetail cd
 				 JOIN ork_event e ON e.event_id = cd.event_id
-				 WHERE e.kingdom_id = {$kid}
+				 WHERE e.kingdom_id IN ({$statsEvtKids})
 				   AND cd.event_start >  DATE_ADD(NOW(), INTERVAL {$_nextStart} MONTH)
 				   AND cd.event_start <= DATE_ADD(NOW(), INTERVAL 120 MONTH)
 				 LIMIT 1"
@@ -415,6 +417,12 @@ class Controller_Kingdom extends Controller {
 			? array_values(array_filter($rawParks['Parks'], function($p) { return $p['Active'] == 'Active'; }))
 			: [];
 
+		// Whether this kingdom has active child principalities (and is not itself one).
+		// Drives the admin 'Include Principality in Statistics' toggle visibility.
+		$this->data['HasChildPrincipalities'] = (empty($this->data['IsPrinz'])
+			&& is_array($this->data['principalities']['Principalities'] ?? null)
+			&& count($this->data['principalities']['Principalities']) > 0);
+
 		// Child-principality parks for the Parks tab (tile/list) and the kingdom map.
 		// Only when this kingdom is NOT itself a principality; both keys always set.
 		$this->data['principality_parks'] = [];
@@ -451,6 +459,22 @@ class Controller_Kingdom extends Controller {
 			}
 		}
 
+		// Hero/tab 'Parks (N)' count: roll up family park count when the stats flag is on
+		// (main parks + principality parks already gathered above). Falls back to the
+		// kingdom's own park count otherwise. Does NOT merge principality parks into the tiles.
+		$ownParkCount = is_array($this->data['park_summary']['KingdomParkAveragesSummary'] ?? null)
+			? count($this->data['park_summary']['KingdomParkAveragesSummary'])
+			: 0;
+		if (!empty($this->data['HasChildPrincipalities']) && $this->Kingdom->StatsIncludesPrincipalities($kingdom_id)) {
+			$prinzParkCount = 0;
+			foreach ($this->data['principality_parks'] as $prGroup) {
+				$prinzParkCount += is_array($prGroup['parks'] ?? null) ? count($prGroup['parks']) : 0;
+			}
+			$this->data['StatsParkCount'] = $ownParkCount + $prinzParkCount;
+		} else {
+			$this->data['StatsParkCount'] = $ownParkCount;
+		}
+
 		$this->data['park_edit_lookup'] = [];
 		if (is_array($rawParks['Parks'])) {
 			foreach ($rawParks['Parks'] as $p) {
@@ -466,6 +490,7 @@ class Controller_Kingdom extends Controller {
 
 		global $DB;
 		$kid = (int)$kingdom_id;
+		$statsEvtKids = implode(',', array_map('intval', $this->Kingdom->GetStatsKingdomIds($kid)));
 
 		$evtSql = "
 			SELECT e.event_id, e.name, e.park_id, p.name AS park_name, p.abbreviation AS park_abbr,
@@ -485,7 +510,7 @@ class Controller_Kingdom extends Controller {
 			    FROM ork_event_rsvp
 			    GROUP BY event_calendardetail_id
 			) rsvp ON rsvp.event_calendardetail_id = cd.event_calendardetail_id
-			WHERE e.kingdom_id = {$kid}
+			WHERE e.kingdom_id IN ({$statsEvtKids})
 			ORDER BY cd.event_start, p.name, e.name";
 		$DB->Clear();
 		$evtResult    = $DB->DataSet($evtSql);
@@ -516,7 +541,7 @@ class Controller_Kingdom extends Controller {
 		$moreRes = $DB->DataSet(
 			"SELECT 1 FROM ork_event_calendardetail cd
 			 JOIN ork_event e ON e.event_id = cd.event_id
-			 WHERE e.kingdom_id = {$kid}
+			 WHERE e.kingdom_id IN ({$statsEvtKids})
 			   AND cd.event_start >  DATE_ADD(NOW(), INTERVAL 12 MONTH)
 			   AND cd.event_start <= DATE_ADD(NOW(), INTERVAL 120 MONTH)
 			 LIMIT 1"
@@ -643,10 +668,12 @@ class Controller_Kingdom extends Controller {
 			];
 
 			$adminConfig = [];
+			$hasChildPrinz = !empty($this->data['HasChildPrincipalities']);
 			foreach ($kd['KingdomConfiguration'] ?? [] as $cfg) {
-				if (!empty($cfg['UserSetting'])) {
-					$adminConfig[] = $cfg;
-				}
+				if (empty($cfg['UserSetting'])) continue;
+				// Only surface the principality-stats toggle for kingdoms that have principalities.
+				if (($cfg['Key'] ?? '') === 'IncludePrincipalityInStatistics' && !$hasChildPrinz) continue;
+				$adminConfig[] = $cfg;
 			}
 			$this->data['AdminConfig']     = $adminConfig;
 			$this->data['AdminParkTitles'] = array_values($kd['ParkTitles'] ?? []);
@@ -716,6 +743,7 @@ class Controller_Kingdom extends Controller {
 	public function ics($kingdom_id = null) {
 		$kingdom_id = preg_replace('/[^0-9]/', '', $kingdom_id);
 		$kid = (int)$kingdom_id;
+		$statsEvtKids = implode(',', array_map('intval', $this->Kingdom->GetStatsKingdomIds($kid)));
 
 		// Kingdom name for CALNAME
 		$knName = $this->Kingdom->get_kingdom_name($kid);
@@ -735,7 +763,7 @@ class Controller_Kingdom extends Controller {
 			JOIN ork_event_calendardetail cd ON cd.event_id = e.event_id
 				AND cd.event_start >= CURDATE()
 				AND cd.event_start <= DATE_ADD(NOW(), INTERVAL 12 MONTH)
-			WHERE e.kingdom_id = {$kid}
+			WHERE e.kingdom_id IN ({$statsEvtKids})
 			ORDER BY cd.event_start ASC";
 		$DB->Clear();
 		$result = $DB->DataSet($sql);

--- a/orkui/controller/controller.KingdomAjax.php
+++ b/orkui/controller/controller.KingdomAjax.php
@@ -591,8 +591,8 @@ class Controller_KingdomAjax extends Controller {
 				: json_encode(['status' => $r['Status'], 'error' => ($r['Error'] ?? 'Error') . ': ' . ($r['Detail'] ?? '')]);
 
 		} elseif ($action === 'getparks') {
-			$this->load_model('Kingdom');
-			$r = $this->Kingdom->get_park_info($kingdom_id);
+			// Always return family parks (kingdom + child principalities) for dropdowns.
+			$r = Ork3::$Lib->kingdom->GetParks(['KingdomIds' => Ork3::$Lib->kingdom->GetFamilyKingdomIds($kingdom_id)]);
 			$parks = [];
 			foreach ($r['Parks'] ?? [] as $park) {
 				$parks[] = ['ParkId' => $park['ParkId'], 'Name' => $park['Name']];
@@ -833,7 +833,9 @@ class Controller_KingdomAjax extends Controller {
 			$kingdom_clause = '';
 			$park_clause    = '';
 		} else {
-			$kingdom_clause = "AND m.kingdom_id = {$kid}";
+			// Own-kingdom scope ALWAYS includes child principalities (family), not toggle-gated.
+			$familyIds      = implode(',', array_map('intval', Ork3::$Lib->kingdom->GetFamilyKingdomIds($kid)));
+			$kingdom_clause = "AND m.kingdom_id IN ({$familyIds})";
 			$park_clause    = valid_id($park_id) ? "AND m.park_id = {$park_id}" : '';
 		}
 

--- a/orkui/controller/controller.KingdomAjax.php
+++ b/orkui/controller/controller.KingdomAjax.php
@@ -138,6 +138,14 @@ class Controller_KingdomAjax extends Controller {
 				'KingdomId'            => $kingdom_id,
 				'KingdomConfiguration' => $configList,
 			]);
+			if ($r['Status'] == 0) {
+				// Kingdom config can change which kingdoms roll up into stats
+				// (IncludePrincipalityInStatistics) and a lot of other derived
+				// values across reports / averages / recap. Cheapest correct
+				// fix is a full memcached flush — config saves are infrequent
+				// admin actions, not worth enumerating every dependent cache key.
+				Ork3::$Lib->ghettocache->memcache->flush();
+			}
 			echo $r['Status'] == 0
 				? json_encode(['status' => 0])
 				: json_encode(['status' => $r['Status'], 'error' => ($r['Error'] ?? 'Error') . ': ' . ($r['Detail'] ?? '')]);

--- a/orkui/controller/controller.Reports.php
+++ b/orkui/controller/controller.Reports.php
@@ -52,6 +52,11 @@ class Controller_Reports extends Controller {
 		$this->data['page_title'] = "Park Heraldry";
 	}
 
+	public function orkremental($action = null) {
+		$this->template = 'Reports_orkremental.tpl';
+		$this->data['page_title'] = "ORKremental";
+	}
+
 	function kingdomheraldry($request=null) {
 		$this->template = 'Reports_heraldry.tpl';
 		$this->data['Blank'] = HERALDRY_KINGDOM_DEFAULT;

--- a/orkui/controller/controller.Reports.php
+++ b/orkui/controller/controller.Reports.php
@@ -887,6 +887,7 @@ class Controller_Reports extends Controller {
 		$this->data['OfficerDirectory']    = $result['Rows'];
 		$this->data['OfficerDirectoryMode'] = $result['Mode'];
 		$this->data['OfficerDirectoryKingdomId'] = $kingdom_id;
+		$this->data['OfficerDirectoryPrincipalities'] = $result['Principalities'] ?? [];
 		$uid = isset($this->session->user_id) ? (int)$this->session->user_id : 0;
 		$this->data['IsOrkAdmin'] = $uid && Ork3::$Lib->authorization->HasAuthority($uid, AUTH_ADMIN, 0, AUTH_ADMIN);
 	}

--- a/orkui/model/model.Principality.php
+++ b/orkui/model/model.Principality.php
@@ -36,19 +36,18 @@ class Model_Principality extends Model {
 	}
 	
 	function get_officers($principality_id) {
-		$r = $this->Kingdom->GetOfficers(array( 'PrincipalityId' => $principality_id ));
-		logtrace("get_officers($principality_id)", $r);
+		$r = $this->Principality->GetPrincipalityOfficers(array( 'PrincipalityId' => $principality_id ));
 		if ($r['Status']['Status'] == 0)
 			return $r['Officers'];
 		return false;
 	}
-	
+
 	function set_officers($token, $principality_id, $request) {
 		$r = array();
 		foreach ($request as $k => $officer_request) {
 			$officer_request['Token'] = $token;
 			$officer_request['PrincipalityId'] = $principality_id;
-			$r[] = $this->Kingdom->SetOfficer($officer_request);
+			$r[] = $this->Principality->SetPrincipalityOfficer($officer_request);
 		}
 		return $r;
 	}

--- a/orkui/model/model.Reports.php
+++ b/orkui/model/model.Reports.php
@@ -47,6 +47,12 @@ class Model_Reports extends Model {
 		return false;
 	}
 
+	// Cheap count for the Kingdom profile's "Recommendations (N)" tab badge —
+	// avoids hydrating every rec just to size the list.
+	function recommended_awards_count($request) {
+		return (int)$this->Report->PlayerAwardRecommendationsCount($request);
+	}
+
 	function deleted_recommended_awards($request) {
 		$r = $this->Report->DeletedAwardRecommendations($request);
 		if (isset($r['Status']['Status']) && $r['Status']['Status'] == 0) {

--- a/orkui/model/model.Reports.php
+++ b/orkui/model/model.Reports.php
@@ -442,10 +442,22 @@ class Model_Reports extends Model {
 
 	function kingdom_officer_directory($kingdom_id = null) {
 		$r = $this->Report->KingdomOfficerDirectory(array('KingdomId' => $kingdom_id));
-		if ($r['Status']['Status'] == 0) {
-			return ['Rows' => $r['Kingdoms'], 'Mode' => $r['Mode']];
+		if (($r['Status']['Status'] ?? 1) != 0) {
+			return ['Rows' => [], 'Mode' => 'kingdoms', 'Principalities' => []];
 		}
-		return ['Rows' => [], 'Mode' => 'kingdoms'];
+		// Toggle-gated: append each active child principality's park-officer directory as a subsection.
+		$principalities = [];
+		if (valid_id($kingdom_id) && Ork3::$Lib->kingdom->StatsIncludesPrincipalities($kingdom_id)) {
+			$prList = Ork3::$Lib->kingdom->GetPrincipalities(['KingdomId' => $kingdom_id]);
+			foreach (($prList['Principalities'] ?? []) as $pr) {
+				$prId = (int)$pr['KingdomId'];
+				$dir  = $this->Report->KingdomOfficerDirectory(['KingdomId' => $prId]);
+				if (($dir['Status']['Status'] ?? 1) == 0 && !empty($dir['Kingdoms'])) {
+					$principalities[] = ['KingdomId' => $prId, 'Name' => $pr['Name'], 'Rows' => $dir['Kingdoms']];
+				}
+			}
+		}
+		return ['Rows' => $r['Kingdoms'], 'Mode' => $r['Mode'], 'Principalities' => $principalities];
 	}
 	function event_attendance($request) {
 		$r = $this->Report->EventAttendanceReport($request);

--- a/orkui/template/default/Reports_kingdomofficerdirectory.tpl
+++ b/orkui/template/default/Reports_kingdomofficerdirectory.tpl
@@ -5,6 +5,18 @@ $_od_mode  = ($OfficerDirectoryMode ?? 'kingdoms') === 'parks' ? 'parks' : 'king
 $_od_label = $_od_mode === 'parks' ? 'Park' : 'Kingdom';
 $_od_entity_url_prefix = $_od_mode === 'parks' ? 'Park/profile/' : 'Kingdom/profile/';
 $_od_admin = !empty($IsOrkAdmin);
+$_od_principalities = is_array($OfficerDirectoryPrincipalities ?? null) ? $OfficerDirectoryPrincipalities : [];
+
+function _od_cell($persona, $id, $uir, $given = '', $surname = '', $email = '', $admin = false) {
+	if (empty($persona) || !$id) return '<span class="od-vacant-badge">Vacant</span>';
+	$out = '<a class="od-officer-link" href="' . $uir . 'Player/profile/' . (int)$id . '">' . htmlspecialchars($persona) . '</a>';
+	if ($admin) {
+		$real = trim($given . ' ' . $surname);
+		if ($real)  $out .= '<span class="od-real-name">'  . htmlspecialchars($real)  . '</span>';
+		if ($email) $out .= '<a class="od-email-link" href="mailto:' . htmlspecialchars($email) . '">' . htmlspecialchars($email) . '</a>';
+	}
+	return $out;
+}
 
 /* Count vacancies per role */
 $_vacant = ['Monarch' => 0, 'Regent' => 0, 'PM' => 0, 'Champion' => 0, 'GMR' => 0];
@@ -107,19 +119,7 @@ foreach ($_od_rows as $_r) {
 				</tr>
 			</thead>
 			<tbody>
-<?php
-function _od_cell($persona, $id, $uir, $given = '', $surname = '', $email = '', $admin = false) {
-	if (empty($persona) || !$id) return '<span class="od-vacant-badge">Vacant</span>';
-	$out = '<a class="od-officer-link" href="' . $uir . 'Player/profile/' . (int)$id . '">' . htmlspecialchars($persona) . '</a>';
-	if ($admin) {
-		$real = trim($given . ' ' . $surname);
-		if ($real)  $out .= '<span class="od-real-name">'  . htmlspecialchars($real)  . '</span>';
-		if ($email) $out .= '<a class="od-email-link" href="mailto:' . htmlspecialchars($email) . '">' . htmlspecialchars($email) . '</a>';
-	}
-	return $out;
-}
-foreach ($_od_rows as $row):
-?>
+<?php foreach ($_od_rows as $row): ?>
 				<tr>
 					<td><a class="od-officer-link" href="<?=UIR?><?=$_od_entity_url_prefix?><?=$row['KingdomId']?>"><?=htmlspecialchars($row['KingdomName'])?></a></td>
 					<td><?=_od_cell($row['MonarchPersona'],  $row['MonarchId'],  UIR, $row['MonarchGiven'],  $row['MonarchSurname'],  $row['MonarchEmail'],  $_od_admin)?></td>
@@ -133,6 +133,31 @@ foreach ($_od_rows as $row):
 		</table>
 <?php endif; ?>
 	</div>
+
+<?php foreach ($_od_principalities as $_pr): ?>
+	<div class="rp-table-area" style="margin-top:24px;">
+		<div style="font-size:15px;font-weight:700;color:var(--rp-text);margin:0 0 8px;display:flex;align-items:center;gap:8px;">
+			<i class="fas fa-shield-alt" style="color:var(--rp-accent);"></i>
+			<a href="<?=UIR?>Kingdom/profile/<?=(int)$_pr['KingdomId']?>" style="color:inherit;text-decoration:none;"><?=htmlspecialchars($_pr['Name'])?></a>
+			<span style="font-size:11px;font-weight:600;color:var(--rp-text-muted);text-transform:uppercase;letter-spacing:.05em;">Principality</span>
+		</div>
+		<table class="dataTable" style="width:100%">
+			<thead><tr><th>Park</th><th>Monarch</th><th>Regent</th><th>Prime Minister</th><th>Champion</th><th>GMR</th></tr></thead>
+			<tbody>
+<?php foreach ((array)$_pr['Rows'] as $row): ?>
+				<tr>
+					<td><a class="od-officer-link" href="<?=UIR?>Park/profile/<?=$row['KingdomId']?>"><?=htmlspecialchars($row['KingdomName'])?></a></td>
+					<td><?=_od_cell($row['MonarchPersona'],  $row['MonarchId'],  UIR, $row['MonarchGiven'],  $row['MonarchSurname'],  $row['MonarchEmail'],  $_od_admin)?></td>
+					<td><?=_od_cell($row['RegentPersona'],   $row['RegentId'],   UIR, $row['RegentGiven'],   $row['RegentSurname'],   $row['RegentEmail'],   $_od_admin)?></td>
+					<td><?=_od_cell($row['PMPersona'],       $row['PMId'],       UIR, $row['PMGiven'],       $row['PMSurname'],       $row['PMEmail'],       $_od_admin)?></td>
+					<td><?=_od_cell($row['ChampionPersona'], $row['ChampionId'], UIR, $row['ChampionGiven'], $row['ChampionSurname'], $row['ChampionEmail'], $_od_admin)?></td>
+					<td><?=_od_cell($row['GMRPersona'],      $row['GMRId'],      UIR, $row['GMRGiven'],      $row['GMRSurname'],      $row['GMREmail'],      $_od_admin)?></td>
+				</tr>
+<?php endforeach; ?>
+			</tbody>
+		</table>
+	</div>
+<?php endforeach; ?>
 
 </div>
 

--- a/orkui/template/default/Reports_orkremental.tpl
+++ b/orkui/template/default/Reports_orkremental.tpl
@@ -1,0 +1,302 @@
+<link rel="stylesheet" href="<?=HTTP_TEMPLATE?>default/style/reports.css?v=<?=filemtime(__DIR__.'/style/reports.css')?>">
+<link rel="stylesheet" href="<?=HTTP_TEMPLATE?>default/orkremental/orkremental.css?v=<?=filemtime(__DIR__.'/orkremental/orkremental.css')?>">
+
+<div class="rp-root">
+	<div class="rp-header">
+		<div class="rp-header-left">
+			<div class="rp-header-icon-title">
+				<i class="fas fa-dice-d20 rp-header-icon"></i>
+				<h1 class="rp-header-title">ORKremental</h1>
+			</div>
+		</div>
+	</div>
+	<div class="rp-context">
+		<i class="fas fa-info-circle rp-context-icon"></i>
+		<span>Welcome to ORKremental, a perfectly normal simulation of playing Amtgard.</span>
+	</div>
+	<div class="rp-content">
+
+		<div id="orkr-root">
+			<div class="w3-margin">
+				<div style="width: 1220px; height: 600px">
+					<div class="panel w3-padding" style="width: 300px; height: auto; float: left">
+						<span id="deathText">
+							<div style="font-size: large; color: red">You've burned out and gone mundane.</div>
+							<div class="sidebar-element" style="color: gray">Your time is nearly up — use the Relic to reroll before you retire for good.</div>
+						</span>
+
+						<div class="" style="font-size: large">Age <span id="ageDisplay">14</span> Day <span id="dayDisplay">0</span></div>
+						<div class="sidebar-element" style="color: gray">Lifespan: <span id="lifespanDisplay">70</span> years</div>
+
+						<button id="pauseButton" class="w3-button button sidebar-element" onClick="setPause()">Pause</button>
+
+						<span id="automation" class="inline" style="margin-left: 8px">
+							<span>
+								<div class="inline">Auto-advance</div>
+								<input type="checkbox" class="inline" id="autoPromote">
+							</span>
+							</br>
+							<span>
+								<div class="inline">Auto-train</div>
+								<input type="checkbox" class="inline sidebar-element" id="autoLearn">
+							</span>
+						</span>
+
+						<div style="font-size: large" id="coinDisplay">
+							<span></span>
+							<span></span>
+							<span></span>
+							<span></span>
+						</div>
+						<div style="color: gray">Treasury</div>
+
+						<ul class="sidebar-element" style="padding-left: 20px;">
+							<li><span style="color: rgb(9, 160, 230)">Net/day: </span ><b id="signDisplay"></b><span id="netDisplay">
+								<span></span>
+								<span></span>
+								<span></span>
+								<span></span>
+							</span></li>
+							<li><span style="color: green">Income/day: </span><span id="incomeDisplay">
+								<span></span>
+								<span></span>
+								<span></span>
+								<span></span>
+							</span></li>
+							<li><span style="color: red">Expense/day: </span><span id="expenseDisplay">
+								<span></span>
+								<span></span>
+								<span></span>
+								<span></span>
+							</span></li>
+						</ul>
+
+						<span id="quickTaskDisplay">
+							<div style="width: 230px" class="small-margin inline job progress-bar progressBar">
+								<div class="progress-fill progressFill" style="background-color:rgb(225, 165, 0)"></div>
+								<div class="progress-text name">Task</div>
+							</div>
+							<div class="sidebar-element" style="color: gray">Current job</div>
+
+							<div style="width: 230px" class="small-margin skill progress-bar progressBar">
+								<div class="progress-fill progressFill" style="background-color:rgb(225, 165, 0)"></div>
+								<div class="progress-text name">Task</div>
+							</div>
+							<div class="sidebar-element" style="color: gray">Current skill</div>
+						</span>
+
+						<div style="font-size: large"><span style="color: rgb(15, 105, 207)">Morale: </span><span id="happinessDisplay"></span></div>
+						<div style="color: gray" class="sidebar-element">Affects all xp gain</div>
+
+						<span id="evilInfo">
+							<div style="font-size: large"><span style="color: rgb(200, 0, 0)">Corruption: </span><span id="evilDisplay"></span></div>
+							<div style="color: gray" class="sidebar-element">Affects Anti-Paladin xp gain</div>
+						</span>
+
+						<!--
+						<span id="scheduling">
+							<div style="font-size: large">Scheduling</div>
+							<div style="color: gray" class="sidebar-element">Schedule time to jobs/skills</div>
+							<span style="height: 30px">
+								<p style="width: 5px">Jobs</br>(32%)</p>
+								<input id="schedulingSlider" class="slider" type="range" min="0" max="100" value="0">
+								<p style="width: 5px">Skills</br>(68%)</p>
+							</span>
+						</span>
+						-->
+
+						<span id="timeWarping">
+							<div style="font-size: large"><span style="color: rgb(204, 34, 219)">Crown Time: </span><span id="timeWarpingDisplay"></span></div>
+							<div style="color: gray">Affects game speed</div>
+							<button id="timeWarpingButton" class="w3-button button sidebar-element" style="margin-top: 5px; width:150px" onClick="setTimeWarping()">Enable Crown Time</button>
+						</span>
+					</div>
+
+					<div class="panel w3-margin-left" style="width: 900px; height: 40px; float: left">
+						<div class="w3-button w3-bar-item tabButton" id="jobTabButton" onClick="setTab(this, 'jobs')">Classes</div>
+						<div class="w3-button w3-bar-item tabButton" onClick="setTab(this, 'skills')">Training</div>
+						<div class="w3-button w3-bar-item tabButton" id="shopTabButton" onClick="setTab(this, 'shop')">Quartermaster</div>
+						<div class="w3-button w3-bar-item tabButton" id="rebirthTabButton" onClick="setTab(this, 'rebirth')">The Relic</div>
+						<div class="w3-button w3-bar-item tabButton" onClick="setTab(this, 'settings')" style="float: right">Settings</div>
+					</div>
+
+					<div class="panel w3-margin-left w3-margin-top w3-padding" style="width: 900px; height: auto; float: left">
+						<template class="headerRowTaskTemplate">
+							<tr>
+								<th class="category" style="width: 250px">Job</th>
+								<th>Level</th>
+								<th class="valueType">Value type</th>
+								<th>Xp/day</th>
+								<th>Xp left</th>
+								<th class="maxLevel">Max level</th>
+								<th class="skipSkill">Skip</th>
+							</tr>
+						</template>
+
+						<template class="headerRowItemTemplate">
+							<tr>
+								<th class="category" style="width: 250px">Item</th>
+								<th style="width: 100px">Active</th>
+								<th style="width: 250px">Effect</th>
+								<th>Expense/day</th>
+							</tr>
+						</template>
+
+						<template class="rowTaskTemplate">
+							<tr>
+								<td>
+									<div class="progress-bar progressBar tooltip">
+										<div class="progress-fill progressFill"></div>
+										<div class="progress-text name">Task</div>
+										<span class="tooltipText"></span>
+									</div>
+								</td>
+								<td class="level">Level</td>
+								<td class="value">
+									<div class="effect"></div>
+									<div class="income">
+										<span></span>
+										<span></span>
+										<span></span>
+										<span></span>
+									</div>
+								</td>
+								<td class="xpGain">Xp/day</td>
+								<td class="xpLeft">Xp left</td>
+								<td class="maxLevel">Max level</td>
+								<td class="skipSkill">
+									<input class="checkbox" type="checkbox"></input>
+								</td>
+							</tr>
+						</template>
+
+						<template class="rowItemTemplate">
+							<tr>
+								<td>
+
+									<button class="button item-button tooltip">
+										<span class="name"></span>
+										<span class="tooltipText">tooltip</span>
+									</button>
+
+								</td>
+								<td>
+									<div class="w3-border w3-circle" style="width: 40px; height: 40px; padding: 7px">
+										<div class="active w3-circle" style="width: 24px; height: 24px;"></div>
+									</div>
+								</td>
+								<td class="effect"></td>
+								<td class="expense">
+									<span></span>
+									<span></span>
+									<span></span>
+									<span></span>
+								</td>
+							</tr>
+						</template>
+
+						<template class="requiredRowTemplate">
+							<td class="w3-text-gray" style="padding-left: 16px" colspan=5>
+								Required:
+								<span class="value" colspan=5>
+									<span class="levels"></span>
+									<span class="coins">
+										<span></span>
+										<span></span>
+										<span></span>
+										<span></span>
+									</span>
+									<span style="color: rgb(200, 0, 0)" class="evil"></span>
+								</span>
+							</td>
+						</template>
+
+						<div class="tab" id="jobs">
+							<table id="jobTable" class="w3-table w3-bordered">
+							</table>
+						</div>
+
+						<div class="tab" id="skills">
+							<table id="skillTable" class="w3-table w3-bordered">
+							</table>
+						</div>
+
+						<div class="tab" id="shop">
+							<table id="itemTable" class="w3-table w3-bordered">
+							</table>
+						</div>
+
+						<div class="tab" id="rebirth">
+							<ul>
+								<li style="margin: 8px;">
+									Digging through a battered box of loaner gear at an event, you find a strange old medallion —
+									a dead knight's persona token, by the look of it. It's cheap pot-metal and nobody claims it,
+									so you pocket it. Something about it just feels like it wants to come home with you.
+								</li>
+								<li style="margin: 8px;" id="rebirthNote1">
+									A few seasons later the medallion goes cold and heavy in your pouch one night at fighter
+									practice. When you pull it out, an old maker's mark you swear wasn't there before is etched
+									across its face.
+								</li>
+								<li style="margin: 8px;" id="rebirthNote2">
+									<div style="margin-bottom: 8px">
+										After years on the field your knees are shot and your sword arm isn't what it was. That's when
+										the relic stirs again — and you realize it's offering you a clean slate. A brand new persona,
+										a brand new name at gate, fresh out of the loaner pile.
+									</div>
+									<i style="color: grey">
+										Roll a new persona and you start over from scratch, losing all your levels and coins.
+										But your hands remember. You keep <b>xp multipliers</b> on every class and skill equal to:
+										<b>1 + the max level of that class or skill / 10.</b>
+										Everything you grind the second time comes much faster than it did the first.
+										<span style="color: rgb(200, 0, 0)">
+										And you get the feeling the relic has darker things to offer if you stick around long enough...</span>
+									</i>
+									</br>
+									<button class="w3-button button" style="margin-bottom: 8px; margin-top: 8px" onClick="rebirthOne()">Reroll Persona</button>
+									</br>
+								</li>
+								<li style="margin: 8px;" id="rebirthNote3">
+									<div style="margin-bottom: 8px;">
+										You were right to be wary. After enough lifetimes on the field, the relic finally speaks —
+										a low whisper offering you the path the knights never talk about around the fire:
+										forsake your oaths, and the dead will fight for you.
+									</div>
+									<i style="color: rgb(200, 0, 0)">
+										Take the Anti-Paladin's Oath and everything resets — every level, every coin, even your max levels.
+										You begin again as a blank slate. But you unlock the dark line of skills and gain
+										<b><span id="evilGainDisplay"></span> Corruption</b>, which will haunt every life that follows.
+									</i>
+									</br>
+										<button class="w3-button button" style="margin-bottom: 8px; margin-top: 8px" onClick="rebirthTwo()">Take the Oath</button>
+									</br>
+								</li>
+							</ul>
+						</div>
+
+						<div class="tab" id="settings">
+							<ul>
+								<li>
+									<h2>Import/export save</h2>
+									<button class="w3-button button" onClick="importGameData()">Import</button>
+									<button class="w3-button button" onClick="exportGameData()">Export</button>
+									<form style="margin-top: 16px">
+										<input id="importExportBox" type="text" style="width:300px; height:30px"></input>
+									</form>
+								</li>
+								<li>
+									<h2>Hard reset game</h2>
+									<button class="w3-button button w3-red" onClick="resetGameData()">Reset</button>
+								</li>
+							</ul>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+
+	</div>
+</div>
+
+<script type="text/javascript" src="<?=HTTP_TEMPLATE?>default/orkremental/classes.js?v=<?=filemtime(__DIR__.'/orkremental/classes.js')?>"></script>
+<script type="text/javascript" src="<?=HTTP_TEMPLATE?>default/orkremental/game.js?v=<?=filemtime(__DIR__.'/orkremental/game.js')?>"></script>

--- a/orkui/template/default/default.theme
+++ b/orkui/template/default/default.theme
@@ -726,6 +726,10 @@ endif;
   Amtgard is a registered trademark of Amtgard International, Inc., a 501(c)(3) non-profit organization.
   &nbsp;&middot;&nbsp;
   <a href="<?=UIR?>ReleaseNotes" style="color:var(--ork-text-muted,#94a3b8);text-decoration:none;border-bottom:1px dotted var(--ork-text-muted,#94a3b8);">ORK v<?=ORK_VERSION?></a>
+<?php if (!empty($IsOwnProfile)): ?>
+  &nbsp;&middot;&nbsp;
+  <a href="<?=UIR?>Reports/orkremental" aria-label="Back to top" style="color:var(--ork-text-muted,#94a3b8);text-decoration:none;"><i class="fas fa-chevron-up"></i></a>
+<?php endif; ?>
 </footer>
 
 <script>

--- a/orkui/template/default/orkremental/classes.js
+++ b/orkui/template/default/orkremental/classes.js
@@ -1,0 +1,166 @@
+class Task {
+    constructor(baseData) {
+        this.baseData = baseData
+        this.name = baseData.name
+        this.level = 0
+        this.maxLevel = 0 
+        this.xp = 0
+
+        this.xpMultipliers = [
+        ]
+    }
+
+    getMaxXp() {
+        var maxXp = Math.round(this.baseData.maxXp * (this.level + 1) * Math.pow(1.01, this.level))
+        return maxXp
+    }
+
+    getXpLeft() {
+        return Math.round(this.getMaxXp() - this.xp)
+    }
+
+    getMaxLevelMultiplier() {
+        var maxLevelMultiplier = 1 + this.maxLevel / 10
+        return maxLevelMultiplier
+    }
+
+    getXpGain() {
+        return applyMultipliers(10, this.xpMultipliers)
+    }
+
+    increaseXp() {
+        this.xp += applySpeed(this.getXpGain())
+        if (this.xp >= this.getMaxXp()) {
+            var excess = this.xp - this.getMaxXp()
+            while (excess >= 0) {
+                this.level += 1
+                excess -= this.getMaxXp()
+            }
+            this.xp = this.getMaxXp() + excess
+        }
+    }
+}
+
+class Job extends Task {
+    constructor(baseData) {
+        super(baseData)   
+        this.incomeMultipliers = [
+        ]
+    }
+
+    getLevelMultiplier() {
+        var levelMultiplier = 1 + Math.log10(this.level + 1)
+        return levelMultiplier
+    }
+    
+    getIncome() {
+        return applyMultipliers(this.baseData.income, this.incomeMultipliers) 
+    }
+}
+
+class Skill extends Task {
+    constructor(baseData) {
+        super(baseData)
+    }
+
+    getEffect() {
+        var effect = 1 + this.baseData.effect * this.level
+        return effect
+    }
+
+    getEffectDescription() {
+        var description = this.baseData.description
+        var text = "x" + String(this.getEffect().toFixed(2)) + " " + description
+        return text
+    }
+}
+
+class Item {
+    constructor(baseData) {  
+        this.baseData = baseData
+        this.name = baseData.name
+        this.expenseMultipliers = [
+         
+        ]
+    }
+
+    getEffect() {
+        if (gameData.currentProperty != this && !gameData.currentMisc.includes(this)) return 1
+        var effect = this.baseData.effect
+        return effect
+    }
+
+    getEffectDescription() {
+        var description = this.baseData.description
+        if (itemCategories["Properties"].includes(this.name)) description = "Morale"
+        var text = "x" + this.baseData.effect.toFixed(1) + " " + description
+        return text
+    }
+
+    getExpense() {
+        return applyMultipliers(this.baseData.expense, this.expenseMultipliers)
+    }
+}
+
+class Requirement {
+    constructor(elements, requirements) {
+        this.elements = elements
+        this.requirements = requirements
+        this.completed = false
+    }
+
+    isCompleted() {
+        if (this.completed) {return true}
+        for (var requirement of this.requirements) {
+            if (!this.getCondition(requirement)) {
+                return false
+            }
+        }
+        this.completed = true
+        return true
+    }
+}
+
+class TaskRequirement extends Requirement {
+    constructor(elements, requirements) {
+        super(elements, requirements)
+        this.type = "task"
+    }
+
+    getCondition(requirement) {
+        return gameData.taskData[requirement.task].level >= requirement.requirement
+    }
+}
+
+class CoinRequirement extends Requirement {
+    constructor(elements, requirements) {
+        super(elements, requirements)
+        this.type = "coins"
+    }
+
+    getCondition(requirement) {
+        return gameData.coins >= requirement.requirement
+    }
+}
+
+class AgeRequirement extends Requirement {
+    constructor(elements, requirements) {
+        super(elements, requirements)
+        this.type = "age"
+    }
+
+    getCondition(requirement) {
+        return daysToYears(gameData.days) >= requirement.requirement
+    }
+}
+
+class EvilRequirement extends Requirement {
+    constructor(elements, requirements) {
+        super(elements, requirements)
+        this.type = "evil"
+    }
+
+    getCondition(requirement) {
+        return gameData.evil >= requirement.requirement
+    }    
+}

--- a/orkui/template/default/orkremental/game.js
+++ b/orkui/template/default/orkremental/game.js
@@ -1,0 +1,1231 @@
+var gameData = {
+    taskData: {},
+    itemData: {},
+
+    coins: 0,
+    days: 365 * 14,
+    evil: 0,
+    paused: false,
+    timeWarpingEnabled: true,
+
+    rebirthOneCount: 0,
+    rebirthTwoCount: 0,
+
+    currentJob: null,
+    currentSkill: null,
+    currentProperty: null,
+    currentMisc: null,
+}
+
+var tempData = {}
+
+var skillWithLowestMaxXp = null
+
+const autoPromoteElement = document.getElementById("autoPromote")
+const autoLearnElement = document.getElementById("autoLearn")
+
+const updateSpeed = 20
+
+const baseLifespan = 365 * 70
+
+const baseGameSpeed = 4
+
+const permanentUnlocks = ["Scheduling", "Shop", "Automation", "Quick task display"]
+
+const jobBaseData = {
+    "Beggar": {name: "Beggar", maxXp: 50, income: 5},
+    "Farmer": {name: "Farmer", maxXp: 100, income: 9},
+    "Fisherman": {name: "Fisherman", maxXp: 200, income: 15},
+    "Miner": {name: "Miner", maxXp: 400, income: 40},
+    "Blacksmith": {name: "Blacksmith", maxXp: 800, income: 80},
+    "Merchant": {name: "Merchant", maxXp: 1600, income: 150},
+
+    "Squire": {name: "Squire", maxXp: 100, income: 5},
+    "Footman": {name: "Footman", maxXp: 1000, income: 50},
+    "Veteran footman": {name: "Veteran footman", maxXp: 10000, income: 120},
+    "Knight": {name: "Knight", maxXp: 100000, income: 300},
+    "Veteran knight": {name: "Veteran knight", maxXp: 1000000, income: 1000},
+    "Elite knight": {name: "Elite knight", maxXp: 7500000, income: 3000},
+    "Holy knight": {name: "Holy knight", maxXp: 40000000, income: 15000},
+    "Legendary knight": {name: "Legendary knight", maxXp: 150000000, income: 50000},
+
+    "Student": {name: "Student", maxXp: 100000, income: 100},
+    "Apprentice mage": {name: "Apprentice mage", maxXp: 1000000, income: 1000},
+    "Mage": {name: "Mage", maxXp: 10000000, income: 7500},
+    "Wizard": {name: "Wizard", maxXp: 100000000, income: 50000},
+    "Master wizard": {name: "Master wizard", maxXp: 10000000000, income: 250000},
+    "Chairman": {name: "Chairman", maxXp: 1000000000000, income: 1000000},
+}
+
+const skillBaseData = {
+    "Concentration": {name: "Concentration", maxXp: 100, effect: 0.01, description: "Training xp"},
+    "Productivity": {name: "Productivity", maxXp: 100, effect: 0.01, description: "Class xp"},
+    "Bargaining": {name: "Bargaining", maxXp: 100, effect: -0.01, description: "Expenses"},
+    "Meditation": {name: "Meditation", maxXp: 100, effect: 0.01, description: "Morale"},
+
+    "Strength": {name: "Strength", maxXp: 100, effect: 0.01, description: "Fighting Company pay"},
+    "Battle tactics": {name: "Battle tactics", maxXp: 100, effect: 0.01, description: "Combat xp"},
+    "Muscle memory": {name: "Muscle memory", maxXp: 100, effect: 0.01, description: "Conditioning xp"},
+
+    "Mana control": {name: "Mana control", maxXp: 100, effect: 0.01, description: "Mages Guild xp"},
+    "Immortality": {name: "Immortality", maxXp: 100, effect: 0.01, description: "Longer career"},
+    "Time warping": {name: "Time warping", maxXp: 100, effect: 0.01, description: "Game speed"},
+    "Super immortality": {name: "Super immortality", maxXp: 100, effect: 0.01, description: "Longer career"},
+
+    "Dark influence": {name: "Dark influence", maxXp: 100, effect: 0.01, description: "All xp"},
+    "Evil control": {name: "Evil control", maxXp: 100, effect: 0.01, description: "Corruption gain"},
+    "Intimidation": {name: "Intimidation", maxXp: 100, effect: -0.01, description: "Expenses"},
+    "Demon training": {name: "Demon training", maxXp: 100, effect: 0.01, description: "All xp"},
+    "Blood meditation": {name: "Blood meditation", maxXp: 100, effect: 0.01, description: "Corruption gain"},
+    "Demon's wealth": {name: "Demon's wealth", maxXp: 100, effect: 0.002, description: "Class pay"},
+    
+}
+
+const itemBaseData = {
+    "Homeless": {name: "Homeless", expense: 0, effect: 1},
+    "Tent": {name: "Tent", expense: 15, effect: 1.4},
+    "Wooden hut": {name: "Wooden hut", expense: 100, effect: 2},
+    "Cottage": {name: "Cottage", expense: 750, effect: 3.5},
+    "House": {name: "House", expense: 3000, effect: 6},
+    "Large house": {name: "Large house", expense: 25000, effect: 12},
+    "Small palace": {name: "Small palace", expense: 300000, effect: 25},
+    "Grand palace": {name: "Grand palace", expense: 5000000, effect: 60},
+
+    "Book": {name: "Book", expense: 10, effect: 1.5, description: "Training xp"},
+    "Dumbbells": {name: "Dumbbells", expense: 50, effect: 1.5, description: "Conditioning xp"},
+    "Personal squire": {name: "Personal squire", expense: 200, effect: 2, description: "Class xp"},
+    "Steel longsword": {name: "Steel longsword", expense: 1000, effect: 2, description: "Combat xp"},
+    "Butler": {name: "Butler", expense: 7500, effect: 1.5, description: "Morale"},
+    "Sapphire charm": {name: "Sapphire charm", expense: 50000, effect: 3, description: "Magic xp"},
+    "Study desk": {name: "Study desk", expense: 1000000, effect: 2, description: "Training xp"},
+    "Library": {name: "Library", expense: 10000000, effect: 1.5, description: "Training xp"},
+}
+
+const jobCategories = {
+    "Common work": ["Beggar", "Farmer", "Fisherman", "Miner", "Blacksmith", "Merchant"],
+    "Military" : ["Squire", "Footman", "Veteran footman", "Knight", "Veteran knight", "Elite knight", "Holy knight", "Legendary knight"],
+    "The Arcane Association" : ["Student", "Apprentice mage", "Mage", "Wizard", "Master wizard", "Chairman"]
+}
+
+const skillCategories = {
+    "Fundamentals": ["Concentration", "Productivity", "Bargaining", "Meditation"],
+    "Combat": ["Strength", "Battle tactics", "Muscle memory"],
+    "Magic": ["Mana control", "Immortality", "Time warping", "Super immortality"],
+    "Dark magic": ["Dark influence", "Evil control", "Intimidation", "Demon training", "Blood meditation", "Demon's wealth"]
+}
+
+const itemCategories = {
+    "Properties": ["Homeless", "Tent", "Wooden hut", "Cottage", "House", "Large house", "Small palace", "Grand palace"],
+    "Misc": ["Book", "Dumbbells", "Personal squire", "Steel longsword", "Butler", "Sapphire charm", "Study desk", "Library"]
+}
+
+const headerRowColors = {
+    "Common work": "#55a630",
+    "Military": "#e63946",
+    "The Arcane Association": "#C71585",
+    "Fundamentals": "#4a4e69",
+    "Combat": "#ff704d",
+    "Magic": "#875F9A",
+    "Dark magic": "#73000f",
+    "Properties": "#219ebc",
+    "Misc": "#b56576",
+}
+
+const tooltips = {
+    "Beggar": "You showed up in jeans and a t-shirt. Someone hands you a loaner sword. You have no idea what 'lay on' means yet.",
+    "Farmer": "You come out most weekends now and you've started learning where to stand so you don't get yelled at by the reeve.",
+    "Fisherman": "You've sewn your own tunic and it mostly stays on. People stop calling you 'the new guy' for whole battles at a time.",
+    "Miner": "You started building your own boffers in the garage. Half of them fail check, but the other half hit like trucks.",
+    "Blacksmith": "Your weapons pass inspection every time now, and other people ask you to build for them. Duct tape is your love language.",
+    "Merchant": "You've got the gate handled, the waiver binder is organized, and you can run a whole event day without losing your mind.",
+
+    "Squire": "You carry the kingdom's water jugs and set up the canopy, but you're soaking up everything. The belted folk are watching.",
+    "Footman": "You hold the line and don't die first anymore. You're not a hero yet, but the captain trusts you to anchor a flank.",
+    "Veteran footman": "You've seen enough wars to read a charge before it happens. New fighters cluster behind you, and that's earned.",
+    "Knight": "You earned your belt the hard way — on the field, fight after fight. People actually want you on their team now.",
+    "Veteran knight": "You've worn the white belt long enough to teach it. Whole units pivot off your calls in the heat of a battle.",
+    "Elite knight": "The Knight of Battle — knighted for mastery of the battlegame itself. You read scenarios, hold the bridge, and win wars lesser fighters can't even follow.",
+    "Holy knight": "Master of the Battle ladder: a Battlemaster. You don't just win battlegames, you author them, and reeves trust your calls without a second glance.",
+    "Legendary knight": "Kingdoms tell stories about you at fires. A title like yours comes around maybe once a generation, and everyone knows it.",
+
+    "Student": "You're learning the magic classes — counting your verbals, memorizing your spell list, and dropping balls way too early.",
+    "Apprentice mage": "You can actually heal someone mid-battle now without fumbling the words. The line stops yelling 'HEALER!' in vain.",
+    "Mage": "You've taken up the Bard — songs and enchantments that buff your allies and lock down the enemy line. The whole team plays better when you're out there.",
+    "Wizard": "You wield the Druid's craft now — control magic, entangles, and healing that turns the terrain itself into a weapon. Captains build battleplans around you.",
+    "Master wizard": "The Wizard, pure and feared — death at range and a spell list dialed to the limit. One clean throw from you can break an entire push by itself.",
+    "Chairman": "You're a Paragon now — the living example of your class, silver trim on your sash. New casters learn the craft at your side, and you set the standard on the field.",
+
+    "Concentration": "Drilling the fundamentals over and over until the basics are second nature. You learn everything faster for it.",
+    "Productivity": "You stop standing around between battles and actually use your reps. More gets done, more class progress earned.",
+    "Bargaining": "You've learned how to talk a merchant down at the garb table and split a hotel room six ways. Everything costs less.",
+    "Meditation": "You're the one who keeps the camp laughing and the fire stocked. Good morale spreads, and it makes everyone better.",
+
+    "Strength": "Conditioning your body so your shots land hard and your shield arm holds all day. The fighting company pays the strong.",
+    "Battle tactics": "Studying flanks, charges, and bridge holds until you can read a battle like a board game. Combat sense sharpens.",
+    "Muscle memory": "Ten thousand reps until the cut throws itself. Your footwork and form improve without you even thinking about it.",
+
+    "Mana control": "Drilling your verbals and spell economy until casting is clean and instant. The whole magic class comes easier.",
+    "Immortality": "Stretching out your years on the field — stretching, hydrating, knowing when to sit a battle. The old guard endures.",
+    "Time warping": "You've been doing this so long you see plays before they happen. The whole day seems to move at your pace now.",
+    "Super immortality": "Some folks are still swinging at sixty like they're twenty. Become one of the legends who simply never leaves the field.",
+
+    "Dark influence": "Forsake your knightly oaths and let darker forces guide your hand. Every art comes faster when you stop holding back.",
+    "Evil control": "Learn to harness the corruption festering in you rather than be consumed by it, carrying more of it across each rebirth.",
+    "Intimidation": "Cultivate a dread presence that makes merchants and rivals alike flinch and offer you whatever you ask, just to be rid of you.",
+    "Demon training": "Forsake your knightly oaths and study the forbidden arts — raise the fallen and let dread do your fighting for you.",
+    "Blood meditation": "Feed your power with rites best left unspoken. Each sacrifice swells the corruption within and makes you something darker.",
+    "Demon's wealth": "Twist the spoils of every battle through unholy means, conjuring coin from suffering and the harvested souls of the slain.",
+
+    "Homeless": "You don't own a stitch of garb. You borrow everything and pray it passes check. There is nowhere to go but up.",
+    "Tent": "A pile of loaner gear from the kingdom box. It smells like a thousand other fighters, but it keeps you on the field.",
+    "Wooden hut": "A basic tabard you threw together yourself. Plain, a little crooked, but unmistakably YOURS for the first time.",
+    "Cottage": "A solid, decent kit that actually fits. Nothing fancy, but you look like you belong out there now.",
+    "House": "A full kit — coordinated garb, working belt favors, the whole look. People can tell which kingdom you ride for at a glance.",
+    "Large house": "Fine garb backed by real armor. You look sharp and you hit hard, and the photos from war weekend come out great.",
+    "Small palace": "A noble's wardrobe — tailored garb, layered pieces, the kind of kit that turns heads across the entire field.",
+    "Grand palace": "Royal regalia fit for a crown. Hand-tooled leather, trimmed in metal, the sort of getup bards describe for years.",
+
+    "Book": "The rulebook. Reading it cover to cover means you finally stop arguing about whether that shot was good.",
+    "Dumbbells": "A practice pell in your backyard. Hit it ten thousand times and your shots start landing on their own.",
+    "Personal squire": "A helpful squire who hauls your gear and fetches your water, freeing you up to actually fight and teach.",
+    "Steel longsword": "A quality boffer that's perfectly balanced and passes check every time. A good blade makes every fight cleaner.",
+    "Butler": "A camp crew that keeps your site set up, your cooler stocked, and your day stress-free. Happy fighters fight better.",
+    "Sapphire charm": "A full bag of spell components — balls, rings, and ribbons, all sorted and ready. Casting magic gets a whole lot easier.",
+    "Study desk": "A proper crafting table for building boffers and garb. With real tools, you learn and improve far faster.",
+    "Library": "The archives — every old rulebook, scroll, and kingdom history in one place. Knowledge of the game flows freely here.",
+}
+
+const units = ["", "k", "M", "B", "T", "q", "Q", "Sx", "Sp", "Oc"];
+
+const displayNames = {
+    // Jobs
+    "Beggar": "Mundane",
+    "Farmer": "Park Regular",
+    "Fisherman": "Garbed Fighter",
+    "Miner": "Boffer Builder",
+    "Blacksmith": "Weaponsmith",
+    "Merchant": "Gate Steward",
+    "Squire": "Page",
+    "Footman": "Man-at-Arms",
+    "Veteran footman": "Squire",
+    "Knight": "Knight of the Sword",
+    "Veteran knight": "Knight of the Crown",
+    "Elite knight": "Knight of Battle",
+    "Holy knight": "Battlemaster",
+    "Legendary knight": "Warlord",
+    "Student": "Apprentice",
+    "Apprentice mage": "Healer",
+    "Mage": "Bard",
+    "Wizard": "Druid",
+    "Master wizard": "Wizard",
+    "Chairman": "Wizard Paragon",
+    // Skills
+    "Concentration": "Focus",
+    "Productivity": "Diligence",
+    "Bargaining": "Haggling",
+    "Meditation": "Camaraderie",
+    "Strength": "Conditioning",
+    "Battle tactics": "Battle Tactics",
+    "Muscle memory": "Footwork",
+    "Mana control": "Spellcraft",
+    "Immortality": "Old Guard",
+    "Time warping": "Crown Time",
+    "Super immortality": "Living Legend",
+    "Dark influence": "Dark Channeling",
+    "Evil control": "Corruption Control",
+    "Intimidation": "Dread Aura",
+    "Demon training": "Necromancy",
+    "Blood meditation": "Blood Rite",
+    "Demon's wealth": "Soul Harvest",
+    // Items
+    "Homeless": "Mundanes",
+    "Tent": "Loaner Garb",
+    "Wooden hut": "Basic Tabard",
+    "Cottage": "Decent Garb",
+    "House": "Full Kit",
+    "Large house": "Fine Garb & Armor",
+    "Small palace": "Noble's Wardrobe",
+    "Grand palace": "Royal Regalia",
+    "Book": "The Corpora",
+    "Dumbbells": "A Pell",
+    "Personal squire": "A Helpful Squire",
+    "Steel longsword": "Quality Boffer",
+    "Butler": "Camp Crew",
+    "Sapphire charm": "Spell Components",
+    "Study desk": "Crafting Table",
+    "Library": "The Archives",
+}        // entity internal-name -> Amtgard display name
+
+const displayCategories = {
+    "Common work": "The Populace",
+    "Military": "The Fighting Company",
+    "The Arcane Association": "The Mages Guild",
+    "Fundamentals": "Fundamentals",
+    "Combat": "Combat",
+    "Magic": "Magic",
+    "Dark magic": "The Anti-Paladin's Oath",
+    "Properties": "Garb & Kit",
+    "Misc": "Gear",
+}   // category internal-name -> Amtgard display label
+function getDisplayName(n) { return displayNames[n] || n }
+function getDisplayCategory(c) { return displayCategories[c] || c }
+
+const jobTabButton = document.getElementById("jobTabButton")
+
+function getBaseLog(x, y) {
+    return Math.log(y) / Math.log(x);
+}
+  
+function getBindedTaskEffect(taskName) {
+    var task = gameData.taskData[taskName]
+    return task.getEffect.bind(task)
+}
+
+function getBindedItemEffect(itemName) {
+    var item = gameData.itemData[itemName]
+    return item.getEffect.bind(item)
+}
+
+function addMultipliers() {
+    for (taskName in gameData.taskData) {
+        var task = gameData.taskData[taskName]
+
+        task.xpMultipliers = []
+        if (task instanceof Job) task.incomeMultipliers = []
+
+        task.xpMultipliers.push(task.getMaxLevelMultiplier.bind(task))
+        task.xpMultipliers.push(getHappiness)
+        task.xpMultipliers.push(getBindedTaskEffect("Dark influence"))
+        task.xpMultipliers.push(getBindedTaskEffect("Demon training"))
+
+        if (task instanceof Job) {
+            task.incomeMultipliers.push(task.getLevelMultiplier.bind(task))
+            task.incomeMultipliers.push(getBindedTaskEffect("Demon's wealth"))
+            task.xpMultipliers.push(getBindedTaskEffect("Productivity"))
+            task.xpMultipliers.push(getBindedItemEffect("Personal squire"))    
+        } else if (task instanceof Skill) {
+            task.xpMultipliers.push(getBindedTaskEffect("Concentration"))
+            task.xpMultipliers.push(getBindedItemEffect("Book"))
+            task.xpMultipliers.push(getBindedItemEffect("Study desk"))
+            task.xpMultipliers.push(getBindedItemEffect("Library"))
+        }
+
+        if (jobCategories["Military"].includes(task.name)) {
+            task.incomeMultipliers.push(getBindedTaskEffect("Strength"))
+            task.xpMultipliers.push(getBindedTaskEffect("Battle tactics"))
+            task.xpMultipliers.push(getBindedItemEffect("Steel longsword"))
+        } else if (task.name == "Strength") {
+            task.xpMultipliers.push(getBindedTaskEffect("Muscle memory"))
+            task.xpMultipliers.push(getBindedItemEffect("Dumbbells"))
+        } else if (skillCategories["Magic"].includes(task.name)) {
+            task.xpMultipliers.push(getBindedItemEffect("Sapphire charm"))
+        } else if (jobCategories["The Arcane Association"].includes(task.name)) {
+            task.xpMultipliers.push(getBindedTaskEffect("Mana control"))
+        } else if (skillCategories["Dark magic"].includes(task.name)) {
+            task.xpMultipliers.push(getEvil)
+        }
+    }
+
+    for (itemName in gameData.itemData) {
+        var item = gameData.itemData[itemName]
+        item.expenseMultipliers = []
+        item.expenseMultipliers.push(getBindedTaskEffect("Bargaining"))
+        item.expenseMultipliers.push(getBindedTaskEffect("Intimidation"))
+    }
+}
+
+function setCustomEffects() {
+    var bargaining = gameData.taskData["Bargaining"]
+    bargaining.getEffect = function() {
+        var multiplier = 1 - getBaseLog(7, bargaining.level + 1) / 10
+        if (multiplier < 0.1) {multiplier = 0.1}
+        return multiplier
+    }
+
+    var intimidation = gameData.taskData["Intimidation"]
+    intimidation.getEffect = function() {
+        var multiplier = 1 - getBaseLog(7, intimidation.level + 1) / 10
+        if (multiplier < 0.1) {multiplier = 0.1}
+        return multiplier
+    }
+
+    var timeWarping = gameData.taskData["Time warping"]
+    timeWarping.getEffect = function() {
+        var multiplier = 1 + getBaseLog(13, timeWarping.level + 1) 
+        return multiplier
+    }
+
+    var immortality = gameData.taskData["Immortality"]
+    immortality.getEffect = function() {
+        var multiplier = 1 + getBaseLog(33, immortality.level + 1) 
+        return multiplier
+    }
+}
+
+function getHappiness() {
+    var meditationEffect = getBindedTaskEffect("Meditation")
+    var butlerEffect = getBindedItemEffect("Butler")
+    var happiness = meditationEffect() * butlerEffect() * gameData.currentProperty.getEffect()
+    return happiness
+}
+
+function getEvil() {
+    return gameData.evil
+}
+
+function applyMultipliers(value, multipliers) {
+    var finalMultiplier = 1
+    multipliers.forEach(function(multiplierFunction) {
+        var multiplier = multiplierFunction()
+        finalMultiplier *= multiplier
+    })
+    var finalValue = Math.round(value * finalMultiplier)
+    return finalValue
+}
+
+function applySpeed(value) {
+    finalValue = value * getGameSpeed() / updateSpeed
+    return finalValue
+}
+
+function getEvilGain() {
+    var evilControl = gameData.taskData["Evil control"]
+    var bloodMeditation = gameData.taskData["Blood meditation"]
+    var evil = evilControl.getEffect() * bloodMeditation.getEffect()
+    return evil
+}
+
+function getGameSpeed() {
+    var timeWarping = gameData.taskData["Time warping"]
+    var timeWarpingSpeed = gameData.timeWarpingEnabled ? timeWarping.getEffect() : 1
+    var gameSpeed = baseGameSpeed * +!gameData.paused * +isAlive() * timeWarpingSpeed
+    return gameSpeed
+}
+
+function applyExpenses() {
+    var coins = applySpeed(getExpense())
+    gameData.coins -= coins
+    if (gameData.coins < 0) {    
+        goBankrupt()
+    }
+}
+
+function getExpense() {
+    var expense = 0
+    expense += gameData.currentProperty.getExpense()
+    for (misc of gameData.currentMisc) {
+        expense += misc.getExpense()
+    }
+    return expense
+}
+
+function goBankrupt() {
+    gameData.coins = 0
+    gameData.currentProperty = gameData.itemData["Homeless"]
+    gameData.currentMisc = []
+}
+
+function setTab(element, selectedTab) {
+
+    var tabs = Array.prototype.slice.call(document.getElementsByClassName("tab"))
+    tabs.forEach(function(tab) {
+        tab.style.display = "none"
+    })
+    document.getElementById(selectedTab).style.display = "block"
+
+    var tabButtons = document.getElementsByClassName("tabButton")
+    for (tabButton of tabButtons) {
+        tabButton.classList.remove("w3-blue-gray")
+    }
+    element.classList.add("w3-blue-gray")
+}
+
+function setPause() {
+    gameData.paused = !gameData.paused
+}
+
+function setTimeWarping() {
+    gameData.timeWarpingEnabled = !gameData.timeWarpingEnabled
+}
+
+function setTask(taskName) {
+    var task = gameData.taskData[taskName]
+    task instanceof Job ? gameData.currentJob = task : gameData.currentSkill = task
+}
+
+function setProperty(propertyName) {
+    var property = gameData.itemData[propertyName]
+    gameData.currentProperty = property
+}
+
+function setMisc(miscName) {
+    var misc = gameData.itemData[miscName]
+    if (gameData.currentMisc.includes(misc)) {
+        for (i = 0; i < gameData.currentMisc.length; i++) {
+            if (gameData.currentMisc[i] == misc) {
+                gameData.currentMisc.splice(i, 1)
+            }
+        }
+    } else {
+        gameData.currentMisc.push(misc)
+    }
+}
+
+function createData(data, baseData) {
+    for (key in baseData) {
+        var entity = baseData[key]
+        createEntity(data, entity)
+    }
+}
+
+function createEntity(data, entity) {
+    if ("income" in entity) {data[entity.name] = new Job(entity)}
+    else if ("maxXp" in entity) {data[entity.name] = new Skill(entity)}
+    else {data[entity.name] = new Item(entity)}
+    data[entity.name].id = "row " + entity.name
+}
+
+function createRequiredRow(categoryName) {
+    var requiredRow = document.getElementsByClassName("requiredRowTemplate")[0].content.firstElementChild.cloneNode(true)
+    requiredRow.classList.add("requiredRow")
+    requiredRow.classList.add(removeSpaces(categoryName))
+    requiredRow.id = categoryName
+    return requiredRow
+}
+
+function createHeaderRow(templates, categoryType, categoryName) {
+    var headerRow = templates.headerRow.content.firstElementChild.cloneNode(true)
+    headerRow.getElementsByClassName("category")[0].textContent = getDisplayCategory(categoryName)
+    if (categoryType != itemCategories) {
+        headerRow.getElementsByClassName("valueType")[0].textContent = categoryType == jobCategories ? "Income/day" : "Effect"
+    }
+
+    headerRow.style.backgroundColor = headerRowColors[categoryName]
+    headerRow.style.color = "#ffffff"
+    headerRow.classList.add(removeSpaces(categoryName))
+    headerRow.classList.add("headerRow")
+    
+    return headerRow
+}
+
+function createRow(templates, name, categoryName, categoryType) {
+    var row = templates.row.content.firstElementChild.cloneNode(true)
+    row.getElementsByClassName("name")[0].textContent = getDisplayName(name)
+    row.getElementsByClassName("tooltipText")[0].textContent = tooltips[name]
+    row.id = "row " + name
+    if (categoryType != itemCategories) {
+        row.getElementsByClassName("progressBar")[0].onclick = function() {setTask(name)}
+    } else {
+        row.getElementsByClassName("button")[0].onclick = categoryName == "Properties" ? function() {setProperty(name)} : function() {setMisc(name)}
+    }
+
+    return row
+}
+
+function createAllRows(categoryType, tableId) {
+    var templates = {
+        headerRow: document.getElementsByClassName(categoryType == itemCategories ? "headerRowItemTemplate" : "headerRowTaskTemplate")[0],
+        row: document.getElementsByClassName(categoryType == itemCategories ? "rowItemTemplate" : "rowTaskTemplate")[0],
+    }
+
+    var table = document.getElementById(tableId)
+
+    for (categoryName in categoryType) {
+        var headerRow = createHeaderRow(templates, categoryType, categoryName)
+        table.appendChild(headerRow)
+        
+        var category = categoryType[categoryName]
+        category.forEach(function(name) {
+            var row = createRow(templates, name, categoryName, categoryType)
+            table.appendChild(row)       
+        })
+
+        var requiredRow = createRequiredRow(categoryName)
+        table.append(requiredRow)
+    }
+}
+
+function updateQuickTaskDisplay(taskType) {
+    var currentTask = taskType == "job" ? gameData.currentJob : gameData.currentSkill
+    var quickTaskDisplayElement = document.getElementById("quickTaskDisplay")
+    var progressBar = quickTaskDisplayElement.getElementsByClassName(taskType)[0]
+    progressBar.getElementsByClassName("name")[0].textContent = getDisplayName(currentTask.name) + " lvl " + currentTask.level
+    progressBar.getElementsByClassName("progressFill")[0].style.width = currentTask.xp / currentTask.getMaxXp() * 100 + "%"
+}
+
+function updateRequiredRows(data, categoryType) {
+    var requiredRows = document.getElementsByClassName("requiredRow")
+    for (requiredRow of requiredRows) {
+        var nextEntity = null
+        var category = categoryType[requiredRow.id] 
+        if (category == null) {continue}
+        for (i = 0; i < category.length; i++) {
+            var entityName = category[i]
+            if (i >= category.length - 1) break
+            var requirements = gameData.requirements[entityName]
+            if (requirements && i == 0) {
+                if (!requirements.isCompleted()) {
+                    nextEntity = data[entityName]
+                    break
+                }
+            }
+
+            var nextIndex = i + 1
+            if (nextIndex >= category.length) {break}
+            var nextEntityName = category[nextIndex]
+            nextEntityRequirements = gameData.requirements[nextEntityName]
+
+            if (!nextEntityRequirements.isCompleted()) {
+                nextEntity = data[nextEntityName]
+                break
+            }       
+        }
+
+        if (nextEntity == null) {
+            requiredRow.classList.add("hiddenTask")           
+        } else {
+            requiredRow.classList.remove("hiddenTask")
+            var requirementObject = gameData.requirements[nextEntity.name]
+            var requirements = requirementObject.requirements
+
+            var coinElement = requiredRow.getElementsByClassName("coins")[0]
+            var levelElement = requiredRow.getElementsByClassName("levels")[0]
+            var evilElement = requiredRow.getElementsByClassName("evil")[0]
+
+            coinElement.classList.add("hiddenTask")
+            levelElement.classList.add("hiddenTask")
+            evilElement.classList.add("hiddenTask")
+
+            var finalText = ""
+            if (data == gameData.taskData) {
+                if (requirementObject instanceof EvilRequirement) {
+                    evilElement.classList.remove("hiddenTask")
+                    evilElement.textContent = format(requirements[0].requirement) + " evil"
+                } else {
+                    levelElement.classList.remove("hiddenTask")
+                    for (requirement of requirements) {
+                        var task = gameData.taskData[requirement.task]
+                        if (task.level >= requirement.requirement) continue
+                        var text = " " + getDisplayName(requirement.task) + " level " + format(task.level) + "/" + format(requirement.requirement) + ","
+                        finalText += text
+                    }
+                    finalText = finalText.substring(0, finalText.length - 1)
+                    levelElement.textContent = finalText
+                }
+            } else if (data == gameData.itemData) {
+                coinElement.classList.remove("hiddenTask")
+                formatCoins(requirements[0].requirement, coinElement)
+            }
+        }   
+    }
+}
+
+function updateTaskRows() {
+    for (key in gameData.taskData) {
+        var task = gameData.taskData[key]
+        var row = document.getElementById("row " + task.name)
+        row.getElementsByClassName("level")[0].textContent = task.level
+        row.getElementsByClassName("xpGain")[0].textContent = format(task.getXpGain())
+        row.getElementsByClassName("xpLeft")[0].textContent = format(task.getXpLeft())
+
+        var maxLevel = row.getElementsByClassName("maxLevel")[0]
+        maxLevel.textContent = task.maxLevel
+        gameData.rebirthOneCount > 0 ? maxLevel.classList.remove("hidden") : maxLevel.classList.add("hidden")
+
+        var progressFill = row.getElementsByClassName("progressFill")[0]
+        progressFill.style.width = task.xp / task.getMaxXp() * 100 + "%"
+        task == gameData.currentJob || task == gameData.currentSkill ? progressFill.classList.add("current") : progressFill.classList.remove("current")
+
+        var valueElement = row.getElementsByClassName("value")[0]
+        valueElement.getElementsByClassName("income")[0].style.display = task instanceof Job
+        valueElement.getElementsByClassName("effect")[0].style.display = task instanceof Skill
+
+        var skipSkillElement = row.getElementsByClassName("skipSkill")[0]
+        skipSkillElement.style.display = task instanceof Skill && autoLearnElement.checked ? "block" : "none"
+
+        if (task instanceof Job) {
+            formatCoins(task.getIncome(), valueElement.getElementsByClassName("income")[0])
+        } else {
+            valueElement.getElementsByClassName("effect")[0].textContent = task.getEffectDescription()
+        }
+    }
+}
+
+function updateItemRows() {
+    for (key in gameData.itemData) {
+        var item = gameData.itemData[key]
+        var row = document.getElementById("row " + item.name)
+        var button = row.getElementsByClassName("button")[0]
+        button.disabled = gameData.coins < item.getExpense()
+        var active = row.getElementsByClassName("active")[0]
+        var color = itemCategories["Properties"].includes(item.name) ? headerRowColors["Properties"] : headerRowColors["Misc"]
+        active.style.backgroundColor = gameData.currentMisc.includes(item) || item == gameData.currentProperty ? color : "white"
+        row.getElementsByClassName("effect")[0].textContent = item.getEffectDescription()
+        formatCoins(item.getExpense(), row.getElementsByClassName("expense")[0])
+    }
+}
+
+function updateHeaderRows(categories) {
+    for (categoryName in categories) {
+        var className = removeSpaces(categoryName)
+        var headerRow = document.getElementsByClassName(className)[0]
+        var maxLevelElement = headerRow.getElementsByClassName("maxLevel")[0]
+        gameData.rebirthOneCount > 0 ? maxLevelElement.classList.remove("hidden") : maxLevelElement.classList.add("hidden")
+        var skipSkillElement = headerRow.getElementsByClassName("skipSkill")[0]
+        skipSkillElement.style.display = categories == skillCategories && autoLearnElement.checked ? "block" : "none"
+    }
+}
+
+function updateText() {
+    //Sidebar
+    document.getElementById("ageDisplay").textContent = daysToYears(gameData.days)
+    document.getElementById("dayDisplay").textContent = getDay()
+    document.getElementById("lifespanDisplay").textContent = daysToYears(getLifespan())
+    document.getElementById("pauseButton").textContent = gameData.paused ? "Play" : "Pause"
+
+    formatCoins(gameData.coins, document.getElementById("coinDisplay"))
+    setSignDisplay()
+    formatCoins(getNet(), document.getElementById("netDisplay"))
+    formatCoins(getIncome(), document.getElementById("incomeDisplay"))
+    formatCoins(getExpense(), document.getElementById("expenseDisplay"))
+
+    document.getElementById("happinessDisplay").textContent = getHappiness().toFixed(1)
+
+    document.getElementById("evilDisplay").textContent = gameData.evil.toFixed(1)
+    document.getElementById("evilGainDisplay").textContent = getEvilGain().toFixed(1)
+
+    document.getElementById("timeWarpingDisplay").textContent = "x" + gameData.taskData["Time warping"].getEffect().toFixed(2)
+    document.getElementById("timeWarpingButton").textContent = gameData.timeWarpingEnabled ? "Disable warp" : "Enable warp"
+}
+
+function setSignDisplay() {
+    var signDisplay = document.getElementById("signDisplay")
+    if (getIncome() > getExpense()) {
+        signDisplay.textContent = "+"
+        signDisplay.style.color = "green"
+    } else if (getExpense() > getIncome()) {
+        signDisplay.textContent = "-"
+        signDisplay.style.color = "red"
+    } else {
+        signDisplay.textContent = ""
+        signDisplay.style.color = "gray"
+    }
+}
+
+function getNet() {
+    var net = Math.abs(getIncome() - getExpense())
+    return net
+}
+
+function hideEntities() {
+    for (key in gameData.requirements) {
+        var requirement = gameData.requirements[key]
+        var completed = requirement.isCompleted()
+        for (element of requirement.elements) {
+            if (completed) {
+                element.classList.remove("hidden")
+            } else {
+                element.classList.add("hidden")
+            }
+        }
+    }
+}
+
+function createItemData(baseData) {
+    for (var item of baseData) {
+        gameData.itemData[item.name] = "happiness" in item ? new Property(task) : new Misc(task)
+        gameData.itemData[item.name].id = "item " + item.name
+    }
+}
+
+function doCurrentTask(task) {
+    task.increaseXp()
+    if (task instanceof Job) {
+        increaseCoins()
+    }
+}
+
+function getIncome() {
+    var income = 0
+    income += gameData.currentJob.getIncome()
+    return income
+}
+
+function increaseCoins() {
+    var coins = applySpeed(getIncome())
+    gameData.coins += coins
+}
+
+function daysToYears(days) {
+    var years = Math.floor(days / 365)
+    return years
+}
+
+function getCategoryFromEntityName(categoryType, entityName) {
+    for (categoryName in categoryType) {
+        var category = categoryType[categoryName]
+        if (category.includes(entityName)) {
+            return category
+        }
+    }
+}
+
+function getNextEntity(data, categoryType, entityName) {
+    var category = getCategoryFromEntityName(categoryType, entityName)
+    var nextIndex = category.indexOf(entityName) + 1
+    if (nextIndex > category.length - 1) return null
+    var nextEntityName = category[nextIndex]
+    var nextEntity = data[nextEntityName]
+    return nextEntity
+}
+
+function autoPromote() {
+    if (!autoPromoteElement.checked) return
+    var nextEntity = getNextEntity(gameData.taskData, jobCategories, gameData.currentJob.name)
+    if (nextEntity == null) return
+    var requirement = gameData.requirements[nextEntity.name]
+    if (requirement.isCompleted()) gameData.currentJob = nextEntity
+}
+
+function checkSkillSkipped(skill) {
+    var row = document.getElementById("row " + skill.name)
+    var isSkillSkipped = row.getElementsByClassName("checkbox")[0].checked
+    return isSkillSkipped
+}
+
+function setSkillWithLowestMaxXp() {
+    var xpDict = {}
+
+    for (skillName in gameData.taskData) {
+        var skill = gameData.taskData[skillName]
+        var requirement = gameData.requirements[skillName]
+        if (skill instanceof Skill && requirement.isCompleted() && !checkSkillSkipped(skill)) {
+            xpDict[skill.name] = skill.level //skill.getMaxXp() / skill.getXpGain()
+        }
+    }
+
+    if (xpDict == {}) {
+        skillWithLowestMaxXp = gameData.taskData["Concentration"]
+        return
+    }
+
+    var skillName = getKeyOfLowestValueFromDict(xpDict)
+    skillWithLowestMaxXp = gameData.taskData[skillName]
+}
+
+function getKeyOfLowestValueFromDict(dict) {
+    var values = []
+    for (key in dict) {
+        var value = dict[key]
+        values.push(value)
+    }
+
+    values.sort(function(a, b){return a - b})
+
+    for (key in dict) {
+        var value = dict[key]
+        if (value == values[0]) {
+            return key
+        }
+    }
+}
+
+function autoLearn() {
+    if (!autoLearnElement.checked || !skillWithLowestMaxXp) return
+    gameData.currentSkill = skillWithLowestMaxXp
+}
+
+function yearsToDays(years) {
+    var days = years * 365
+    return days
+}
+ 
+function getDay() {
+    var day = Math.floor(gameData.days - daysToYears(gameData.days) * 365)
+    return day
+}
+
+function increaseDays() {
+    var increase = applySpeed(1)
+    gameData.days += increase
+}
+
+function format(number) {
+
+    // what tier? (determines SI symbol)
+    var tier = Math.log10(number) / 3 | 0;
+
+    // if zero, we don't need a suffix
+    if(tier == 0) return number;
+
+    // get suffix and determine scale
+    var suffix = units[tier];
+    var scale = Math.pow(10, tier * 3);
+
+    // scale the number
+    var scaled = number / scale;
+
+    // format number and add suffix
+    return scaled.toFixed(1) + suffix;
+}
+
+function formatCoins(coins, element) {
+    var tiers = ["p", "g", "s"]
+    var colors = {
+        "p": "#79b9c7",
+        "g": "#E5C100",
+        "s": "#a8a8a8",
+        "c": "#a15c2f"
+    }
+    var leftOver = coins
+    var i = 0
+    for (tier of tiers) {
+        var x = Math.floor(leftOver / Math.pow(10, (tiers.length - i) * 2))
+        var leftOver = Math.floor(leftOver - x * Math.pow(10, (tiers.length - i) * 2))
+        var text = format(String(x)) + tier + " "
+        element.children[i].textContent = x > 0 ? text : ""
+        element.children[i].style.color = colors[tier]
+        i += 1
+    }
+    if (leftOver == 0 && coins > 0) {element.children[3].textContent = ""; return}
+    var text = String(Math.floor(leftOver)) + "c"
+    element.children[3].textContent = text
+    element.children[3].style.color = colors["c"]
+}
+
+function getTaskElement(taskName) {
+    var task = gameData.taskData[taskName]
+    var element = document.getElementById(task.id)
+    return element
+}
+
+function getItemElement(itemName) {
+    var item = gameData.itemData[itemName]
+    var element = document.getElementById(item.id)
+    return element
+}
+
+function getElementsByClass(className) {
+    var elements = document.getElementsByClassName(removeSpaces(className))
+    return elements
+}
+
+function setLightDarkMode() {
+    var root = document.getElementById("orkr-root")
+    root.classList.contains("orkr-dark") ? root.classList.remove("orkr-dark") : root.classList.add("orkr-dark")
+}
+
+function removeSpaces(string) {
+    var string = string.replace(/ /g, "")
+    return string
+}
+
+function rebirthOne() {
+    gameData.rebirthOneCount += 1
+
+    rebirthReset()
+}
+
+function rebirthTwo() {
+    gameData.rebirthTwoCount += 1
+    gameData.evil += getEvilGain()
+
+    rebirthReset()
+
+    for (taskName in gameData.taskData) {
+        var task = gameData.taskData[taskName]
+        task.maxLevel = 0
+    }    
+}
+
+function rebirthReset() {
+    setTab(jobTabButton, "jobs")
+
+    gameData.coins = 0
+    gameData.days = 365 * 14
+    gameData.currentJob = gameData.taskData["Beggar"]
+    gameData.currentSkill = gameData.taskData["Concentration"]
+    gameData.currentProperty = gameData.itemData["Homeless"]
+    gameData.currentMisc = []
+
+    for (taskName in gameData.taskData) {
+        var task = gameData.taskData[taskName]
+        if (task.level > task.maxLevel) task.maxLevel = task.level
+        task.level = 0
+        task.xp = 0
+    }
+
+    for (key in gameData.requirements) {
+        var requirement = gameData.requirements[key]
+        if (requirement.completed && permanentUnlocks.includes(key)) continue
+        requirement.completed = false
+    }
+}
+
+function getLifespan() {
+    var immortality = gameData.taskData["Immortality"]
+    var superImmortality = gameData.taskData["Super immortality"]
+    var lifespan = baseLifespan * immortality.getEffect() * superImmortality.getEffect()
+    return lifespan
+}
+
+function isAlive() {
+    var condition = gameData.days < getLifespan()
+    var deathText = document.getElementById("deathText")
+    if (!condition) {
+        gameData.days = getLifespan()
+        deathText.classList.remove("hidden")
+    }
+    else {
+        deathText.classList.add("hidden")
+    }
+    return condition
+}
+
+function assignMethods() {
+
+    for (key in gameData.taskData) {
+        var task = gameData.taskData[key]
+        if (task.baseData.income) {
+            task.baseData = jobBaseData[task.name]
+            task = Object.assign(new Job(jobBaseData[task.name]), task)
+            
+        } else {
+            task.baseData = skillBaseData[task.name]
+            task = Object.assign(new Skill(skillBaseData[task.name]), task)
+        } 
+        gameData.taskData[key] = task
+    }
+
+    for (key in gameData.itemData) {
+        var item = gameData.itemData[key]
+        item.baseData = itemBaseData[item.name]
+        item = Object.assign(new Item(itemBaseData[item.name]), item)
+        gameData.itemData[key] = item
+    }
+
+    for (key in gameData.requirements) {
+        var requirement = gameData.requirements[key]
+        if (requirement.type == "task") {
+            requirement = Object.assign(new TaskRequirement(requirement.elements, requirement.requirements), requirement)
+        } else if (requirement.type == "coins") {
+            requirement = Object.assign(new CoinRequirement(requirement.elements, requirement.requirements), requirement)
+        } else if (requirement.type == "age") {
+            requirement = Object.assign(new AgeRequirement(requirement.elements, requirement.requirements), requirement)
+        } else if (requirement.type == "evil") {
+            requirement = Object.assign(new EvilRequirement(requirement.elements, requirement.requirements), requirement)
+        }
+
+        var tempRequirement = tempData["requirements"][key]
+        requirement.elements = tempRequirement.elements
+        requirement.requirements = tempRequirement.requirements
+        gameData.requirements[key] = requirement
+    }
+
+    gameData.currentJob = gameData.taskData[gameData.currentJob.name]
+    gameData.currentSkill = gameData.taskData[gameData.currentSkill.name]
+    gameData.currentProperty = gameData.itemData[gameData.currentProperty.name]
+    var newArray = []
+    for (misc of gameData.currentMisc) {
+        newArray.push(gameData.itemData[misc.name])
+    }
+    gameData.currentMisc = newArray
+}
+
+function replaceSaveDict(dict, saveDict) {
+    for (key in dict) {
+        if (!(key in saveDict)) {
+            saveDict[key] = dict[key]
+        } else if (dict == gameData.requirements) {
+            if (saveDict[key].type != tempData["requirements"][key].type) {
+                saveDict[key] = tempData["requirements"][key]
+            }
+        }
+    }
+
+    for (key in saveDict) {
+        if (!(key in dict)) {
+            delete saveDict[key]
+        }
+    }
+}
+
+function saveGameData() {
+    localStorage.setItem("orkrementalSave", JSON.stringify(gameData))
+}
+
+function loadGameData() {
+    var gameDataSave = JSON.parse(localStorage.getItem("orkrementalSave"))
+
+    if (gameDataSave !== null) {
+        replaceSaveDict(gameData, gameDataSave)
+        replaceSaveDict(gameData.requirements, gameDataSave.requirements)
+        replaceSaveDict(gameData.taskData, gameDataSave.taskData)
+        replaceSaveDict(gameData.itemData, gameDataSave.itemData)
+
+        gameData = gameDataSave
+    }
+
+    assignMethods()
+}
+
+function updateUI() {
+    updateTaskRows()
+    updateItemRows()
+    updateRequiredRows(gameData.taskData, jobCategories)
+    updateRequiredRows(gameData.taskData, skillCategories)
+    updateRequiredRows(gameData.itemData, itemCategories)
+    updateHeaderRows(jobCategories)
+    updateHeaderRows(skillCategories)
+    updateQuickTaskDisplay("job")
+    updateQuickTaskDisplay("skill")
+    hideEntities()
+    updateText()  
+}
+
+function update() {
+    increaseDays()
+    autoPromote()
+    autoLearn()
+    doCurrentTask(gameData.currentJob)
+    doCurrentTask(gameData.currentSkill)
+    applyExpenses()
+    updateUI()
+}
+
+function resetGameData() {
+    localStorage.clear()
+    location.reload()
+}
+
+function importGameData() {
+    var importExportBox = document.getElementById("importExportBox")
+    var data = JSON.parse(window.atob(importExportBox.value))
+    gameData = data
+    saveGameData()
+    location.reload()
+}
+
+function exportGameData() {
+    var importExportBox = document.getElementById("importExportBox")
+    importExportBox.value = window.btoa(JSON.stringify(gameData))
+}
+
+//Init
+
+createAllRows(jobCategories, "jobTable")
+createAllRows(skillCategories, "skillTable")
+createAllRows(itemCategories, "itemTable") 
+
+createData(gameData.taskData, jobBaseData)
+createData(gameData.taskData, skillBaseData)
+createData(gameData.itemData, itemBaseData) 
+
+gameData.currentJob = gameData.taskData["Beggar"]
+gameData.currentSkill = gameData.taskData["Concentration"]
+gameData.currentProperty = gameData.itemData["Homeless"]
+gameData.currentMisc = []
+
+gameData.requirements = {
+    //Other
+    "The Arcane Association": new TaskRequirement(getElementsByClass("The Arcane Association"), [{task: "Concentration", requirement: 200}, {task: "Meditation", requirement: 200}]),
+    "Dark magic": new EvilRequirement(getElementsByClass("Dark magic"), [{requirement: 1}]),
+    "Shop": new CoinRequirement([document.getElementById("shopTabButton")], [{requirement: gameData.itemData["Tent"].getExpense() * 50}]),
+    "Rebirth tab": new AgeRequirement([document.getElementById("rebirthTabButton")], [{requirement: 25}]),
+    "Rebirth note 1": new AgeRequirement([document.getElementById("rebirthNote1")], [{requirement: 45}]),
+    "Rebirth note 2": new AgeRequirement([document.getElementById("rebirthNote2")], [{requirement: 65}]),
+    "Rebirth note 3": new AgeRequirement([document.getElementById("rebirthNote3")], [{requirement: 200}]),
+    "Evil info": new EvilRequirement([document.getElementById("evilInfo")], [{requirement: 1}]),
+    "Time warping info": new TaskRequirement([document.getElementById("timeWarping")], [{task: "Mage", requirement: 10}]),
+    "Automation": new AgeRequirement([document.getElementById("automation")], [{requirement: 20}]),
+    "Quick task display": new AgeRequirement([document.getElementById("quickTaskDisplay")], [{requirement: 20}]),
+
+    //Common work
+    "Beggar": new TaskRequirement([getTaskElement("Beggar")], []),
+    "Farmer": new TaskRequirement([getTaskElement("Farmer")], [{task: "Beggar", requirement: 10}]),
+    "Fisherman": new TaskRequirement([getTaskElement("Fisherman")], [{task: "Farmer", requirement: 10}]),
+    "Miner": new TaskRequirement([getTaskElement("Miner")], [{task: "Strength", requirement: 10}, {task: "Fisherman", requirement: 10}]),
+    "Blacksmith": new TaskRequirement([getTaskElement("Blacksmith")], [{task: "Strength", requirement: 30}, {task: "Miner", requirement: 10}]),
+    "Merchant": new TaskRequirement([getTaskElement("Merchant")], [{task: "Bargaining", requirement: 50}, {task: "Blacksmith", requirement: 10}]),
+
+    //Military 
+    "Squire": new TaskRequirement([getTaskElement("Squire")], [{task: "Strength", requirement: 5}]),
+    "Footman": new TaskRequirement([getTaskElement("Footman")], [{task: "Strength", requirement: 20}, {task: "Squire", requirement: 10}]),
+    "Veteran footman": new TaskRequirement([getTaskElement("Veteran footman")], [{task: "Battle tactics", requirement: 40}, {task: "Footman", requirement: 10}]),
+    "Knight": new TaskRequirement([getTaskElement("Knight")], [{task: "Strength", requirement: 100}, {task: "Veteran footman", requirement: 10}]),
+    "Veteran knight": new TaskRequirement([getTaskElement("Veteran knight")], [{task: "Battle tactics", requirement: 150}, {task: "Knight", requirement: 10}]),
+    "Elite knight": new TaskRequirement([getTaskElement("Elite knight")], [{task: "Strength", requirement: 300}, {task: "Veteran knight", requirement: 10}]),
+    "Holy knight": new TaskRequirement([getTaskElement("Holy knight")], [{task: "Mana control", requirement: 500}, {task: "Elite knight", requirement: 10}]),
+    "Legendary knight": new TaskRequirement([getTaskElement("Legendary knight")], [{task: "Mana control", requirement: 1000}, {task: "Battle tactics", requirement: 1000}, {task: "Holy knight", requirement: 10}]),
+
+    //The Arcane Association
+    "Student": new TaskRequirement([getTaskElement("Student")], [{task: "Concentration", requirement: 200}, {task: "Meditation", requirement: 200}]),
+    "Apprentice mage": new TaskRequirement([getTaskElement("Apprentice mage")], [{task: "Mana control", requirement: 400}, {task: "Student", requirement: 10}]),
+    "Mage": new TaskRequirement([getTaskElement("Mage")], [{task: "Mana control", requirement: 700}, {task: "Apprentice mage", requirement: 10}]),
+    "Wizard": new TaskRequirement([getTaskElement("Wizard")], [{task: "Mana control", requirement: 1000}, {task: "Mage", requirement: 10}]),
+    "Master wizard": new TaskRequirement([getTaskElement("Master wizard")], [{task: "Mana control", requirement: 1500}, {task: "Wizard", requirement: 10}]),
+    "Chairman": new TaskRequirement([getTaskElement("Chairman")], [{task: "Mana control", requirement: 2000}, {task: "Master wizard", requirement: 10}]),
+
+    //Fundamentals
+    "Concentration": new TaskRequirement([getTaskElement("Concentration")], []),
+    "Productivity": new TaskRequirement([getTaskElement("Productivity")], [{task: "Concentration", requirement: 5}]),
+    "Bargaining": new TaskRequirement([getTaskElement("Bargaining")], [{task: "Concentration", requirement: 20}]),
+    "Meditation": new TaskRequirement([getTaskElement("Meditation")], [{task: "Concentration", requirement: 30}, {task: "Productivity", requirement: 20}]),
+
+    //Combat
+    "Strength": new TaskRequirement([getTaskElement("Strength")], []),
+    "Battle tactics": new TaskRequirement([getTaskElement("Battle tactics")], [{task: "Concentration", requirement: 20}]),
+    "Muscle memory": new TaskRequirement([getTaskElement("Muscle memory")], [{task: "Concentration", requirement: 30}, {task: "Strength", requirement: 30}]),
+
+    //Magic
+    "Mana control": new TaskRequirement([getTaskElement("Mana control")], [{task: "Concentration", requirement: 200}, {task: "Meditation", requirement: 200}]),
+    "Immortality": new TaskRequirement([getTaskElement("Immortality")], [{task: "Apprentice mage", requirement: 10}]),
+    "Time warping": new TaskRequirement([getTaskElement("Time warping")], [{task: "Mage", requirement: 10}]),
+    "Super immortality": new TaskRequirement([getTaskElement("Super immortality")], [{task: "Chairman", requirement: 1000}]),
+
+    //Dark magic
+    "Dark influence": new EvilRequirement([getTaskElement("Dark influence")], [{requirement: 1}]),
+    "Evil control": new EvilRequirement([getTaskElement("Evil control")], [{requirement: 1}]),
+    "Intimidation": new EvilRequirement([getTaskElement("Intimidation")], [{requirement: 1}]),
+    "Demon training": new EvilRequirement([getTaskElement("Demon training")], [{requirement: 25}]),
+    "Blood meditation": new EvilRequirement([getTaskElement("Blood meditation")], [{requirement: 75}]),
+    "Demon's wealth": new EvilRequirement([getTaskElement("Demon's wealth")], [{requirement: 500}]),
+
+    //Properties
+    "Homeless": new CoinRequirement([getItemElement("Homeless")], [{requirement: 0}]),
+    "Tent": new CoinRequirement([getItemElement("Tent")], [{requirement: 0}]),
+    "Wooden hut": new CoinRequirement([getItemElement("Wooden hut")], [{requirement: gameData.itemData["Wooden hut"].getExpense() * 100}]),
+    "Cottage": new CoinRequirement([getItemElement("Cottage")], [{requirement: gameData.itemData["Cottage"].getExpense() * 100}]),
+    "House": new CoinRequirement([getItemElement("House")], [{requirement: gameData.itemData["House"].getExpense() * 100}]),
+    "Large house": new CoinRequirement([getItemElement("Large house")], [{requirement: gameData.itemData["Large house"].getExpense() * 100}]),
+    "Small palace": new CoinRequirement([getItemElement("Small palace")], [{requirement: gameData.itemData["Small palace"].getExpense() * 100}]),
+    "Grand palace": new CoinRequirement([getItemElement("Grand palace")], [{requirement: gameData.itemData["Grand palace"].getExpense() * 100}]),
+
+    //Misc
+    "Book": new CoinRequirement([getItemElement("Book")], [{requirement: 0}]),
+    "Dumbbells": new CoinRequirement([getItemElement("Dumbbells")], [{requirement: gameData.itemData["Dumbbells"].getExpense() * 100}]),
+    "Personal squire": new CoinRequirement([getItemElement("Personal squire")], [{requirement: gameData.itemData["Personal squire"].getExpense() * 100}]),
+    "Steel longsword": new CoinRequirement([getItemElement("Steel longsword")], [{requirement: gameData.itemData["Steel longsword"].getExpense() * 100}]),
+    "Butler": new CoinRequirement([getItemElement("Butler")], [{requirement: gameData.itemData["Butler"].getExpense() * 100}]),
+    "Sapphire charm": new CoinRequirement([getItemElement("Sapphire charm")], [{requirement: gameData.itemData["Sapphire charm"].getExpense() * 100}]),
+    "Study desk": new CoinRequirement([getItemElement("Study desk")], [{requirement: gameData.itemData["Study desk"].getExpense() * 100}]),
+    "Library": new CoinRequirement([getItemElement("Library")], [{requirement: gameData.itemData["Library"].getExpense() * 100}]), 
+}
+
+tempData["requirements"] = {}
+for (key in gameData.requirements) {
+    var requirement = gameData.requirements[key]
+    tempData["requirements"][key] = requirement
+}
+
+loadGameData()
+
+setCustomEffects()
+addMultipliers()
+
+setTab(jobTabButton, "jobs")
+
+update()
+setInterval(update, 1000 / updateSpeed)
+setInterval(saveGameData, 3000)
+setInterval(setSkillWithLowestMaxXp, 1000)

--- a/orkui/template/default/orkremental/orkremental.css
+++ b/orkui/template/default/orkremental/orkremental.css
@@ -1,0 +1,343 @@
+/* =====================================================================
+   ORKremental — self-contained game board stylesheet
+   ---------------------------------------------------------------------
+   EVERY selector is scoped under #orkr-root so nothing bleeds into ORK
+   chrome. The board FOLLOWS ORK's own theme (ORK sets <html data-theme=
+   "light|dark">): PK's light styles are the base, and the dark palette
+   applies under html[data-theme="dark"]. No independent in-game toggle.
+
+   Sections:
+     1. Root wrapper + heading reset + box-sizing
+     2. w3.css shim (only the classes the game actually uses, scoped)
+     3. Progress Knight styles.css (scoped) — light theme base
+     4. Progress Knight dark.css (scoped to html[data-theme="dark"])
+   ===================================================================== */
+
+/* ---------------------------------------------------------------------
+   1. Root wrapper + heading reset
+   --------------------------------------------------------------------- */
+
+/* Allow the fixed-width (1220px) PK layout to scroll horizontally inside
+   the ORK page instead of overflowing and breaking surrounding chrome. */
+#orkr-root {
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+    color: rgb(32, 32, 32);
+}
+
+/* w3.css (which the original game loads) applies box-sizing:border-box
+   globally. We don't load w3.css, so replicate it here — otherwise the
+   PK panels' inline widths (300px / 900px) + .w3-padding overflow the
+   1220px container and the main panel wraps below the sidebar. */
+#orkr-root,
+#orkr-root *,
+#orkr-root *::before,
+#orkr-root *::after {
+    box-sizing: border-box;
+}
+
+/* ORK's global orkui.css forces a gray box (background/border/text-shadow)
+   on ALL h1-h6. Reset every heading inside the board. */
+#orkr-root h1,
+#orkr-root h2,
+#orkr-root h3,
+#orkr-root h4,
+#orkr-root h5,
+#orkr-root h6 {
+    background: transparent;
+    border: none;
+    padding: 0;
+    border-radius: 0;
+    text-shadow: none;
+}
+
+/* ---------------------------------------------------------------------
+   2. w3.css shim — scoped reimplementations of ONLY the w3 classes the
+      game uses. We deliberately do NOT load the w3schools CDN.
+   --------------------------------------------------------------------- */
+
+#orkr-root .w3-button {
+    padding: 6px 12px;
+    cursor: pointer;
+    border: none;
+    display: inline-block;
+    user-select: none;
+    -webkit-user-select: none;
+    background-color: transparent;
+    color: inherit;
+    font-size: inherit;
+    font-family: inherit;
+    text-align: center;
+    white-space: nowrap;
+    vertical-align: middle;
+}
+
+#orkr-root .w3-button:hover {
+    background-color: rgba(0, 0, 0, 0.10);
+}
+
+#orkr-root .w3-bar-item {
+    display: inline-block;
+    padding: 8px 16px;
+}
+
+#orkr-root .w3-table {
+    width: 100%;
+    border-collapse: collapse;
+    border-spacing: 0;
+    display: table;
+}
+
+#orkr-root .w3-table td,
+#orkr-root .w3-table th {
+    padding: 8px;
+    display: table-cell;
+    text-align: left;
+    vertical-align: top;
+}
+
+#orkr-root .w3-bordered tr {
+    border-bottom: 1px solid #ccc;
+}
+
+#orkr-root .w3-border {
+    border: 1px solid #ccc;
+}
+
+#orkr-root .w3-circle {
+    border-radius: 50%;
+}
+
+#orkr-root .w3-text-gray {
+    color: #757575;
+}
+
+/* active-tab marker */
+#orkr-root .w3-blue-gray {
+    background-color: #607d8b !important;
+    color: #fff !important;
+}
+
+#orkr-root .w3-red {
+    background-color: #f44336 !important;
+    color: #fff !important;
+}
+
+#orkr-root .w3-margin {
+    margin: 16px;
+}
+
+#orkr-root .w3-margin-left {
+    margin-left: 16px;
+}
+
+#orkr-root .w3-margin-top {
+    margin-top: 16px;
+}
+
+#orkr-root .w3-padding {
+    padding: 8px 16px;
+}
+
+/* ---------------------------------------------------------------------
+   3. Progress Knight styles.css (scoped)
+   --------------------------------------------------------------------- */
+
+/* PK's "body" rule only set a background — apply it to the board root. */
+#orkr-root {
+    background-color: rgb(243, 243, 243);
+}
+
+#orkr-root .w3-bar-item {
+    width: 100px;
+    height: 40px;
+    text-align: center;
+}
+
+#orkr-root td {
+    vertical-align: middle !important;
+}
+
+#orkr-root .current {
+    background-color: orange !important;
+}
+
+#orkr-root .progress-text {
+    position: absolute;
+    top: 0px;
+    bottom: 0px;
+    padding: 5px;
+    color: white;
+}
+
+#orkr-root .progress-bar {
+    position: relative;
+    background-color: rgb(12, 101, 173);
+    cursor: pointer;
+    width: 200px;
+}
+
+#orkr-root .progress-fill {
+    height: 30px;
+    background-color: rgb(46, 148, 231);
+}
+
+#orkr-root .hidden {
+    display: none !important;
+}
+
+#orkr-root .hiddenTask {
+    display: none !important;
+}
+
+#orkr-root .button {
+    border: 1px solid black !important;
+}
+
+#orkr-root .item-button {
+    background-color: white;
+    text-align: center;
+    width: 200px;
+    height: 40px;
+    padding: 8px;
+}
+
+#orkr-root .item-button:hover {
+    cursor: pointer;
+    background-color: rgb(192, 192, 192);
+}
+
+#orkr-root button:focus {
+    outline: none;
+}
+
+#orkr-root .scroll {
+    overflow-y: auto;
+}
+
+#orkr-root .tooltip {
+    position: relative;
+    display: inline-block;
+}
+
+#orkr-root .tooltip .tooltipText {
+    visibility: hidden;
+    width: 240px;
+    background-color: black;
+    color: #fff;
+    text-align: center;
+    border-radius: 6px;
+    padding: 10px 0;
+
+    /* Position the tooltip */
+    position: absolute;
+    z-index: 1;
+    top: -5px;
+    left: 105%;
+
+    opacity: 0;
+    transition: opacity 0.5s;
+}
+
+#orkr-root .tooltip:hover .tooltipText {
+    visibility: visible;
+    opacity: 0.8;
+}
+
+#orkr-root .sidebar-element {
+    margin-bottom: 16px;
+}
+
+#orkr-root .slidecontainer {
+    width: 100%;
+}
+
+#orkr-root .slider {
+    -webkit-appearance: none;
+    width: 50%;
+    height: 15px;
+    border-radius: 5px;
+    background: #d3d3d3;
+    outline: none;
+    opacity: 0.7;
+    -webkit-transition: .2s;
+    transition: opacity .2s;
+}
+
+#orkr-root .slider:hover {
+    opacity: 1;
+}
+
+#orkr-root .slider::-webkit-slider-thumb {
+    -webkit-appearance: none;
+    appearance: none;
+    width: 25px;
+    height: 25px;
+    border-radius: 50%;
+    background: #4CAF50;
+    cursor: pointer;
+}
+
+#orkr-root .slider::-moz-range-thumb {
+    width: 25px;
+    height: 25px;
+    border-radius: 50%;
+    background: #4CAF50;
+    cursor: pointer;
+}
+
+#orkr-root .inline {
+    display: inline-block;
+}
+
+#orkr-root .panel {
+    background-color: white;
+}
+
+#orkr-root .small-margin {
+    margin-bottom: 2px;
+}
+
+/* ---------------------------------------------------------------------
+   4. Progress Knight dark.css (scoped to ORK's dark theme)
+      The board FOLLOWS ORK's own theme: ORK sets <html data-theme="dark">
+      / "light". When ORK is dark, these rules apply the PK dark palette;
+      when ORK is light, the base rules above (PK's light theme) show.
+      No independent in-game toggle — the board matches the surrounding app.
+   --------------------------------------------------------------------- */
+
+html[data-theme="dark"] #orkr-root {
+    background-color: rgb(32, 32, 32);
+    color: white;
+}
+
+html[data-theme="dark"] #orkr-root .panel {
+    background-color: rgb(46, 46, 46);
+}
+
+html[data-theme="dark"] #orkr-root .button {
+    background-color: rgb(31, 31, 31);
+    border-color: white !important;
+    color: white !important;
+}
+
+html[data-theme="dark"] #orkr-root .w3-bordered tr,
+html[data-theme="dark"] #orkr-root .w3-table-all tr {
+    border-bottom: 1px solid rgb(73, 73, 73);
+}
+
+html[data-theme="dark"] #orkr-root .w3-button:hover {
+    background-color: rgb(82, 82, 82) !important;
+    color: white !important;
+}
+
+/* In dark mode the PK item-button keeps a light fill in the original game,
+   which clashes; give it a dark-board-consistent fill for good contrast. */
+html[data-theme="dark"] #orkr-root .item-button {
+    background-color: rgb(31, 31, 31);
+    color: white;
+}
+
+html[data-theme="dark"] #orkr-root .item-button:hover {
+    background-color: rgb(82, 82, 82);
+}

--- a/orkui/template/revised-frontend/Kingdomnew_index.tpl
+++ b/orkui/template/revised-frontend/Kingdomnew_index.tpl
@@ -8,6 +8,8 @@
 	$eventList        = is_array($event_summary) ? $event_summary : array();
 	// [TOURNAMENTS HIDDEN] $tournamentList = [];
 	$principalityList = is_array($principalities['Principalities']) ? $principalities['Principalities'] : array();
+	$prinzParks       = is_array($principality_parks ?? null) ? $principality_parks : [];
+	$prinzMapParks    = is_array($prinz_map_parks ?? null) ? $prinz_map_parks : [];
 	$officerList      = is_array($kingdom_officers['Officers']) ? $kingdom_officers['Officers'] : array();
 
 	// Aggregate attendance — weekly loaded now, monthly loaded via AJAX after page load
@@ -59,6 +61,31 @@
 			'dir'      => kn_map_markdown($p['Directions'] ?? ''),
 			'desc'     => kn_map_markdown($p['Description'] ?? ''),
 		];
+	}
+	// Principality parks — same location objects, flagged with prinz metadata
+	foreach ($prinzMapParks as $prinz) {
+		$prName = (string)($prinz['Name'] ?? '');
+		$prId   = (int)($prinz['KingdomId'] ?? 0);
+		foreach ((array)($prinz['parks'] ?? []) as $p) {
+			$loc = @json_decode(stripslashes((string)$p['Location']));
+			if (!$loc) continue;
+			$latlng = isset($loc->location) ? $loc->location : (isset($loc->bounds->northeast) ? $loc->bounds->northeast : null);
+			if (!$latlng || !is_numeric($latlng->lat) || !is_numeric($latlng->lng)) continue;
+			$knMapLocations[] = [
+				'name'     => ucwords($p['Name']),
+				'lat'      => (float)$latlng->lat,
+				'lng'      => (float)$latlng->lng,
+				'id'       => (int)$p['ParkId'],
+				'city'     => htmlspecialchars(trim($p['City'] ?? '')),
+				'province' => htmlspecialchars(trim($p['Province'] ?? '')),
+				'heraldry' => $p['HasHeraldry'] ? HTTP_PARK_HERALDRY . Common::resolve_image_ext(DIR_PARK_HERALDRY, sprintf('%05d', $p['ParkId'])) : '',
+				'dir'      => kn_map_markdown($p['Directions'] ?? ''),
+				'desc'     => kn_map_markdown($p['Description'] ?? ''),
+				'prinz'    => true,
+				'prName'   => $prName,
+				'prId'     => $prId,
+			];
+		}
 	}
 ?>
 
@@ -263,12 +290,6 @@
 				<li data-kntab="map">
 					<i class="fas fa-map"></i><span class="kn-tab-label"> Map</span>
 				</li>
-				<?php if (!$IsPrinz && count($principalityList) > 0): ?>
-					<li data-kntab="principalities">
-						<i class="fas fa-shield-alt"></i><span class="kn-tab-label"> Principalities</span>
-						<span class="kn-tab-count">(<?= count($principalityList) ?>)</span>
-					</li>
-				<?php endif; ?>
 				<li data-kntab="players" id="kn-tab-btn-players">
 					<i class="fas fa-users"></i><span class="kn-tab-label"> Players</span>
 					<span class="kn-tab-count" id="kn-players-tab-count"></span>
@@ -412,7 +433,111 @@
 						</table>
 					</div>
 
-				<?php else: ?>
+				<?php endif; ?>
+
+				<!-- ===== Principalities (folded into Parks tab) ===== -->
+				<?php if (count($prinzParks) > 0): ?>
+
+					<!-- Principality tile sections (tile view) -->
+					<div id="kn-prinz-tile-sections">
+						<?php foreach ($prinzParks as $prinz): ?>
+							<?php $prId = (int)$prinz['KingdomId']; $prHeraldry = HTTP_KINGDOM_HERALDRY . Common::resolve_image_ext(DIR_KINGDOM_HERALDRY, sprintf("%04d", $prId)); ?>
+							<section class="kn-prinz-section" data-prinz-id="<?= $prId ?>">
+								<a class="kn-prinz-head" href="<?= UIR ?>Kingdom/profile/<?= $prId ?>">
+									<img class="kn-prinz-heraldry" loading="lazy" src="<?= $prHeraldry ?>" onerror="this.src='<?= HTTP_KINGDOM_HERALDRY ?>0000.jpg'" alt="">
+									<span class="kn-prinz-name"><?= htmlspecialchars($prinz['Name']) ?></span>
+									<i class="fas fa-external-link-alt kn-prinz-extlink"></i>
+								</a>
+								<div class="kn-park-tiles">
+									<?php foreach ((array)$prinz['parks'] as $park): ?>
+										<?php $tileHeraldry = $park['HasHeraldry'] == 1
+											? HTTP_PARK_HERALDRY . Common::resolve_image_ext(DIR_PARK_HERALDRY, sprintf("%05d", $park['ParkId']))
+											: HTTP_PARK_HERALDRY . '00000.jpg'; ?>
+										<a class="kn-park-tile" href="<?= UIR ?>Park/profile/<?= $park['ParkId'] ?>" data-park-id="<?= (int)$park['ParkId'] ?>">
+											<div class="kn-park-tile-img-wrap">
+												<img src="<?= $tileHeraldry ?>"
+													loading="lazy"
+													onerror="this.src='<?= HTTP_PARK_HERALDRY ?>00000.jpg'"
+													alt="<?= htmlspecialchars($park['ParkName']) ?>">
+											</div>
+											<div class="kn-park-tile-body">
+												<div class="kn-park-tile-name"><?= htmlspecialchars($park['ParkName']) ?></div>
+												<div class="kn-park-tile-type"><?= htmlspecialchars(!empty($park['Title']) ? $park['Title'] : 'Park') ?></div>
+												<div class="kn-park-tile-stats">
+													<div class="kn-park-tile-stat">
+														<div class="kn-park-tile-stat-val kn-avgwk-tile"><i class="fas fa-spinner fa-spin kn-stat-spinner"></i></div>
+														<div class="kn-park-tile-stat-lbl">Avg/Wk</div>
+													</div>
+													<div class="kn-park-tile-stat">
+														<div class="kn-park-tile-stat-val kn-avgmo-tile"><i class="fas fa-spinner fa-spin kn-stat-spinner"></i></div>
+														<div class="kn-park-tile-stat-lbl">Avg/Mo</div>
+													</div>
+												</div>
+											</div>
+										</a>
+									<?php endforeach; ?>
+								</div>
+							</section>
+						<?php endforeach; ?>
+					</div>
+
+					<!-- Principality tables (list view) -->
+					<div id="kn-prinz-tables" style="display:none">
+						<?php foreach ($prinzParks as $prinz): ?>
+							<?php $prId = (int)$prinz['KingdomId']; $prHeraldry = HTTP_KINGDOM_HERALDRY . Common::resolve_image_ext(DIR_KINGDOM_HERALDRY, sprintf("%04d", $prId)); ?>
+							<div class="kn-prinz-table-wrap" data-prinz-id="<?= $prId ?>">
+								<a class="kn-prinz-head" href="<?= UIR ?>Kingdom/profile/<?= $prId ?>">
+									<img class="kn-prinz-heraldry" loading="lazy" src="<?= $prHeraldry ?>" onerror="this.src='<?= HTTP_KINGDOM_HERALDRY ?>0000.jpg'" alt="">
+									<span class="kn-prinz-name"><?= htmlspecialchars($prinz['Name']) ?></span>
+									<i class="fas fa-external-link-alt kn-prinz-extlink"></i>
+								</a>
+								<table class="kn-table kn-sortable">
+									<thead>
+										<tr>
+											<th data-sorttype="text">Park</th>
+											<th data-sorttype="text">Type</th>
+											<th data-sorttype="numeric" class="kn-col-numeric" title="Average distinct players per week over the past 6 months">Avg/Wk</th>
+											<th data-sorttype="numeric" class="kn-col-numeric" title="Average distinct players per month over the past 12 months">Avg/Mo</th>
+											<th data-sorttype="numeric" class="kn-col-numeric" title="Distinct players who signed in at this park in the past 12 months">Total Players</th>
+											<th data-sorttype="numeric" class="kn-col-numeric" title="Distinct players whose home park is here who signed in at this park in the past 12 months">Total Members</th>
+										</tr>
+									</thead>
+									<tbody>
+										<?php foreach ((array)$prinz['parks'] as $park): ?>
+											<tr class="kn-row-link" data-park-id="<?= (int)$park['ParkId'] ?>" onclick="window.location.href='<?= UIR ?>Park/profile/<?= $park['ParkId'] ?>'">
+												<td class="kn-col-nowrap">
+													<img class="kn-thumb"
+														loading="lazy"
+														src="<?= $park['HasHeraldry'] == 1 ? HTTP_PARK_HERALDRY . Common::resolve_image_ext(DIR_PARK_HERALDRY, sprintf("%05d", $park['ParkId'])) : HTTP_PARK_HERALDRY . '00000.jpg' ?>"
+														onerror="this.src='<?= HTTP_PARK_HERALDRY ?>00000.jpg'"
+														alt="">
+													<a href="<?= UIR ?>Park/profile/<?= $park['ParkId'] ?>"><?= htmlspecialchars($park['ParkName']) ?></a>
+												</td>
+												<td><?= htmlspecialchars(!empty($park['Title']) ? $park['Title'] : '') ?></td>
+												<td class="kn-col-numeric kn-avgwk-row"><i class="fas fa-spinner fa-spin kn-stat-spinner"></i></td>
+												<td class="kn-col-numeric kn-avgmo-row"><i class="fas fa-spinner fa-spin kn-stat-spinner"></i></td>
+												<td class="kn-col-numeric kn-tp-row">—</td>
+												<td class="kn-col-numeric kn-tm-row">—</td>
+											</tr>
+										<?php endforeach; ?>
+									</tbody>
+									<tfoot>
+										<tr>
+											<td colspan="2"><?= htmlspecialchars($prinz['Name']) ?> Total</td>
+											<td class="kn-col-numeric" id="kn-prinz-<?= $prId ?>-avgwk">—</td>
+											<td class="kn-col-numeric" id="kn-prinz-<?= $prId ?>-avgmo">—</td>
+											<td class="kn-col-numeric" id="kn-prinz-<?= $prId ?>-tp" title="Sum across parks (players may be counted in multiple parks)">—</td>
+											<td class="kn-col-numeric" id="kn-prinz-<?= $prId ?>-tm">—</td>
+										</tr>
+									</tfoot>
+								</table>
+							</div>
+						<?php endforeach; ?>
+					</div>
+
+				<?php endif; ?>
+
+				<?php if (count($parkList) === 0 && count($prinzParks) === 0): ?>
 					<div class="kn-empty">No parks found</div>
 				<?php endif; ?>
 			</div>
@@ -587,24 +712,6 @@
 					<div class="kn-empty">No park location data available</div>
 				<?php endif; ?>
 			</div>
-
-			<!-- Principalities Tab (only rendered if applicable) -->
-			<?php if (!$IsPrinz && count($principalityList) > 0): ?>
-				<div class="kn-tab-panel" id="kn-tab-principalities" style="display:none">
-					<?php foreach ($principalityList as $prinz): ?>
-						<div class="kn-prinz-row">
-							<img class="kn-prinz-heraldry"
-								loading="lazy"
-								src="<?= HTTP_KINGDOM_HERALDRY . Common::resolve_image_ext(DIR_KINGDOM_HERALDRY, sprintf("%04d", $prinz['KingdomId'])) ?>"
-								onerror="this.src='<?= HTTP_KINGDOM_HERALDRY ?>0000.jpg'"
-								alt="">
-							<div class="kn-prinz-name">
-								<a href="<?= UIR ?>Kingdom/profile/<?= $prinz['KingdomId'] ?>"><?= htmlspecialchars($prinz['Name']) ?></a>
-							</div>
-						</div>
-					<?php endforeach; ?>
-				</div>
-			<?php endif; ?>
 
 			<!-- Reports Tab -->
 			<div class="kn-tab-panel" id="kn-tab-reports" style="display:none">
@@ -938,6 +1045,7 @@ var KnConfig = {
 	parkEditLookup:   <?= json_encode($CanManageKingdom ? array_values($park_edit_lookup ?? []) : [], JSON_HEX_TAG | JSON_HEX_AMP) ?>,
 	officerList:      <?= json_encode($CanManageKingdom ? array_map(function($o) { return ['OfficerRole' => $o['OfficerRole'], 'MundaneId' => (int)$o['MundaneId'], 'Persona' => $o['Persona']]; }, $officerList) : [], JSON_HEX_TAG | JSON_HEX_AMP) ?>,
 	mapLocations:     <?= json_encode(array_values($knMapLocations ?? []), JSON_HEX_TAG | JSON_HEX_AMP) ?>,
+	principalityIds:  <?= json_encode(array_map(function($p){ return (int)$p['KingdomId']; }, $prinzParks)) ?>,
 	preloadOfficers:  <?= json_encode($PreloadOfficers ?? [], JSON_HEX_TAG | JSON_HEX_AMP) ?>,
 	awardOptHTML:   <?= json_encode('<option value="">Select award...</option>' . ($AwardOptions ?? ''), JSON_HEX_TAG | JSON_HEX_AMP) ?>,
 	officerOptHTML: <?= json_encode('<option value="">Select title...</option>' . ($OfficerOptions ?? ''), JSON_HEX_TAG | JSON_HEX_AMP) ?>,
@@ -2027,63 +2135,98 @@ html[data-theme="dark"] .kn-btn-danger { background: #fc8181; color: #1a202c; bo
 	if (!kingdomId) return;
 
 	// ---- Park averages + player counts (AJAX) ----
-	fetch('<?= UIR ?>Kingdom/park_averages_json/' + kingdomId)
-		.then(function(r) { return r.json(); })
-		.then(function(data) {
-			var totalAtt = 0, totalTp = 0, totalTm = 0;
-			var wkCount = (data._kingdom && data._kingdom.wk_count) ? data._kingdom.wk_count : 26;
-			var kingdomAtt = (data._kingdom && data._kingdom.att) ? data._kingdom.att : null;
-			function knTrend(cur, prev, decimals) {
-				if (prev === undefined) return '';
-				if (cur > prev) return ' <span class="kn-trend kn-trend-up" title="Up from ' + prev.toFixed(decimals) + ' (prev period)">&#9650;</span>';
-				if (cur < prev) return ' <span class="kn-trend kn-trend-dn" title="Down from ' + prev.toFixed(decimals) + ' (prev period)">&#9660;</span>';
-				return '';
+	// Fill tile/row averages for a given park_averages_json payload.
+	// opts = { scope: Element|null (default document),
+	//          footer: {avgwk, avgmo, tp, tm} element-ids | null,
+	//          statCards: bool }
+	function knFillAverages(data, opts) {
+		opts = opts || {};
+		var scope = opts.scope || document;
+		var totalAtt = 0, totalTp = 0, totalTm = 0;
+		var wkCount = (data._kingdom && data._kingdom.wk_count) ? data._kingdom.wk_count : 26;
+		var kingdomAtt = (data._kingdom && data._kingdom.att) ? data._kingdom.att : null;
+		function knTrend(cur, prev, decimals) {
+			if (prev === undefined) return '';
+			if (cur > prev) return ' <span class="kn-trend kn-trend-up" title="Up from ' + prev.toFixed(decimals) + ' (prev period)">&#9650;</span>';
+			if (cur < prev) return ' <span class="kn-trend kn-trend-dn" title="Down from ' + prev.toFixed(decimals) + ' (prev period)">&#9660;</span>';
+			return '';
+		}
+		for (var parkId in data) {
+			if (parkId === '_kingdom') continue;
+			var att = data[parkId].att || 0, mo = data[parkId].mo || 0;
+			var tp  = data[parkId].tp  || 0, tm = data[parkId].tm  || 0;
+			var prevAtt = data[parkId].prev_att, prevMo = data[parkId].prev_mo;
+			totalAtt += att; totalTp += tp; totalTm += tm;
+			// Tile view
+			var tile = scope.querySelector('.kn-park-tile[data-park-id="' + parkId + '"]');
+			if (tile) {
+				var wkEl = tile.querySelector('.kn-avgwk-tile');
+				var moEl = tile.querySelector('.kn-avgmo-tile');
+				if (wkEl) wkEl.innerHTML = (att / wkCount).toFixed(1) + knTrend(att / wkCount, prevAtt !== undefined ? prevAtt / wkCount : undefined, 1);
+				if (moEl) moEl.innerHTML = mo.toFixed(1) + knTrend(mo, prevMo !== undefined ? prevMo : undefined, 1);
 			}
-			for (var parkId in data) {
-				if (parkId === '_kingdom') continue;
-				var att = data[parkId].att || 0, mo = data[parkId].mo || 0;
-				var tp  = data[parkId].tp  || 0, tm = data[parkId].tm  || 0;
-				var prevAtt = data[parkId].prev_att, prevMo = data[parkId].prev_mo;
-				totalAtt += att; totalTp += tp; totalTm += tm;
-				// Tile view
-				var tile = document.querySelector('.kn-park-tile[data-park-id="' + parkId + '"]');
-				if (tile) {
-					var wkEl = tile.querySelector('.kn-avgwk-tile');
-					var moEl = tile.querySelector('.kn-avgmo-tile');
-					if (wkEl) wkEl.innerHTML = (att / wkCount).toFixed(1) + knTrend(att / wkCount, prevAtt !== undefined ? prevAtt / wkCount : undefined, 1);
-					if (moEl) moEl.innerHTML = mo.toFixed(1) + knTrend(mo, prevMo !== undefined ? prevMo : undefined, 1);
-				}
-				// List view row
-				var row = document.querySelector('tr[data-park-id="' + parkId + '"]');
-				if (row) {
-					var wkTd = row.querySelector('.kn-avgwk-row');
-					var moTd = row.querySelector('.kn-avgmo-row');
-					var tpTd = row.querySelector('.kn-tp-row');
-					var tmTd = row.querySelector('.kn-tm-row');
-					if (wkTd) { wkTd.innerHTML = (att / wkCount).toFixed(2) + knTrend(att / wkCount, prevAtt !== undefined ? prevAtt / wkCount : undefined, 2); wkTd.setAttribute('data-sortval', att / wkCount); }
-					if (moTd) { moTd.innerHTML = mo.toFixed(1) + knTrend(mo, prevMo !== undefined ? prevMo : undefined, 1); moTd.setAttribute('data-sortval', mo); }
-					if (tpTd) { tpTd.textContent = tp;  tpTd.setAttribute('data-sortval', tp); }
-					if (tmTd) { tmTd.textContent = tm;  tmTd.setAttribute('data-sortval', tm); }
-				}
+			// List view row
+			var row = scope.querySelector('tr[data-park-id="' + parkId + '"]');
+			if (row) {
+				var wkTd = row.querySelector('.kn-avgwk-row');
+				var moTd = row.querySelector('.kn-avgmo-row');
+				var tpTd = row.querySelector('.kn-tp-row');
+				var tmTd = row.querySelector('.kn-tm-row');
+				if (wkTd) { wkTd.innerHTML = (att / wkCount).toFixed(2) + knTrend(att / wkCount, prevAtt !== undefined ? prevAtt / wkCount : undefined, 2); wkTd.setAttribute('data-sortval', att / wkCount); }
+				if (moTd) { moTd.innerHTML = mo.toFixed(1) + knTrend(mo, prevMo !== undefined ? prevMo : undefined, 1); moTd.setAttribute('data-sortval', mo); }
+				if (tpTd) { tpTd.textContent = tp;  tpTd.setAttribute('data-sortval', tp); }
+				if (tmTd) { tmTd.textContent = tm;  tmTd.setAttribute('data-sortval', tm); }
 			}
-			// Stat cards — use kingdom-level deduped values (avoids double-counting multi-park players)
-			var wkBase = kingdomAtt !== null ? kingdomAtt : totalAtt;
-			var moBase = (data._kingdom && data._kingdom.mo) ? data._kingdom.mo : 0;
+		}
+		// Stat cards — use kingdom-level deduped values (avoids double-counting multi-park players)
+		var wkBase = kingdomAtt !== null ? kingdomAtt : totalAtt;
+		var moBase = (data._kingdom && data._kingdom.mo) ? data._kingdom.mo : 0;
+		if (opts.statCards) {
 			var statWk = document.getElementById('kn-stat-avgwk');
 			var statMo = document.getElementById('kn-stat-avgmo');
 			if (statWk) statWk.textContent = (wkBase / wkCount).toFixed(1);
 			if (statMo) statMo.textContent = moBase.toFixed(1);
-			// Footer totals
-			var footWk = document.getElementById('kn-total-avgwk');
-			var footMo = document.getElementById('kn-total-avgmo');
-			var footTp = document.getElementById('kn-total-tp');
-			var footTm = document.getElementById('kn-total-tm');
+		}
+		// Footer totals
+		if (opts.footer) {
+			var footWk = document.getElementById(opts.footer.avgwk);
+			var footMo = document.getElementById(opts.footer.avgmo);
+			var footTp = document.getElementById(opts.footer.tp);
+			var footTm = document.getElementById(opts.footer.tm);
 			if (footWk) footWk.textContent = (wkBase / wkCount).toFixed(2);
 			if (footMo) footMo.textContent = moBase.toFixed(1);
 			if (footTp) footTp.textContent = totalTp;
 			if (footTm) footTm.textContent = totalTm;
+		}
+	}
+
+	// Kingdom's own parks (stat cards + kingdom footer)
+	fetch('<?= UIR ?>Kingdom/park_averages_json/' + kingdomId)
+		.then(function(r) { return r.json(); })
+		.then(function(data) {
+			knFillAverages(data, {
+				scope: document,
+				footer: { avgwk: 'kn-total-avgwk', avgmo: 'kn-total-avgmo', tp: 'kn-total-tp', tm: 'kn-total-tm' },
+				statCards: true
+			});
 		})
 		.catch(function(err) { console.error('Kingdom park_averages_json failed:', err); });
+
+	// Principality parks — one fetch per principality id; park ids are globally unique so
+	// document-scoped fills land on the right tiles/rows, and per-section footer ids keep totals separate.
+	var knPrinzIds = (KnConfig.principalityIds || []);
+	knPrinzIds.forEach(function(prId) {
+		fetch('<?= UIR ?>Kingdom/park_averages_json/' + prId)
+			.then(function(r) { return r.json(); })
+			.then(function(data) {
+				knFillAverages(data, {
+					scope: document,
+					footer: { avgwk: 'kn-prinz-' + prId + '-avgwk', avgmo: 'kn-prinz-' + prId + '-avgmo', tp: 'kn-prinz-' + prId + '-tp', tm: 'kn-prinz-' + prId + '-tm' },
+					statCards: false
+				});
+			})
+			.catch(function(err) { console.error('Principality park_averages_json failed (' + prId + '):', err); });
+	});
 
 	// ---- Players tab: lazy-load on first click ----
 	function knHtmlEsc(s) {

--- a/orkui/template/revised-frontend/Kingdomnew_index.tpl
+++ b/orkui/template/revised-frontend/Kingdomnew_index.tpl
@@ -292,17 +292,18 @@
 				</li>
 				<li data-kntab="players" id="kn-tab-btn-players">
 					<i class="fas fa-users"></i><span class="kn-tab-label"> Players</span>
-					<span class="kn-tab-count" id="kn-players-tab-count"></span>
+					<?php $_pcN = (int)($PlayerCount ?? 0); ?>
+					<span class="kn-tab-count" id="kn-players-tab-count"><?= $_pcN > 0 ? '(' . $_pcN . ')' : '' ?></span>
 				</li>
 				<li data-kntab="reports">
 					<i class="fas fa-chart-bar"></i><span class="kn-tab-label"> Reports</span>
 				</li>
-				<?php if ($ShowRecsTab ?? false): ?>
+				<?php if ($ShowRecsTab ?? false):
+					$_recsN = (int)($AwardRecommendationsCount ?? 0);
+				?>
 				<li data-kntab="recommendations">
 					<i class="fas fa-star"></i><span class="kn-tab-label"> Recommendations</span>
-					<?php if (!empty($AwardRecommendations)): ?>
-					<span class="kn-tab-count">(<?= count($AwardRecommendations) ?>)</span>
-					<?php endif; ?>
+					<span class="kn-tab-count" id="kn-tab-count-recs"<?= $_recsN > 0 ? '' : ' style="display:none"' ?>><?= $_recsN > 0 ? '(' . $_recsN . ')' : '' ?></span>
 				</li>
 				<?php endif; ?>
 				<?php if ($CanManageKingdom ?? false): ?>
@@ -838,155 +839,16 @@
 		</div>
 		<?php endif; ?>
 
-		<!-- Recommendations Tab -->
+		<!-- Recommendations Tab — body is lazy-loaded via Kingdom::recommendations_panel()
+		     on first tab activation. Rendering the full list inline (1k-4k <tr> rows on a
+		     busy kingdom) was blocking DOMContentLoaded for 1+ seconds. -->
 		<?php if ($ShowRecsTab ?? false): ?>
 		<div class="kn-tab-panel" id="kn-tab-recommendations" style="display:none">
-			<?php if ($IsLoggedIn): ?>
-			<div class="pk-tab-toolbar">
-				<button class="kn-btn kn-btn-secondary" onclick="knOpenRecModal()">
-					<i class="fas fa-star"></i> Recommend an Award
-				</button>
-			</div>
-			<?php endif; ?>
-			<?php if (empty($AwardRecommendations)): ?>
-			<div class="pk-recs-empty">There are no open award recommendations for <?= htmlspecialchars($kingdom_name) ?>.</div>
-			<?php else: ?>
-			<?php if ($CanManageKingdom ?? false): ?>
-			<div class="kn-rec-filter-bar">
-				<button class="kn-rec-filter-btn kn-rec-filter-active" data-filter="open">Open Recs</button>
-				<button class="kn-rec-filter-btn" data-filter="below">Below Recommended</button>
-				<button class="kn-rec-filter-btn" data-filter="nonladder">Non-Ladder</button>
-				<button class="kn-rec-filter-btn" data-filter="already">At or Above Recommended</button>
-				<button class="kn-rec-filter-btn" data-filter="all">All</button>
-				<span class="kn-rec-filter-info">
-					<button class="kn-rec-filter-info-btn" type="button" aria-label="Filter help"><i class="fas fa-question-circle"></i></button>
-					<div class="kn-rec-filter-popover">
-						<h4>About These Filters</h4>
-						<dl>
-							<dt>Open Recs <small style="font-weight:400;color:#718096">(default)</small></dt>
-							<dd>All pending recommendations &mdash; both rank-based and flat awards. Hides recs that have already been fulfilled.</dd>
-							<dt>Below Recommended</dt>
-							<dd>Players who haven&rsquo;t yet reached the recommended rank. The core action list &mdash; Grant these.</dd>
-							<dt>Non-Ladder</dt>
-							<dd>Includes titles such as Master, Noble, or Knight, custom awards, and other non-ranked options. Grant or Delete as appropriate.</dd>
-							<dt>At or Above Recommended</dt>
-							<dd>Players who already hold this award at or above the recommended rank. The rec has been fulfilled &mdash; Delete these to keep the list tidy.</dd>
-							<dt>All</dt>
-							<dd>Every recommendation regardless of status. Use for a full audit.</dd>
-						</dl>
-					</div>
-				</span>
-				<span class="kn-rec-export-btns">
-					<button class="kn-rec-export-btn" type="button" onclick="knRecPrint()"><i class="fas fa-print"></i> Print</button>
-					<button class="kn-rec-export-btn" type="button" onclick="knRecCsv()"><i class="fas fa-download"></i> CSV</button>
-				</span>
-			</div>
-			<?php endif; ?>
-				<div class="pk-recs-table-wrap">
-				<table id="kn-rec-table" class="pk-recs-table display">
-					<thead>
-						<tr>
-							<th>Player</th>
-							<th>Award</th>
-							<th>Rank</th>
-							<th data-short="Rec. By">Recommended By</th>
-							<th>Date</th>
-							<th>Notes</th>
-							<?php if (!empty($IsLoggedIn)): ?><th style="width:1%;white-space:nowrap"></th><?php endif; ?>
-						</tr>
-					</thead>
-					<tbody id="kn-recs-tbody">
-					<?php foreach ($AwardRecommendations as $rec): ?>
-					<tr class="pk-rec-row"
-						data-rec-id="<?= (int)$rec['RecommendationsId'] ?>"
-						data-filter="<?= !empty($rec['AlreadyHas']) ? 'already' : ((int)$rec['Rank'] > 0 ? 'below' : 'nonladder') ?>">
-						<td><a href="<?= UIR ?>Player/profile/<?= (int)$rec['MundaneId'] ?>"><?= htmlspecialchars($rec['Persona']) ?></a></td>
-						<td><?= htmlspecialchars($rec['AwardName']) ?></td>
-						<td style="white-space:nowrap">
-							<?= (int)$rec['Rank'] > 0 ? (int)$rec['Rank'] : '&mdash;' ?>
-							<?php if (!empty($rec['AlreadyHas'])): ?>
-							<span class="pk-rec-has-tip"
-								title="<?= (int)$rec['Rank'] > 0 ? 'Player is currently at rank ' . (int)$rec['CurrentRank'] . ' as of ' . htmlspecialchars($rec['CurrentRankDate'] ?? '') : 'Player already has this award (granted ' . htmlspecialchars($rec['CurrentRankDate'] ?? 'unknown date') . ')' ?>">
-								<i class="fas fa-info-circle"></i>
-							</span>
-							<?php endif; ?>
-						</td>
-						<td><?php if (!empty($rec['RecommendedById'])): ?><a href="<?= UIR ?>Player/profile/<?= (int)$rec['RecommendedById'] ?>"><?= htmlspecialchars($rec['RecommendedByName']) ?></a><?php else: ?>&mdash;<?php endif; ?></td>
-						<td><?= htmlspecialchars($rec['DateRecommended']) ?></td>
-						<td class="pk-rec-notes"><?php if (!empty($rec['Reason'])): ?><span class="pk-rec-notes-short"><?= htmlspecialchars(mb_substr($rec['Reason'], 0, 50)) ?><?php if (mb_strlen($rec['Reason']) > 50): ?><span class="pk-rec-notes-ellipsis">&hellip; <button class="pk-rec-expand-btn" type="button">[&hellip;]</button></span><span class="pk-rec-notes-full" style="display:none"><?= htmlspecialchars(mb_substr($rec['Reason'], 50)) ?> <button class="pk-rec-expand-btn pk-rec-collapse-btn" type="button">[&laquo;]</button></span><?php endif; ?></span><?php else: ?>&mdash;<?php endif; ?>
-							<?php if (!empty($rec['ViewerCanEditReason'])): ?>
-							<button class="rs-edit-reason-btn" data-rec="<?= (int)$rec['RecommendationsId'] ?>" data-reason="<?= htmlspecialchars($rec['Reason'] ?? '', ENT_QUOTES) ?>" data-award="<?= htmlspecialchars($rec['AwardName'] ?? '', ENT_QUOTES) ?>" data-rstip="Edit your reason"><i class="fas fa-pen"></i></button>
-							<?php endif; ?>
-							<?php if (!empty($rec['Seconds']) && is_array($rec['Seconds'])): ?>
-							<div class="rs-seconds">
-								<?php foreach ($rec['Seconds'] as $sec): ?>
-								<div class="rs-second"><i class="fas fa-thumbs-up" style="color:#48bb78;font-size:10px"></i><a class="rs-supporter" href="<?= UIR ?>Player/profile/<?= (int)$sec['SupporterMundaneId'] ?>"><?= htmlspecialchars($sec['SupporterName'] ?? '') ?></a><?php if (!empty($sec['Notes'])): $_sn = $sec['Notes']; ?><span class="rs-notes">&mdash; "<?php if (mb_strlen($_sn) > 50): ?><span class="pk-rec-notes-short"><?= htmlspecialchars(mb_substr($_sn, 0, 50)) ?><span class="pk-rec-notes-ellipsis">&hellip; <button class="pk-rec-expand-btn" type="button">[&hellip;]</button></span><span class="pk-rec-notes-full" style="display:none"><?= htmlspecialchars(mb_substr($_sn, 50)) ?> <button class="pk-rec-expand-btn pk-rec-collapse-btn" type="button">[&laquo;]</button></span></span><?php else: ?><?= htmlspecialchars($_sn) ?><?php endif; ?>"</span><?php else: ?><span class="rs-notes-empty">&mdash; (no comment)</span><?php endif; ?><?php $_canWithdrawSec = !empty($sec['IsMine']) || ($CanManageKingdom ?? false); if (!empty($sec['IsMine']) || $_canWithdrawSec): ?> <span class="rs-second-actions"><?php if (!empty($sec['IsMine'])): ?><button class="rs-second-edit" data-sid="<?= (int)$sec['RecommendationSecondsId'] ?>" data-notes="<?= htmlspecialchars($sec['Notes'] ?? '', ENT_QUOTES) ?>" data-rstip="Edit your notes"><i class="fas fa-pen"></i></button><?php endif; ?><?php if ($_canWithdrawSec): ?><button class="rs-second-withdraw" data-sid="<?= (int)$sec['RecommendationSecondsId'] ?>" data-supporter="<?= htmlspecialchars($sec['SupporterName'] ?? '', ENT_QUOTES) ?>" data-rstip="<?= !empty($sec['IsMine']) ? 'Withdraw your second' : 'Remove this second' ?>"><i class="fas fa-times"></i></button><?php endif; ?></span><?php endif; ?></div>
-								<?php endforeach; ?>
-							</div>
-							<?php endif; ?>
-						</td>
-						<?php if (!empty($IsLoggedIn)): ?>
-						<td class="pk-rec-actions rs-tip-right" style="white-space:nowrap;text-align:right;width:1%">
-							<?php if (!empty($rec['SecondsCount'])): $_sc = (int)$rec['SecondsCount']; ?>
-							<span class="rs-seconds-badge" data-rstip="<?= $_sc ?> supporting <?= $_sc === 1 ? 'second' : 'seconds' ?>"><i class="fas fa-thumbs-up"></i><?= $_sc ?></span>
-							<?php endif; ?>
-							<?php if (!empty($rec['ViewerCanSecond'])): ?>
-							<button class="rs-action-btn" data-rec="<?= (int)$rec['RecommendationsId'] ?>" data-award="<?= htmlspecialchars($rec['AwardName'] ?? '', ENT_QUOTES) ?>" data-recipient="<?= htmlspecialchars($rec['Persona'] ?? '', ENT_QUOTES) ?>" data-rstip="Second this recommendation and add your feedback."><i class="fas fa-plus"></i></button>
-							<?php endif; ?>
-							<?php if ($CanManageKingdom ?? false): ?>
-							<button class="pk-btn pk-btn-primary pk-rec-grant-btn"
-								data-rec="<?= htmlspecialchars(json_encode(['RecommendationsId'=>(int)$rec['RecommendationsId'],'MundaneId'=>(int)$rec['MundaneId'],'Persona'=>$rec['Persona'],'KingdomAwardId'=>(int)$rec['KingdomAwardId'],'Rank'=>(int)$rec['Rank'],'Reason'=>$rec['Reason']??''])) ?>">
-								<i class="fas fa-medal"></i> Grant
-							</button>
-							<button class="pk-rec-dismiss-btn"
-								data-rec-id="<?= (int)$rec['RecommendationsId'] ?>">
-								<i class="fas fa-times"></i> Delete
-							</button>
-							<?php endif; ?>
-						</td>
-						<?php endif; ?>
-					</tr>
-					<?php endforeach; ?>
-					</tbody>
-				</table>
-			</div>
-			<?php endif; ?>
-			<?php if ($CanManageKingdom ?? false): ?>
-			<div class="pk-deleted-recs" id="kn-deleted-recs" data-loaded="0">
-				<button type="button" class="pk-deleted-recs-toggle" id="kn-deleted-recs-toggle" aria-expanded="false">
-					<span class="pk-deleted-recs-caret">&#9654;</span>
-					<span class="pk-deleted-recs-toggle-label">Show Deleted Recommendations</span>
-					<span class="pk-deleted-recs-count" id="kn-deleted-recs-count" style="display:none">0</span>
-				</button>
-				<div class="pk-deleted-recs-body" id="kn-deleted-recs-body" style="display:none">
-					<div class="pk-deleted-recs-loading" id="kn-deleted-recs-loading">Loading&hellip;</div>
-					<div class="pk-deleted-recs-empty" id="kn-deleted-recs-empty" style="display:none">No deleted recommendations.</div>
-					<div class="pk-deleted-recs-search-wrap" style="display:none">
-						<i class="fas fa-search"></i>
-						<input type="text" class="pk-deleted-recs-search" placeholder="Search player, award, notes, or actor&hellip;" autocomplete="off">
-					</div>
-					<div class="pk-deleted-recs-no-match" style="display:none">No deleted recommendations match your search.</div>
-					<div class="pk-deleted-recs-table-wrap" id="kn-deleted-recs-table-wrap" style="display:none">
-						<table class="pk-deleted-recs-table">
-							<thead>
-								<tr>
-									<th>Player</th>
-									<th>Award</th>
-									<th>Rank</th>
-									<th>Notes</th>
-									<th>Date Rec.</th>
-									<th>Recommended By</th>
-									<th>Deleted At</th>
-									<th>Deleted By</th>
-									<th></th>
-								</tr>
-							</thead>
-							<tbody id="kn-deleted-recs-tbody"></tbody>
-						</table>
-					</div>
+			<div id="kn-recs-lazy" data-loaded="0" data-kid="<?= (int)$kingdom_id ?>">
+				<div class="pk-recs-loading" style="padding:2em 0;text-align:center;color:#a0aec0">
+					<i class="fas fa-spinner fa-spin"></i> Loading recommendations&hellip;
 				</div>
 			</div>
-			<?php endif; ?>
 		</div>
 		<?php endif; ?>
 
@@ -2587,20 +2449,41 @@ $.fn.dataTable.ext.search.push(function(settings, data, dataIndex) {
 	if (filter === 'open') return rowFilter !== 'already';
 	return rowFilter === filter;
 });
-$(function() {
-	if ($('#kn-rec-table').length) {
-		window.knRecDT = $('#kn-rec-table').DataTable({
-			order: [[4, 'desc']],
-			columnDefs: [
-				{ targets: [4], type: 'date' },
-				<?php if ($CanManageKingdom ?? false): ?>
-				{ targets: [-1], orderable: false, searchable: false },
-				<?php endif; ?>
-			],
-			pageLength: 25
+// Initialise the rec-table DataTable + filter bar. Idempotent so the lazy-loader
+// can call it again after injecting the rec-tab HTML on first tab activation.
+window.knInitRecsTab = function() {
+	var $tbl = $('#kn-rec-table');
+	if (!$tbl.length) return;
+	if ($.fn.dataTable.isDataTable('#kn-rec-table')) {
+		$tbl.DataTable().destroy();
+	}
+	window.knRecDT = $tbl.DataTable({
+		order: [[4, 'desc']],
+		columnDefs: [
+			{ targets: [4], type: 'date' },
+			<?php if ($CanManageKingdom ?? false): ?>
+			{ targets: [-1], orderable: false, searchable: false },
+			<?php endif; ?>
+		],
+		pageLength: 25
+	});
+	// Filter bar: re-bind in case the HTML is freshly injected.
+	var bar = document.querySelector('#kn-tab-recommendations .kn-rec-filter-bar');
+	if (bar && !bar.__knFilterBound) {
+		bar.__knFilterBound = true;
+		bar.addEventListener('click', function(e) {
+			var btn = e.target.closest('.kn-rec-filter-btn');
+			if (!btn) return;
+			var filter = btn.dataset.filter;
+			bar.querySelectorAll('.kn-rec-filter-btn').forEach(function(b) {
+				b.classList.toggle('kn-rec-filter-active', b.dataset.filter === filter);
+			});
+			window.knRecActiveFilter = filter;
+			if (window.knRecDT) window.knRecDT.draw();
 		});
 	}
-});
+};
+$(function() { window.knInitRecsTab(); });
 window.knRecPrint = function() { if (window.knRecDT) window.recsExportPrint(window.knRecDT, 'Award Recommendations \u2014 <?= htmlspecialchars(addslashes($kingdom_name)) ?>'); };
 window.knRecCsv   = function() { if (window.knRecDT) window.recsExportCsv(window.knRecDT, 'recs-<?= preg_replace('/[^a-z0-9]+/i', '-', $kingdom_name) ?>.csv'); };
 initEmailSpellCheck('kn-addplayer-email', 'kn-addplayer-email-suggestion');

--- a/orkui/template/revised-frontend/Kingdomnew_index.tpl
+++ b/orkui/template/revised-frontend/Kingdomnew_index.tpl
@@ -1449,6 +1449,15 @@ var KnConfig = {
 				</button>
 				<div class="kn-admin-panel-body" id="kn-admin-body-awards" style="display:none">
 					<div id="kn-admin-awards-feedback" class="kn-admin-feedback" style="display:none"></div>
+					<div class="kn-admin-award-search-wrap">
+						<i class="fas fa-search kn-admin-award-search-icon"></i>
+						<input type="text" id="kn-admin-award-search" class="kn-admin-award-search-input"
+							placeholder="Filter awards by name or class&hellip;" autocomplete="off">
+						<button type="button" id="kn-admin-award-search-clear" class="kn-admin-award-search-clear" title="Clear" style="display:none">&times;</button>
+					</div>
+					<div class="kn-admin-award-search-empty" id="kn-admin-award-search-empty" style="display:none">
+						No awards match this filter.
+					</div>
 					<div class="kn-admin-table-wrap"><table class="kn-admin-table kn-admin-awards-table">
 						<thead>
 							<tr>
@@ -2458,9 +2467,10 @@ window.knInitRecsTab = function() {
 		$tbl.DataTable().destroy();
 	}
 	window.knRecDT = $tbl.DataTable({
-		order: [[4, 'desc']],
+		// Columns: 0 Player · 1 Park · 2 Award · 3 Rank · 4 Rec By · 5 Date · 6 Notes · (-1 actions)
+		order: [[5, 'desc']],
 		columnDefs: [
-			{ targets: [4], type: 'date' },
+			{ targets: [5], type: 'date' },
 			<?php if ($CanManageKingdom ?? false): ?>
 			{ targets: [-1], orderable: false, searchable: false },
 			<?php endif; ?>

--- a/orkui/template/revised-frontend/Kingdomnew_index.tpl
+++ b/orkui/template/revised-frontend/Kingdomnew_index.tpl
@@ -165,7 +165,7 @@
 <div class="kn-stats-row">
 	<div class="kn-stat-card kn-stat-card-link" onclick="knActivateTab('parks')">
 		<div class="kn-stat-icon"><i class="fas fa-map-marker-alt"></i></div>
-		<div class="kn-stat-number"><?= count($parkList) ?></div>
+		<div class="kn-stat-number"><?= $StatsParkCount ?? count($parkList) ?></div>
 		<div class="kn-stat-label">Parks</div>
 	</div>
 	<div class="kn-stat-card kn-stat-card-link" onclick="knActivateTab('events')">
@@ -281,7 +281,7 @@
 			<ul class="kn-tab-nav">
 				<li class="kn-tab-active" data-kntab="parks">
 					<i class="fas fa-map-marker-alt"></i><span class="kn-tab-label"> Parks</span>
-					<span class="kn-tab-count">(<?= count($parkList) ?>)</span>
+					<span class="kn-tab-count">(<?= $StatsParkCount ?? count($parkList) ?>)</span>
 				</li>
 				<li data-kntab="events">
 					<i class="fas fa-calendar-alt"></i><span class="kn-tab-label"> Events</span>

--- a/orkui/template/revised-frontend/Kingdomnew_recommendations_panel.tpl
+++ b/orkui/template/revised-frontend/Kingdomnew_recommendations_panel.tpl
@@ -52,6 +52,7 @@
 					<thead>
 						<tr>
 							<th>Player</th>
+							<th>Park</th>
 							<th>Award</th>
 							<th>Rank</th>
 							<th data-short="Rec. By">Recommended By</th>
@@ -66,6 +67,7 @@
 						data-rec-id="<?= (int)$rec['RecommendationsId'] ?>"
 						data-filter="<?= !empty($rec['AlreadyHas']) ? 'already' : ((int)$rec['Rank'] > 0 ? 'below' : 'nonladder') ?>">
 						<td><a href="<?= UIR ?>Player/profile/<?= (int)$rec['MundaneId'] ?>"><?= htmlspecialchars($rec['Persona']) ?></a></td>
+						<td><?php if (!empty($rec['ParkId'])): ?><a href="<?= UIR ?>Park/profile/<?= (int)$rec['ParkId'] ?>"><?= htmlspecialchars($rec['ParkName']) ?></a><?php else: ?>&mdash;<?php endif; ?></td>
 						<td><?= htmlspecialchars($rec['AwardName']) ?></td>
 						<td style="white-space:nowrap">
 							<?= (int)$rec['Rank'] > 0 ? (int)$rec['Rank'] : '&mdash;' ?>

--- a/orkui/template/revised-frontend/Kingdomnew_recommendations_panel.tpl
+++ b/orkui/template/revised-frontend/Kingdomnew_recommendations_panel.tpl
@@ -1,0 +1,154 @@
+<?php /*
+ * Lazy-loaded inner body for the "Recommendations" tab on the Kingdom profile.
+ * Rendered by Controller_Kingdom::recommendations_panel($kingdom_id) on first
+ * tab activation — kept out of the initial profile() page load because rendering
+ * thousands of <tr> rows inline blew up the browser's DOMContentLoaded handler.
+ * Expects $AwardRecommendations, $IsLoggedIn, $CanManageKingdom, $kingdom_name,
+ * $kingdom_id to be in scope.
+ */ ?>
+			<?php if ($IsLoggedIn): ?>
+			<div class="pk-tab-toolbar">
+				<button class="kn-btn kn-btn-secondary" onclick="knOpenRecModal()">
+					<i class="fas fa-star"></i> Recommend an Award
+				</button>
+			</div>
+			<?php endif; ?>
+			<?php if (empty($AwardRecommendations)): ?>
+			<div class="pk-recs-empty">There are no open award recommendations for <?= htmlspecialchars($kingdom_name) ?>.</div>
+			<?php else: ?>
+			<?php if ($CanManageKingdom ?? false): ?>
+			<div class="kn-rec-filter-bar">
+				<button class="kn-rec-filter-btn kn-rec-filter-active" data-filter="open">Open Recs</button>
+				<button class="kn-rec-filter-btn" data-filter="below">Below Recommended</button>
+				<button class="kn-rec-filter-btn" data-filter="nonladder">Non-Ladder</button>
+				<button class="kn-rec-filter-btn" data-filter="already">At or Above Recommended</button>
+				<button class="kn-rec-filter-btn" data-filter="all">All</button>
+				<span class="kn-rec-filter-info">
+					<button class="kn-rec-filter-info-btn" type="button" aria-label="Filter help"><i class="fas fa-question-circle"></i></button>
+					<div class="kn-rec-filter-popover">
+						<h4>About These Filters</h4>
+						<dl>
+							<dt>Open Recs <small style="font-weight:400;color:#718096">(default)</small></dt>
+							<dd>All pending recommendations &mdash; both rank-based and flat awards. Hides recs that have already been fulfilled.</dd>
+							<dt>Below Recommended</dt>
+							<dd>Players who haven&rsquo;t yet reached the recommended rank. The core action list &mdash; Grant these.</dd>
+							<dt>Non-Ladder</dt>
+							<dd>Includes titles such as Master, Noble, or Knight, custom awards, and other non-ranked options. Grant or Delete as appropriate.</dd>
+							<dt>At or Above Recommended</dt>
+							<dd>Players who already hold this award at or above the recommended rank. The rec has been fulfilled &mdash; Delete these to keep the list tidy.</dd>
+							<dt>All</dt>
+							<dd>Every recommendation regardless of status. Use for a full audit.</dd>
+						</dl>
+					</div>
+				</span>
+				<span class="kn-rec-export-btns">
+					<button class="kn-rec-export-btn" type="button" onclick="knRecPrint()"><i class="fas fa-print"></i> Print</button>
+					<button class="kn-rec-export-btn" type="button" onclick="knRecCsv()"><i class="fas fa-download"></i> CSV</button>
+				</span>
+			</div>
+			<?php endif; ?>
+				<div class="pk-recs-table-wrap">
+				<table id="kn-rec-table" class="pk-recs-table display">
+					<thead>
+						<tr>
+							<th>Player</th>
+							<th>Award</th>
+							<th>Rank</th>
+							<th data-short="Rec. By">Recommended By</th>
+							<th>Date</th>
+							<th>Notes</th>
+							<?php if (!empty($IsLoggedIn)): ?><th style="width:1%;white-space:nowrap"></th><?php endif; ?>
+						</tr>
+					</thead>
+					<tbody id="kn-recs-tbody">
+					<?php foreach ($AwardRecommendations as $rec): ?>
+					<tr class="pk-rec-row"
+						data-rec-id="<?= (int)$rec['RecommendationsId'] ?>"
+						data-filter="<?= !empty($rec['AlreadyHas']) ? 'already' : ((int)$rec['Rank'] > 0 ? 'below' : 'nonladder') ?>">
+						<td><a href="<?= UIR ?>Player/profile/<?= (int)$rec['MundaneId'] ?>"><?= htmlspecialchars($rec['Persona']) ?></a></td>
+						<td><?= htmlspecialchars($rec['AwardName']) ?></td>
+						<td style="white-space:nowrap">
+							<?= (int)$rec['Rank'] > 0 ? (int)$rec['Rank'] : '&mdash;' ?>
+							<?php if (!empty($rec['AlreadyHas'])): ?>
+							<span class="pk-rec-has-tip"
+								title="<?= (int)$rec['Rank'] > 0 ? 'Player is currently at rank ' . (int)$rec['CurrentRank'] . ' as of ' . htmlspecialchars($rec['CurrentRankDate'] ?? '') : 'Player already has this award (granted ' . htmlspecialchars($rec['CurrentRankDate'] ?? 'unknown date') . ')' ?>">
+								<i class="fas fa-info-circle"></i>
+							</span>
+							<?php endif; ?>
+						</td>
+						<td><?php if (!empty($rec['RecommendedById'])): ?><a href="<?= UIR ?>Player/profile/<?= (int)$rec['RecommendedById'] ?>"><?= htmlspecialchars($rec['RecommendedByName']) ?></a><?php else: ?>&mdash;<?php endif; ?></td>
+						<td><?= htmlspecialchars($rec['DateRecommended']) ?></td>
+						<td class="pk-rec-notes"><?php if (!empty($rec['Reason'])): ?><span class="pk-rec-notes-short"><?= htmlspecialchars(mb_substr($rec['Reason'], 0, 50)) ?><?php if (mb_strlen($rec['Reason']) > 50): ?><span class="pk-rec-notes-ellipsis">&hellip; <button class="pk-rec-expand-btn" type="button">[&hellip;]</button></span><span class="pk-rec-notes-full" style="display:none"><?= htmlspecialchars(mb_substr($rec['Reason'], 50)) ?> <button class="pk-rec-expand-btn pk-rec-collapse-btn" type="button">[&laquo;]</button></span><?php endif; ?></span><?php else: ?>&mdash;<?php endif; ?>
+							<?php if (!empty($rec['ViewerCanEditReason'])): ?>
+							<button class="rs-edit-reason-btn" data-rec="<?= (int)$rec['RecommendationsId'] ?>" data-reason="<?= htmlspecialchars($rec['Reason'] ?? '', ENT_QUOTES) ?>" data-award="<?= htmlspecialchars($rec['AwardName'] ?? '', ENT_QUOTES) ?>" data-rstip="Edit your reason"><i class="fas fa-pen"></i></button>
+							<?php endif; ?>
+							<?php if (!empty($rec['Seconds']) && is_array($rec['Seconds'])): ?>
+							<div class="rs-seconds">
+								<?php foreach ($rec['Seconds'] as $sec): ?>
+								<div class="rs-second"><i class="fas fa-thumbs-up" style="color:#48bb78;font-size:10px"></i><a class="rs-supporter" href="<?= UIR ?>Player/profile/<?= (int)$sec['SupporterMundaneId'] ?>"><?= htmlspecialchars($sec['SupporterName'] ?? '') ?></a><?php if (!empty($sec['Notes'])): $_sn = $sec['Notes']; ?><span class="rs-notes">&mdash; "<?php if (mb_strlen($_sn) > 50): ?><span class="pk-rec-notes-short"><?= htmlspecialchars(mb_substr($_sn, 0, 50)) ?><span class="pk-rec-notes-ellipsis">&hellip; <button class="pk-rec-expand-btn" type="button">[&hellip;]</button></span><span class="pk-rec-notes-full" style="display:none"><?= htmlspecialchars(mb_substr($_sn, 50)) ?> <button class="pk-rec-expand-btn pk-rec-collapse-btn" type="button">[&laquo;]</button></span></span><?php else: ?><?= htmlspecialchars($_sn) ?><?php endif; ?>"</span><?php else: ?><span class="rs-notes-empty">&mdash; (no comment)</span><?php endif; ?><?php $_canWithdrawSec = !empty($sec['IsMine']) || ($CanManageKingdom ?? false); if (!empty($sec['IsMine']) || $_canWithdrawSec): ?> <span class="rs-second-actions"><?php if (!empty($sec['IsMine'])): ?><button class="rs-second-edit" data-sid="<?= (int)$sec['RecommendationSecondsId'] ?>" data-notes="<?= htmlspecialchars($sec['Notes'] ?? '', ENT_QUOTES) ?>" data-rstip="Edit your notes"><i class="fas fa-pen"></i></button><?php endif; ?><?php if ($_canWithdrawSec): ?><button class="rs-second-withdraw" data-sid="<?= (int)$sec['RecommendationSecondsId'] ?>" data-supporter="<?= htmlspecialchars($sec['SupporterName'] ?? '', ENT_QUOTES) ?>" data-rstip="<?= !empty($sec['IsMine']) ? 'Withdraw your second' : 'Remove this second' ?>"><i class="fas fa-times"></i></button><?php endif; ?></span><?php endif; ?></div>
+								<?php endforeach; ?>
+							</div>
+							<?php endif; ?>
+						</td>
+						<?php if (!empty($IsLoggedIn)): ?>
+						<td class="pk-rec-actions rs-tip-right" style="white-space:nowrap;text-align:right;width:1%">
+							<?php if (!empty($rec['SecondsCount'])): $_sc = (int)$rec['SecondsCount']; ?>
+							<span class="rs-seconds-badge" data-rstip="<?= $_sc ?> supporting <?= $_sc === 1 ? 'second' : 'seconds' ?>"><i class="fas fa-thumbs-up"></i><?= $_sc ?></span>
+							<?php endif; ?>
+							<?php if (!empty($rec['ViewerCanSecond'])): ?>
+							<button class="rs-action-btn" data-rec="<?= (int)$rec['RecommendationsId'] ?>" data-award="<?= htmlspecialchars($rec['AwardName'] ?? '', ENT_QUOTES) ?>" data-recipient="<?= htmlspecialchars($rec['Persona'] ?? '', ENT_QUOTES) ?>" data-rstip="Second this recommendation and add your feedback."><i class="fas fa-plus"></i></button>
+							<?php endif; ?>
+							<?php if ($CanManageKingdom ?? false): ?>
+							<button class="pk-btn pk-btn-primary pk-rec-grant-btn"
+								data-rec="<?= htmlspecialchars(json_encode(['RecommendationsId'=>(int)$rec['RecommendationsId'],'MundaneId'=>(int)$rec['MundaneId'],'Persona'=>$rec['Persona'],'KingdomAwardId'=>(int)$rec['KingdomAwardId'],'Rank'=>(int)$rec['Rank'],'Reason'=>$rec['Reason']??''])) ?>">
+								<i class="fas fa-medal"></i> Grant
+							</button>
+							<button class="pk-rec-dismiss-btn"
+								data-rec-id="<?= (int)$rec['RecommendationsId'] ?>">
+								<i class="fas fa-times"></i> Delete
+							</button>
+							<?php endif; ?>
+						</td>
+						<?php endif; ?>
+					</tr>
+					<?php endforeach; ?>
+					</tbody>
+				</table>
+			</div>
+			<?php endif; ?>
+			<?php if ($CanManageKingdom ?? false): ?>
+			<div class="pk-deleted-recs" id="kn-deleted-recs" data-loaded="0">
+				<button type="button" class="pk-deleted-recs-toggle" id="kn-deleted-recs-toggle" aria-expanded="false">
+					<span class="pk-deleted-recs-caret">&#9654;</span>
+					<span class="pk-deleted-recs-toggle-label">Show Deleted Recommendations</span>
+					<span class="pk-deleted-recs-count" id="kn-deleted-recs-count" style="display:none">0</span>
+				</button>
+				<div class="pk-deleted-recs-body" id="kn-deleted-recs-body" style="display:none">
+					<div class="pk-deleted-recs-loading" id="kn-deleted-recs-loading">Loading&hellip;</div>
+					<div class="pk-deleted-recs-empty" id="kn-deleted-recs-empty" style="display:none">No deleted recommendations.</div>
+					<div class="pk-deleted-recs-search-wrap" style="display:none">
+						<i class="fas fa-search"></i>
+						<input type="text" class="pk-deleted-recs-search" placeholder="Search player, award, notes, or actor&hellip;" autocomplete="off">
+					</div>
+					<div class="pk-deleted-recs-no-match" style="display:none">No deleted recommendations match your search.</div>
+					<div class="pk-deleted-recs-table-wrap" id="kn-deleted-recs-table-wrap" style="display:none">
+						<table class="pk-deleted-recs-table">
+							<thead>
+								<tr>
+									<th>Player</th>
+									<th>Award</th>
+									<th>Rank</th>
+									<th>Notes</th>
+									<th>Date Rec.</th>
+									<th>Recommended By</th>
+									<th>Deleted At</th>
+									<th>Deleted By</th>
+									<th></th>
+								</tr>
+							</thead>
+							<tbody id="kn-deleted-recs-tbody"></tbody>
+						</table>
+					</div>
+				</div>
+			</div>
+			<?php endif; ?>

--- a/orkui/template/revised-frontend/script/revised.js
+++ b/orkui/template/revised-frontend/script/revised.js
@@ -4495,13 +4495,14 @@ $(document).ready(function() {
 
             var lbl = document.createElement('div');
             lbl.className   = 'kn-admin-config-label';
-            var keyLabels = { 'AwardRecsPublic': 'Award Recommendations Visibility' };
+            var keyLabels = { 'AwardRecsPublic': 'Award Recommendations Visibility', 'IncludePrincipalityInStatistics': 'Include Principality in Statistics' };
             lbl.textContent = keyLabels[cfg.Key] || cfg.Key;
             var keyHints = {
                 'AttendanceWeeklyMinimum': 'Minimum distinct weeks with at least one sign-in in the last 6 months. Leave blank to not require this.',
                 'AttendanceDailyMinimum':  'Minimum distinct days with at least one sign-in in the last 6 months. Leave blank to not require this.',
                 'AttendanceCreditMinimum': 'Minimum total credits earned in the last 6 months. Leave blank to not require this.',
                 'MonthlyCreditMaximum':    'Cap on credits counted per calendar month (excess is discarded). Leave blank for no cap.',
+                'IncludePrincipalityInStatistics': 'When looking at statistics, graphs, and reports, include relevant metrics from Principality(ies) such as attendance and player counts.',
             };
             if (keyHints[cfg.Key]) {
                 var hint = document.createElement('span');
@@ -4559,6 +4560,16 @@ $(document).ready(function() {
                     else optPrivate.selected = true;
                     inp.appendChild(optPublic);
                     inp.appendChild(optPrivate);
+                } else if (cfg.Key === 'IncludePrincipalityInStatistics') {
+                    inp = document.createElement('input');
+                    inp.type = 'checkbox';
+                    inp.className = 'kn-admin-config-input';
+                    inp.checked = (String(val) === '1');
+                    // Make `.value` resolve to '1'/'0' from checked state so the existing
+                    // wireConfig collector + setconfig POST persist it unchanged.
+                    Object.defineProperty(inp, 'value', {
+                        get: function() { return this.checked ? '1' : '0'; }
+                    });
                 } else {
                     inp = document.createElement('input');
                     inp.type  = (cfg.Type === 'color')  ? 'color'

--- a/orkui/template/revised-frontend/script/revised.js
+++ b/orkui/template/revised-frontend/script/revised.js
@@ -2539,7 +2539,8 @@ function knRenderMapSidebar(loc) {
         : '<a href="' + profileUrl + '"><div class="kn-park-heraldry-placeholder"><i class="fas fa-shield-alt"></i></div></a>';
     var heroHtml = heraldryHtml
         + '<a href="' + profileUrl + '" class="kn-park-hero-name" style="text-decoration:none">' + escHtml(loc.name) + '</a>'
-        + (locLine ? '<div class="kn-park-hero-location"><i class="fas fa-map-marker-alt" style="font-size:10px"></i>' + escHtml(locLine) + '</div>' : '');
+        + (locLine ? '<div class="kn-park-hero-location"><i class="fas fa-map-marker-alt" style="font-size:10px"></i>' + escHtml(locLine) + '</div>' : '')
+        + (loc.prinz && loc.prName ? '<div class="kn-park-hero-location"><i class="fas fa-crown" style="font-size:10px"></i>Principality: ' + escHtml(loc.prName) + '</div>' : '');
 
     var bodyHtml = '';
     if (loc.dir) {
@@ -2593,10 +2594,35 @@ window.knInitMap = async function() {
         // fitBounds zoom used as-is (no pullback)
     }
 
+    // ---- Map legend (Kingdom vs Principality pin colors) ----
+    var knHasPrinz = false;
+    for (var li = 0; li < knMapLocations.length; li++) {
+        if (knMapLocations[li].prinz) { knHasPrinz = true; break; }
+    }
+    var legendCard = document.getElementById('kn-map-sidebar-card');
+    if (legendCard && !document.getElementById('kn-map-legend')) {
+        var legendEl = document.createElement('div');
+        legendEl.id = 'kn-map-legend';
+        legendEl.style.cssText = 'display:flex;flex-wrap:wrap;gap:14px;align-items:center;'
+            + 'margin-top:12px;padding:8px 10px;border-radius:6px;font-size:12px;'
+            + 'background:rgba(127,127,127,0.12);';
+        var legendHtml = '<span style="display:inline-flex;align-items:center;gap:6px">'
+            + '<span style="width:12px;height:12px;border-radius:2px;background:#8B1A1A;border:1px solid #B8860B;display:inline-block"></span>'
+            + 'Kingdom</span>';
+        if (knHasPrinz) {
+            legendHtml += '<span style="display:inline-flex;align-items:center;gap:6px">'
+                + '<span style="width:12px;height:12px;border-radius:2px;background:#2C5F8B;border:1px solid #B8860B;display:inline-block"></span>'
+                + 'Principality</span>';
+        }
+        legendEl.innerHTML = legendHtml;
+        legendCard.appendChild(legendEl);
+    }
+
     var infowindow = new google.maps.InfoWindow();
     for (var i = 0; i < knMapLocations.length; i++) {
         (function(loc) {
-            var pinGlyph = new PinElement({ scale: 0.7, background: '#8B1A1A', borderColor: '#B8860B', glyphColor: '#FFD700' });
+            var pinBg = loc.prinz ? '#2C5F8B' : '#8B1A1A';
+            var pinGlyph = new PinElement({ scale: 0.7, background: pinBg, borderColor: '#B8860B', glyphColor: '#FFD700' });
             var marker = new google.maps.marker.AdvancedMarkerElement({
                 position: new google.maps.LatLng(loc.lat, loc.lng),
                 map: map,
@@ -2819,11 +2845,15 @@ $(document).ready(function() {
         if (view === 'list') {
             $('#kn-parks-tiles').hide();
             $('#kn-parks-list-view').show();
+            $('#kn-prinz-tile-sections').hide();
+            $('#kn-prinz-tables').show();
             $('#kn-view-list').addClass('kn-view-active');
             $('#kn-view-tiles').removeClass('kn-view-active');
         } else {
             $('#kn-parks-list-view').hide();
             $('#kn-parks-tiles').show();
+            $('#kn-prinz-tables').hide();
+            $('#kn-prinz-tile-sections').show();
             $('#kn-view-tiles').addClass('kn-view-active');
             $('#kn-view-list').removeClass('kn-view-active');
         }

--- a/orkui/template/revised-frontend/script/revised.js
+++ b/orkui/template/revised-frontend/script/revised.js
@@ -2666,6 +2666,48 @@ function knActivateTab(tab) {
     if (tab === 'events' && knCalendar) {
         knCalendar.updateSize();
     }
+    if (tab === 'recommendations') {
+        knLazyLoadRecs();
+    }
+}
+
+// Lazily fetch the Recommendations tab's inner HTML the first time the tab is
+// activated. Inlining the rows on initial page render was blocking the
+// browser's DOMContentLoaded for 1+ seconds on busy kingdoms.
+function knLazyLoadRecs() {
+    var host = document.getElementById('kn-recs-lazy');
+    if (!host) return;
+    if (host.getAttribute('data-loaded') !== '0') return; // 'loading' or '1' — skip
+    var kid = host.getAttribute('data-kid');
+    if (!kid) return;
+    host.setAttribute('data-loaded', 'loading');
+    fetch('/orkui/index.php?Route=Kingdom/recommendations_panel/' + encodeURIComponent(kid), {
+        credentials: 'same-origin',
+        headers: { 'Accept': 'text/html' }
+    }).then(function(r) {
+        if (!r.ok) throw new Error('HTTP ' + r.status);
+        var count = r.headers.get('X-Recs-Count');
+        return r.text().then(function(html) { return { html: html, count: count }; });
+    }).then(function(payload) {
+        host.innerHTML = payload.html;
+        host.setAttribute('data-loaded', '1');
+        // Tab badge: show count if non-zero.
+        var badge = document.getElementById('kn-tab-count-recs');
+        if (badge && payload.count !== null && payload.count !== '0') {
+            badge.textContent = '(' + payload.count + ')';
+            badge.style.display = '';
+        }
+        // Let other initializers (rec filters, datatables, etc.) wire up.
+        if (typeof knInitRecsTab === 'function') {
+            try { knInitRecsTab(host); } catch (e) { console.error('knInitRecsTab failed:', e); }
+        }
+        document.dispatchEvent(new CustomEvent('kn:recs-loaded', { detail: { host: host, count: payload.count } }));
+    }).catch(function(err) {
+        host.setAttribute('data-loaded', '0'); // allow retry
+        host.innerHTML = '<div class="pk-recs-empty" style="color:#fc8181">Could not load recommendations: '
+            + String(err).replace(/[<>&]/g, function(c){ return '&#' + c.charCodeAt(0) + ';'; })
+            + ' &mdash; <a href="#" onclick="knLazyLoadRecs();return false">retry</a></div>';
+    });
 }
 
 // ---- Hero color from heraldry ----

--- a/orkui/template/revised-frontend/script/revised.js
+++ b/orkui/template/revised-frontend/script/revised.js
@@ -4787,6 +4787,44 @@ $(document).ready(function() {
     }
 
     // ── Section: Awards ──────────────────────────────────────
+    // Filters the rendered admin-awards table based on the search input's value.
+    // O(rows) per keystroke — fine up to a few hundred. Each row carries the
+    // pre-lowered haystack on its dataset, set in makeAwardRow().
+    function applyAdminAwardFilter() {
+        var inp = gid('kn-admin-award-search');
+        if (!inp) return;
+        var q     = inp.value.trim().toLowerCase();
+        var tbody = gid('kn-admin-awards-tbody');
+        var clear = gid('kn-admin-award-search-clear');
+        var empty = gid('kn-admin-award-search-empty');
+        if (clear) clear.style.display = q ? '' : 'none';
+        if (!tbody) return;
+        var rows = tbody.querySelectorAll('tr');
+        var visible = 0;
+        rows.forEach(function(tr) {
+            var hay  = tr.dataset.searchHaystack || '';
+            var show = !q || hay.indexOf(q) !== -1;
+            tr.style.display = show ? '' : 'none';
+            if (show) visible++;
+        });
+        if (empty) empty.style.display = (q && visible === 0) ? '' : 'none';
+    }
+
+    var awardSearchWired = false;
+    function wireAwardSearch() {
+        if (awardSearchWired) return;
+        var inp   = gid('kn-admin-award-search');
+        var clear = gid('kn-admin-award-search-clear');
+        if (!inp) return;
+        awardSearchWired = true;
+        inp.addEventListener('input', applyAdminAwardFilter);
+        if (clear) clear.addEventListener('click', function() {
+            inp.value = '';
+            inp.focus();
+            applyAdminAwardFilter();
+        });
+    }
+
     var awardsBuilt = false;
     function buildAwards() {
         if (awardsBuilt) return;
@@ -4797,10 +4835,19 @@ $(document).ready(function() {
         (KnConfig.adminAwards || []).forEach(function(aw) {
             tbody.appendChild(makeAwardRow(aw));
         });
+        wireAwardSearch();
     }
 
     function makeAwardRow(aw) {
         var tr = document.createElement('tr');
+        // Cached searchable haystack for the filter input above the table —
+        // built once at render time, lower-cased, and re-read on each keystroke
+        // instead of walking the DOM for every cell.
+        tr.dataset.searchHaystack = (
+            (aw.KingdomAwardName || '') + ' ' +
+            (aw.AwardName        || '') + ' ' +
+            (aw.TitleClass       || '')
+        ).toLowerCase();
 
         function ntd(isText, val) {
             var td  = document.createElement('td');
@@ -4845,8 +4892,19 @@ $(document).ready(function() {
         var saveBtn = document.createElement('button');
         saveBtn.className   = 'kn-admin-tsave';
         saveBtn.innerHTML   = '<i class="fas fa-save"></i>';
-        saveBtn.title       = 'Save';
+        saveBtn.title       = 'No changes to save';
+        saveBtn.disabled    = true;                  // clean rows start "nothing to save"
         saveBtn.style.marginRight = '4px';
+        // Flip the save button live when any field in this row gets edited.
+        // Click on the save button itself doesn't bubble through these listeners.
+        function markDirty() {
+            saveBtn.disabled = false;
+            saveBtn.title    = 'Save';
+        }
+        [nameCell.inp, reignCell.inp, monthCell.inp, classCell.inp].forEach(function(inp) {
+            inp.addEventListener('input', markDirty);
+        });
+        titleCb.addEventListener('change', markDirty);
         (function(btn, nc, rc, mc, cb, cc, kawId) {
             btn.addEventListener('click', function() {
                 clearFeedback('kn-admin-awards-feedback');
@@ -4859,9 +4917,16 @@ $(document).ready(function() {
                     IsTitle:          cb.checked ? 1 : 0,
                     TitleClass:       cc.value,
                 }, function(r) {
-                    btn.disabled = false;
-                    if (r && r.status === 0) { knClearPending('kn-admin-body-awards'); feedback('kn-admin-awards-feedback', 'Award saved!', true); }
-                    else feedback('kn-admin-awards-feedback', (r && r.error) ? r.error : 'Save failed.', false);
+                    if (r && r.status === 0) {
+                        // Save succeeded — row is "clean" again, leave disabled.
+                        btn.title = 'No changes to save';
+                        knClearPending('kn-admin-body-awards');
+                        feedback('kn-admin-awards-feedback', 'Award saved!', true);
+                    } else {
+                        // Save failed — re-enable so they can retry.
+                        btn.disabled = false;
+                        feedback('kn-admin-awards-feedback', (r && r.error) ? r.error : 'Save failed.', false);
+                    }
                 }, 'json').fail(function() { btn.disabled = false; feedback('kn-admin-awards-feedback', 'Request failed.', false); });
             });
         })(saveBtn, nameCell.inp, reignCell.inp, monthCell.inp, titleCb, classCell.inp, aw.KingdomAwardId);
@@ -4872,17 +4937,18 @@ $(document).ready(function() {
         delBtn.title       = 'Delete';
         (function(btn, row, kawId, awName) {
             btn.addEventListener('click', function() {
-                if (!confirm('Delete award "' + awName + '"? This cannot be undone.')) return;
-                btn.disabled = true;
-                $.post(BASE_URL + 'deleteaward', { KingdomAwardId: kawId }, function(r) {
-                    if (r && r.status === 0) {
-                        row.parentNode && row.parentNode.removeChild(row);
-                        knClearPending('kn-admin-body-awards'); feedback('kn-admin-awards-feedback', 'Award deleted.', true);
-                    } else {
-                        btn.disabled = false;
-                        feedback('kn-admin-awards-feedback', (r && r.error) ? r.error : 'Delete failed.', false);
-                    }
-                }, 'json').fail(function() { btn.disabled = false; feedback('kn-admin-awards-feedback', 'Request failed.', false); });
+                knConfirm('Delete award "' + awName + '"? This cannot be undone.', function() {
+                    btn.disabled = true;
+                    $.post(BASE_URL + 'deleteaward', { KingdomAwardId: kawId }, function(r) {
+                        if (r && r.status === 0) {
+                            row.parentNode && row.parentNode.removeChild(row);
+                            knClearPending('kn-admin-body-awards'); feedback('kn-admin-awards-feedback', 'Award deleted.', true);
+                        } else {
+                            btn.disabled = false;
+                            feedback('kn-admin-awards-feedback', (r && r.error) ? r.error : 'Delete failed.', false);
+                        }
+                    }, 'json').fail(function() { btn.disabled = false; feedback('kn-admin-awards-feedback', 'Request failed.', false); });
+                }, 'Delete Award');
             });
         })(delBtn, tr, aw.KingdomAwardId, aw.KingdomAwardName);
 

--- a/orkui/template/revised-frontend/script/revised.js
+++ b/orkui/template/revised-frontend/script/revised.js
@@ -4777,7 +4777,7 @@ $(document).ready(function() {
                     TitleClass:       cc.value,
                 }, function(r) {
                     btn.disabled = false;
-                    if (r && r.status === 0) feedback('kn-admin-awards-feedback', 'Award saved!', true);
+                    if (r && r.status === 0) { knClearPending('kn-admin-body-awards'); feedback('kn-admin-awards-feedback', 'Award saved!', true); }
                     else feedback('kn-admin-awards-feedback', (r && r.error) ? r.error : 'Save failed.', false);
                 }, 'json').fail(function() { btn.disabled = false; feedback('kn-admin-awards-feedback', 'Request failed.', false); });
             });
@@ -4794,7 +4794,7 @@ $(document).ready(function() {
                 $.post(BASE_URL + 'deleteaward', { KingdomAwardId: kawId }, function(r) {
                     if (r && r.status === 0) {
                         row.parentNode && row.parentNode.removeChild(row);
-                        feedback('kn-admin-awards-feedback', 'Award deleted.', true);
+                        knClearPending('kn-admin-body-awards'); feedback('kn-admin-awards-feedback', 'Award deleted.', true);
                     } else {
                         btn.disabled = false;
                         feedback('kn-admin-awards-feedback', (r && r.error) ? r.error : 'Delete failed.', false);
@@ -5365,9 +5365,12 @@ $(document).ready(function() {
 
         var overlay = gid('kn-admin-overlay');
         if (overlay) {
-            overlay.addEventListener('click', function(e) {
-                if (e.target === this) knCloseAdminModal();
-            });
+            // Only close on a click that BOTH started and ended on the overlay.
+            // Without the mousedown gate, drag-selecting text in an input and
+            // releasing outside the input fires a click on the overlay and closes it.
+            var knDownOnSelf = false;
+            overlay.addEventListener('mousedown', function(e) { knDownOnSelf = (e.target === this); });
+            overlay.addEventListener('click', function(e) { if (knDownOnSelf && e.target === this) knCloseAdminModal(); });
         }
 
         document.addEventListener('keydown', function(e) {

--- a/orkui/template/revised-frontend/style/revised.css
+++ b/orkui/template/revised-frontend/style/revised.css
@@ -5580,6 +5580,18 @@ html[data-theme="dark"] .pk-stat-tip-text::after { border-top-color: #e2e8f0; }
 
 /* ---- Edit Parks panel ---- */
 .kn-admin-table-wrap { overflow-x:auto; }
+
+/* Search box above the admin awards list (purely client-side filter) */
+.kn-admin-award-search-wrap { position:relative; margin:0 0 10px; max-width:360px; }
+.kn-admin-award-search-icon { position:absolute; left:10px; top:50%; transform:translateY(-50%); color:#a0aec0; font-size:12px; pointer-events:none; }
+.kn-admin-award-search-input { width:100%; box-sizing:border-box; padding:7px 30px 7px 30px; border:1px solid #cbd5e0; border-radius:6px; background:#fff; color:#2d3748; font-size:13px; }
+.kn-admin-award-search-input:focus { outline:none; border-color:#68d391; box-shadow:0 0 0 2px rgba(104,211,145,0.15); }
+.kn-admin-award-search-clear { position:absolute; right:6px; top:50%; transform:translateY(-50%); background:none; border:none; color:#a0aec0; font-size:18px; line-height:1; cursor:pointer; padding:0 4px; }
+.kn-admin-award-search-clear:hover { color:#4a5568; }
+.kn-admin-award-search-empty { padding:8px 4px; color:#718096; font-size:12px; font-style:italic; }
+html[data-theme="dark"] .kn-admin-award-search-input { background:var(--ork-bg-secondary,#2d3748); color:var(--ork-text,#e2e8f0); border-color:var(--ork-border,#4a5568); }
+html[data-theme="dark"] .kn-admin-award-search-input:focus { border-color:#68d391; box-shadow:0 0 0 2px rgba(104,211,145,0.25); }
+html[data-theme="dark"] .kn-admin-award-search-empty { color:var(--ork-text-muted,#a0aec0); }
 .kn-admin-parks-table .kn-admin-tinput.kn-admin-park-name { min-width:140px; }
 .kn-admin-parks-table .kn-admin-tinput.kn-admin-park-abbr { width:48px; text-align:center; text-transform:uppercase; }
 .kn-admin-park-retired { opacity:0.5; }

--- a/orkui/template/revised-frontend/style/revised.css
+++ b/orkui/template/revised-frontend/style/revised.css
@@ -8821,3 +8821,135 @@ html[data-theme="dark"] .pn-notes-infobox-icon { color: #63b3ed; }
   html:not([data-theme="light"]):not([data-theme="dark"]) .pn-notes-infobox a { color: #90cdf4; }
   html:not([data-theme="light"]):not([data-theme="dark"]) .pn-notes-infobox-icon { color: #63b3ed; }
 }
+
+/* =====================================================
+   Kingdom Parks tab — Principalities sub-group
+   (folded under the kingdom's own parks; tile + list views)
+   Mirrors .kn-park-tile / .kn-table look. Dark mode via
+   html[data-theme="dark"] + --ork-* theme tokens.
+   ===================================================== */
+
+/* Group label / separator — rendered with ::before so the markup
+   does not need to include a label element (avoids the global
+   h1..h6 gray-box treatment from orkui.css entirely). */
+#kn-prinz-tile-sections,
+#kn-prinz-tables {
+	margin-top: 26px;
+	padding-top: 18px;
+	border-top: 1px solid var(--ork-border, #e2e8f0);
+}
+#kn-prinz-tile-sections::before,
+#kn-prinz-tables::before {
+	content: 'Principalities';
+	display: block;
+	margin-bottom: 14px;
+	font-size: 11px;
+	font-weight: 700;
+	text-transform: uppercase;
+	letter-spacing: 1.2px;
+	color: var(--ork-text-muted, #718096);
+}
+
+/* Each principality group reads as a distinct sub-group */
+.kn-prinz-section,
+.kn-prinz-table-wrap {
+	margin-top: 22px;
+	padding-top: 4px;
+}
+.kn-prinz-section:first-of-type,
+.kn-prinz-table-wrap:first-of-type {
+	margin-top: 0;
+}
+/* subtle divider between successive principalities */
+.kn-prinz-section + .kn-prinz-section,
+.kn-prinz-table-wrap + .kn-prinz-table-wrap {
+	margin-top: 26px;
+	padding-top: 22px;
+	border-top: 1px dashed var(--ork-border, #e2e8f0);
+}
+
+/* Header row — it's a link to the principality profile */
+a.kn-prinz-head {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	padding: 6px 6px;
+	margin-bottom: 12px;
+	border-radius: 6px;
+	text-decoration: none;
+	cursor: pointer;
+	transition: background 0.12s;
+}
+a.kn-prinz-head:hover {
+	background: var(--ork-bg-secondary, #f7fafc);
+}
+a.kn-prinz-head:hover .kn-prinz-name {
+	text-decoration: underline;
+}
+
+/* Principality heraldry thumbnail */
+.kn-prinz-heraldry {
+	width: 30px;
+	height: 30px;
+	flex: 0 0 auto;
+	object-fit: contain;
+	border-radius: 4px;
+	border: 1px solid var(--ork-border, #e2e8f0);
+	vertical-align: middle;
+	background: var(--ork-bg, #fff);
+}
+
+/* Principality name — small section header look */
+.kn-prinz-name {
+	font-size: 15px;
+	font-weight: 600;
+	color: var(--ork-text, #2d3748);
+	line-height: 1.2;
+}
+
+/* External-link icon — muted, signals "opens the principality page" */
+.kn-prinz-extlink {
+	margin-left: 4px;
+	font-size: 11px;
+	color: var(--ork-text-lighter, #a0aec0);
+	transition: color 0.12s;
+}
+a.kn-prinz-head:hover .kn-prinz-extlink {
+	color: var(--kn-accent-mid, #276749);
+}
+
+/* The .kn-park-tiles grid inside a section inherits the kingdom grid;
+   no override needed beyond ensuring it is not collapsed. */
+.kn-prinz-section .kn-park-tiles {
+	margin-top: 0;
+}
+
+/* ---------- DARK MODE ---------- */
+html[data-theme="dark"] #kn-prinz-tile-sections,
+html[data-theme="dark"] #kn-prinz-tables {
+	border-top-color: var(--ork-border);
+}
+html[data-theme="dark"] #kn-prinz-tile-sections::before,
+html[data-theme="dark"] #kn-prinz-tables::before {
+	color: var(--ork-text-muted);
+}
+html[data-theme="dark"] .kn-prinz-section + .kn-prinz-section,
+html[data-theme="dark"] .kn-prinz-table-wrap + .kn-prinz-table-wrap {
+	border-top-color: var(--ork-border);
+}
+html[data-theme="dark"] a.kn-prinz-head:hover {
+	background: var(--ork-bg-secondary);
+}
+html[data-theme="dark"] .kn-prinz-heraldry {
+	border-color: var(--ork-border);
+	background: var(--ork-bg-tertiary);
+}
+html[data-theme="dark"] .kn-prinz-name {
+	color: var(--ork-text);
+}
+html[data-theme="dark"] .kn-prinz-extlink {
+	color: var(--ork-text-lighter);
+}
+html[data-theme="dark"] a.kn-prinz-head:hover .kn-prinz-extlink {
+	color: var(--ork-link-bright);
+}

--- a/system/lib/ork3/class.Authorization.php
+++ b/system/lib/ork3/class.Authorization.php
@@ -806,7 +806,7 @@ class Authorization extends Ork3
 		// Upper-level authority check, we have to find the parents of
 		// of the subject, and check their auths
 		// !$sufficient is redundant, but I don't trust the next guy to hold the invariant
-		if (!$sufficient && $type != AUTH_KINGDOM) {
+		if (!$sufficient) {
 			switch ($type) {
 				case AUTH_PARK:
 					$park = new yapo($this->db, DB_PREFIX . 'park');
@@ -826,6 +826,17 @@ class Authorization extends Ork3
 						if ($this->HasAuthority($mundane_id, AUTH_KINGDOM, $event->kingdom_id, $role) || $this->HasAuthority($mundane_id, AUTH_PARK, $event->park_id, $role) || $event->mundane_id == $mundane_id)
 							return true;
 					}
+					break;
+				case AUTH_KINGDOM:
+					// Principalities are sub-groups of their parent kingdom: parent-kingdom
+					// officers hold the same authority over a principality (and its parks)
+					// as over the kingdom itself. Walk up the parent_kingdom_id chain.
+					$kingdom = new yapo($this->db, DB_PREFIX . 'kingdom');
+					$kingdom->clear();
+					$kingdom->kingdom_id = $id;
+					if ($kingdom->find() && valid_id($kingdom->parent_kingdom_id)
+						&& $this->HasAuthority($mundane_id, AUTH_KINGDOM, $kingdom->parent_kingdom_id, $role))
+						return true;
 					break;
 			}
 		}

--- a/system/lib/ork3/class.Authorization.php
+++ b/system/lib/ork3/class.Authorization.php
@@ -717,7 +717,7 @@ class Authorization extends Ork3
 		return array($type, $id);
 	}
 
-	public function HasAuthority($mundane_id, $type, $id, $role)
+	public function HasAuthority($mundane_id, $type, $id, $role, $visited = array())
 	{
 		logtrace("HasAuthority", array($mundane_id, $type, $id, $role));
 
@@ -831,11 +831,17 @@ class Authorization extends Ork3
 					// Principalities are sub-groups of their parent kingdom: parent-kingdom
 					// officers hold the same authority over a principality (and its parks)
 					// as over the kingdom itself. Walk up the parent_kingdom_id chain.
+					// Guard against a corrupt/cyclic parent_kingdom_id (e.g. A->B->A or a
+					// self-parent) with a visited-set of kingdom ids plus a hard depth cap,
+					// so the recursion can never loop forever.
 					$kingdom = new yapo($this->db, DB_PREFIX . 'kingdom');
 					$kingdom->clear();
 					$kingdom->kingdom_id = $id;
+					$visited[] = (int) $id;
 					if ($kingdom->find() && valid_id($kingdom->parent_kingdom_id)
-						&& $this->HasAuthority($mundane_id, AUTH_KINGDOM, $kingdom->parent_kingdom_id, $role))
+						&& !in_array((int) $kingdom->parent_kingdom_id, $visited, true)
+						&& count($visited) < 10
+						&& $this->HasAuthority($mundane_id, AUTH_KINGDOM, $kingdom->parent_kingdom_id, $role, $visited))
 						return true;
 					break;
 			}

--- a/system/lib/ork3/class.Award.php
+++ b/system/lib/ork3/class.Award.php
@@ -39,7 +39,11 @@ class Award  extends Ork3 {
             $kingdomaward->clear();
             $kingdomaward->kingdom_id = $request['KingdomId'];
             $kingdomaward->award_id = $request['AwardId'];
-            $kingdomaward->find();
+            if (!$kingdomaward->find()) {
+                // No matching kingdomaward row — return an invalid id so callers
+                // don't create an orphaned award grant against a stale id.
+                return array(0, $request['AwardId']);
+            }
 			return array($kingdomaward->kingdomaward_id, $kingdomaward->award_id);
         }
     }

--- a/system/lib/ork3/class.Kingdom.php
+++ b/system/lib/ork3/class.Kingdom.php
@@ -2,6 +2,13 @@
 
 class Kingdom  extends Ork3 {
 
+	// Per-request memo caches for the principality-rollup helpers. These are read
+	// dozens of times per kingdom-scoped report page; the Kingdom lib is a single
+	// instance per request (see startup.php), so caching here is safe and avoids
+	// redundant DB hits — most notably for ordinary kingdoms that have no children.
+	private $childPrincipalityCache = array();
+	private $statsIncludesPrincipalityCache = array();
+
 	public function __construct() {
 		parent::__construct();
 		$this->kingdom = new yapo($this->db, DB_PREFIX . 'kingdom');
@@ -601,6 +608,9 @@ class Kingdom  extends Ork3 {
 		if ($kingdomId <= 0) {
 			return $ids;
 		}
+		if (isset($this->childPrincipalityCache[$kingdomId])) {
+			return $this->childPrincipalityCache[$kingdomId];
+		}
 		$child = new yapo($this->db, DB_PREFIX . 'kingdom');
 		$child->clear();
 		$child->parent_kingdom_id = $kingdomId;
@@ -610,6 +620,7 @@ class Kingdom  extends Ork3 {
 				$ids[] = (int)$child->kingdom_id;
 			} while ($child->next());
 		}
+		$this->childPrincipalityCache[$kingdomId] = $ids;
 		return $ids;
 	}
 
@@ -623,9 +634,14 @@ class Kingdom  extends Ork3 {
 	// True iff the IncludePrincipalityInStatistics config flag for $kingdomId is '1'.
 	public function StatsIncludesPrincipalities($kingdomId) {
 		$kingdomId = (int)$kingdomId;
+		if (isset($this->statsIncludesPrincipalityCache[$kingdomId])) {
+			return $this->statsIncludesPrincipalityCache[$kingdomId];
+		}
 		$configs = Common::get_configs($kingdomId, CFG_KINGDOM);
-		return isset($configs['IncludePrincipalityInStatistics'])
+		$enabled = isset($configs['IncludePrincipalityInStatistics'])
 			&& (int)$configs['IncludePrincipalityInStatistics']['Value'] === 1;
+		$this->statsIncludesPrincipalityCache[$kingdomId] = $enabled;
+		return $enabled;
 	}
 
 	// GetFamilyKingdomIds($kingdomId) when StatsIncludesPrincipalities is true AND

--- a/system/lib/ork3/class.Kingdom.php
+++ b/system/lib/ork3/class.Kingdom.php
@@ -378,12 +378,25 @@ class Kingdom  extends Ork3 {
 				'parent_kingdom_id' => (int)$request['ParentKingdomId'],
 			]);
 			$response = Success($this->kingdom->kingdom_id);
+			$this->_flushPrincipalityCaches();
 		} else {
 			$response = NoAuthorization();
 		}
 		return $response;
 	}
-	
+
+	// Full memcache flush after any change that alters the kingdom-family tree
+	// (created / reparented / deactivated kingdoms or principalities). Lots of
+	// derived caches across averages / events / recs / recap / officer directory
+	// key off principality membership; enumerating every dependent key is
+	// whack-a-mole, and these mutations are rare admin actions so the wipe cost
+	// is acceptable.
+	private function _flushPrincipalityCaches() {
+		if (isset(Ork3::$Lib->ghettocache) && isset(Ork3::$Lib->ghettocache->memcache)) {
+			Ork3::$Lib->ghettocache->memcache->flush();
+		}
+	}
+
 	public function GetPrincipalities($request) {
 		$this->kingdom->clear();
 		$this->kingdom->parent_kingdom_id = $request['KingdomId'];
@@ -594,6 +607,7 @@ class Kingdom  extends Ork3 {
 			$this->kingdom->parent_kingdom_id = $parent_id;
 			$this->kingdom->modified = date('Y-m-d H:i:s', time());
 			$this->kingdom->save();
+			$this->_flushPrincipalityCaches();
 			return Success();
 		}
 		return NoAuthorization();
@@ -802,6 +816,7 @@ class Kingdom  extends Ork3 {
 			if ($this->kingdom->find()) {
 				$this->kingdom->active = $waffle;
 				$this->kingdom->save();
+				$this->_flushPrincipalityCaches();
 				$response = Success();
 			} else {
 				$response = InvalidParameter(NULL, 'Problem processing request.');

--- a/system/lib/ork3/class.Kingdom.php
+++ b/system/lib/ork3/class.Kingdom.php
@@ -350,7 +350,8 @@ class Kingdom  extends Ork3 {
 			$c->add_config($mundane_id, CFG_KINGDOM, 'number', $this->kingdom->kingdom_id, 'KingdomDuesTake', $request['KingdomDuesTake']);
     		$c->add_config($mundane_id, CFG_KINGDOM, 'color', $this->kingdom->kingdom_id, 'AtlasColor', 'FE7569');
 			$c->add_config($mundane_id, CFG_KINGDOM, 'fixed', $this->kingdom->kingdom_id, 'AwardRecsPublic', '1');
-			
+			$c->add_config($mundane_id, CFG_KINGDOM, 'fixed', $this->kingdom->kingdom_id, 'IncludePrincipalityInStatistics', '0');
+
 			$c->create_officers($this->kingdom->kingdom_id, 0);
 			
 			$c->create_park_titles($this->kingdom->kingdom_id);
@@ -390,17 +391,23 @@ class Kingdom  extends Ork3 {
 						'ParentKingdomId' => $this->kingdom->parent_kingdom_id
 					);
 			} while ($this->kingdom->next());
-		} else {
-			$result['Status'] = InvalidParameter();
 		}
 		return $result;
 	}
 	
 	public function GetParks($request) {
+		// Optional 'KingdomIds' array → WHERE p.kingdom_id IN (...). Default keeps
+		// single-'KingdomId' behavior unchanged.
+		if (isset($request['KingdomIds']) && is_array($request['KingdomIds']) && count($request['KingdomIds']) > 0) {
+			$ids = implode(',', array_map('intval', $request['KingdomIds']));
+			$kingdom_clause = "p.kingdom_id IN ($ids)";
+		} else {
+			$kingdom_clause = "p.kingdom_id = '" . mysql_real_escape_string($request['KingdomId']) . "'";
+		}
 		$sql = "select * 
 					from " . DB_PREFIX . "park p
 						left join " . DB_PREFIX . "parktitle pt on p.parktitle_id = pt.parktitle_id
-					where p.kingdom_id = '" . mysql_real_escape_string($request['KingdomId']) . "'
+					where $kingdom_clause
 					order by pt.class desc, p.name asc";
 		$r = $this->db->query($sql);
 		if ($r !== false && $r->size() > 0) {
@@ -409,7 +416,6 @@ class Kingdom  extends Ork3 {
 				$response['Parks'][] = array(
 						'ParkId' => $r->park_id,
 						'KingdomId' => $r->kingdom_id,
-						'ParentParkId' => $r->parent_park_id,
 						'Name' => $r->name,
 						'Abbreviation' => $r->abbreviation,
 						'Location' => $r->location,
@@ -422,8 +428,7 @@ class Kingdom  extends Ork3 {
 						'Class' => $r->class,
                         'HasHeraldry' => $r->has_heraldry,
                         'City' => $r->city,
-                        'Province' => $r->province,
-						'ParentOf' => $r->is_principality==1?Ork3::$Lib->park->GetParks(array('ParkId'=>$r->park_id, 'Stack' => array($r->park_id))):null
+                        'Province' => $r->province
 					);
 			}
 		} else {
@@ -553,6 +558,27 @@ class Kingdom  extends Ork3 {
 				if (!$this->kingdom->find()) {
 					return InvalidParameter('Parent kingdom not found.');
 				}
+				// Cycle prevention: walk the proposed parent's ancestor chain. If we
+				// reach $kingdom_id, the proposed parent is a descendant of the
+				// kingdom we are reparenting → that would create a loop. Reject it.
+				$walker  = new yapo($this->db, DB_PREFIX . 'kingdom');
+				$cursor  = $parent_id;
+				$visited = array();
+				while ($cursor > 0) {
+					if ($cursor === $kingdom_id) {
+						return InvalidParameter('A kingdom cannot be made a child of one of its own descendants.');
+					}
+					if (isset($visited[$cursor])) {
+						break; // pre-existing cycle in data — stop walking
+					}
+					$visited[$cursor] = true;
+					$walker->clear();
+					$walker->kingdom_id = $cursor;
+					if (!$walker->find()) {
+						break;
+					}
+					$cursor = (int)$walker->parent_kingdom_id;
+				}
 				$this->kingdom->clear();
 				$this->kingdom->kingdom_id = $kingdom_id;
 				$this->kingdom->find();
@@ -564,6 +590,53 @@ class Kingdom  extends Ork3 {
 			return Success();
 		}
 		return NoAuthorization();
+	}
+
+	// Active child-principality kingdom ids of $kingdomId ([] if none). Uses the
+	// same criteria as GetPrincipalities (parent_kingdom_id = $kingdomId AND
+	// active = 'Active').
+	public function GetChildPrincipalityIds($kingdomId) {
+		$kingdomId = (int)$kingdomId;
+		$ids = array();
+		if ($kingdomId <= 0) {
+			return $ids;
+		}
+		$child = new yapo($this->db, DB_PREFIX . 'kingdom');
+		$child->clear();
+		$child->parent_kingdom_id = $kingdomId;
+		$child->active = 'Active';
+		if ($child->find()) {
+			do {
+				$ids[] = (int)$child->kingdom_id;
+			} while ($child->next());
+		}
+		return $ids;
+	}
+
+	// [$kingdomId, ...child principality ids] — ALWAYS includes children.
+	// Structural scoping (parks dropdown, player search) uses THIS.
+	public function GetFamilyKingdomIds($kingdomId) {
+		$kingdomId = (int)$kingdomId;
+		return array_merge(array($kingdomId), $this->GetChildPrincipalityIds($kingdomId));
+	}
+
+	// True iff the IncludePrincipalityInStatistics config flag for $kingdomId is '1'.
+	public function StatsIncludesPrincipalities($kingdomId) {
+		$kingdomId = (int)$kingdomId;
+		$configs = Common::get_configs($kingdomId, CFG_KINGDOM);
+		return isset($configs['IncludePrincipalityInStatistics'])
+			&& (int)$configs['IncludePrincipalityInStatistics']['Value'] === 1;
+	}
+
+	// GetFamilyKingdomIds($kingdomId) when StatsIncludesPrincipalities is true AND
+	// there are children; otherwise [$kingdomId]. STATS/REPORT scoping uses THIS.
+	public function GetStatsKingdomIds($kingdomId) {
+		$kingdomId = (int)$kingdomId;
+		$children = $this->GetChildPrincipalityIds($kingdomId);
+		if (count($children) > 0 && $this->StatsIncludesPrincipalities($kingdomId)) {
+			return array_merge(array($kingdomId), $children);
+		}
+		return array($kingdomId);
 	}
 
 	public function GetOfficers($request) {

--- a/system/lib/ork3/class.Kingdom.php
+++ b/system/lib/ork3/class.Kingdom.php
@@ -118,7 +118,7 @@ class Kingdom  extends Ork3 {
 			$ladder_clause = " and is_title = 0";
 		}
 		$sql = "select kingdomaward_id, ifnull(ka.name, a.name) as kingdom_awardname, ka.reign_limit, ka.month_limit, a.name as award_name, 
-						a.award_id, a.is_ladder, ifnull(a.is_title, ka.is_title) as is_title, ifnull(a.title_class, ka.title_class) as title_class,
+						a.award_id, a.is_ladder, ka.is_title as is_title, ka.title_class as title_class,
             a.officer_role, a.peerage
 					from " . DB_PREFIX . "kingdomaward ka
 						left join " . DB_PREFIX . "award a on ka.award_id = a.award_id and ka.kingdom_id = '" . mysql_real_escape_string($request['KingdomId']) . "'
@@ -236,7 +236,7 @@ class Kingdom  extends Ork3 {
 	}
 		
 	public function create_kingdom_awards($kingdom_id) {
-		$sql = "insert into " . DB_PREFIX . "kingdomaward (kingdom_id, award_id, name) select " . mysql_real_escape_string($kingdom_id) .", award_id, name from " . DB_PREFIX . "award";
+		$sql = "insert into " . DB_PREFIX . "kingdomaward (kingdom_id, award_id, name, is_title, title_class) select " . mysql_real_escape_string($kingdom_id) .", award_id, name, is_title, title_class from " . DB_PREFIX . "award";
 		$this->db->query($sql);
 	}
 	

--- a/system/lib/ork3/class.Player.php
+++ b/system/lib/ork3/class.Player.php
@@ -1725,6 +1725,12 @@ class Player extends Ork3 {
             return InvalidParameter();
         }
 
+        // Guard against an unresolved kingdomaward (LookupAward/LookupKingdomAward
+        // returned a zero/invalid id) — saving here would create an orphaned grant.
+        if (!valid_id($request['KingdomAwardId'])) {
+            return InvalidParameter();
+        }
+
 		if (valid_id($mundane_id)
 				&& Ork3::$Lib->authorization->HasAuthority($mundane_id, AUTH_PARK, $recipient['ParkId'], AUTH_CREATE)) {
 			if (valid_id($request['ParkId'])) {

--- a/system/lib/ork3/class.Report.php
+++ b/system/lib/ork3/class.Report.php
@@ -443,6 +443,10 @@ class Report  extends Ork3 {
 			return $this->applyViewerFlags($cache, $viewer_id);
 
 		if (valid_id($request['KingdomId'])) {
+			// Roll up principalities when the kingdom's IncludePrincipalityInStatistics
+			// flag is on. Originally pulled back because the inlined rendering was
+			// blocking DOMContentLoaded, but the tab is now lazy-loaded so the row
+			// count no longer affects initial paint.
 			$kidList = implode(',', array_map('intval', Ork3::$Lib->kingdom->GetStatsKingdomIds($request['KingdomId'])));
 			$location_clause = " AND m.kingdom_id IN ($kidList)";
 		}
@@ -684,6 +688,41 @@ class Report  extends Ork3 {
 		}
 		unset($rec);
 		return $response;
+	}
+
+	// Lightweight "how many active recs for this kingdom does this viewer see"
+	// query. Skips the heavy joins / per-row subqueries the full recommendations
+	// report runs, so it's cheap enough to call on every kingdom profile load
+	// just to render the "Recommendations (N)" tab badge.
+	public function PlayerAwardRecommendationsCount($request) {
+		$kid = (int)($request['KingdomId'] ?? 0);
+		if ($kid <= 0) return 0;
+		// Match PlayerAwardRecommendations: roll up principalities when the parent
+		// kingdom's IncludePrincipalityInStatistics flag is on, so the badge stays
+		// in sync with what the lazy-loaded panel actually shows.
+		$kidList = implode(',', array_map('intval', Ork3::$Lib->kingdom->GetStatsKingdomIds($kid)));
+		$key = Ork3::$Lib->ghettocache->key([
+			'KingdomIds'    => $kidList,
+			'RecommendedBy' => (int)($request['RecommendedBy'] ?? 0),
+		]);
+		if (($cache = Ork3::$Lib->ghettocache->get(__CLASS__ . '.' . __FUNCTION__, $key, 300)) !== false)
+			return (int)$cache;
+
+		$where = "m.kingdom_id IN ($kidList) AND (recs.deleted_by IS NULL OR recs.deleted_by = 0)";
+		if (!empty($request['RecommendedBy'])) {
+			$rb = (int)$request['RecommendedBy'];
+			$where .= " AND recs.recommended_by_id = $rb";
+		}
+		$sql = "SELECT COUNT(*) AS n
+				FROM " . DB_PREFIX . "recommendations recs
+				JOIN " . DB_PREFIX . "mundane m ON m.mundane_id = recs.mundane_id
+				WHERE $where";
+		$r = $this->db->query($sql);
+		$n = 0;
+		if ($r !== false && $r->size() > 0 && $r->next()) {
+			$n = (int)$r->n;
+		}
+		return Ork3::$Lib->ghettocache->cache(__CLASS__ . '.' . __FUNCTION__, $key, $n);
 	}
 
 	public function DeletedAwardRecommendations($request) {

--- a/system/lib/ork3/class.Report.php
+++ b/system/lib/ork3/class.Report.php
@@ -151,7 +151,8 @@ class Report  extends Ork3 {
 			return $cache;
 
 		if (valid_id($request['KingdomId'])) {
-			$location_clause = " and m.kingdom_id = $request[KingdomId]";
+			$kidList = implode(',', array_map('intval', Ork3::$Lib->kingdom->GetStatsKingdomIds($request['KingdomId'])));
+			$location_clause = " and m.kingdom_id IN ($kidList)";
 		} else {
 			// Kingdom-wide view: sort kingdom, then park, then persona.
 			$order = "k.name, p.name, m.persona, ";
@@ -207,6 +208,8 @@ class Report  extends Ork3 {
 		if (($cache = Ork3::$Lib->ghettocache->get(__CLASS__ . '.' . __FUNCTION__, $key, 60)) !== false)
 			return $cache;
 
+    $kidList = implode(',', array_map('intval', Ork3::$Lib->kingdom->GetStatsKingdomIds($kingdom_id)));
+
     $sql = "select m.mundane_id, m.persona, ducal_terms.ducal_points, kingdom_terms.kingdom_points from
               ork_mundane m
               left join 
@@ -220,7 +223,7 @@ class Report  extends Ork3 {
                       left join ork_kingdomaward ka on awards.kingdomaward_id = ka.kingdomaward_id
                       left join ork_mundane m on awards.mundane_id = m.mundane_id
                       left join ork_award a on ka.award_id = a.award_id
-                    where crown_points > 0 and m.kingdom_id = $kingdom_id and peerage = 'None'
+                    where crown_points > 0 and m.kingdom_id IN ($kidList) and peerage = 'None'
                     group by m.mundane_id, a.award_id) dterms
                   group by mundane_id, peerage) ducal_terms
                 on m.mundane_id = ducal_terms.mundane_id
@@ -235,11 +238,11 @@ class Report  extends Ork3 {
                       left join ork_kingdomaward ka on awards.kingdomaward_id = ka.kingdomaward_id
                       left join ork_mundane m on awards.mundane_id = m.mundane_id
                       left join ork_award a on ka.award_id = a.award_id
-                    where crown_points > 0 and m.kingdom_id = $kingdom_id and peerage = 'Kingdom-Level-Award'
+                    where crown_points > 0 and m.kingdom_id IN ($kidList) and peerage = 'Kingdom-Level-Award'
                     group by m.mundane_id, a.award_id) kterms
                   group by mundane_id, peerage) kingdom_terms
                 on m.mundane_id = kingdom_terms.mundane_id
-              where m.kingdom_id = $kingdom_id and (ducal_terms.mundane_id is not null or kingdom_terms.mundane_id is not null)
+              where m.kingdom_id IN ($kidList) and (ducal_terms.mundane_id is not null or kingdom_terms.mundane_id is not null)
                 and (kingdom_points >= 4 or (kingdom_points + ducal_points) >= 6 or ducal_points >= 6)
                 order by m.mundane_id";
     logtrace("CrownQualedPlayerAwards", $sql);
@@ -276,7 +279,8 @@ class Report  extends Ork3 {
 			return $cache;
 
 		if (valid_id($request['KingdomId'])) {
-			$location_clause = " and m.kingdom_id = $request[KingdomId]";
+			$kidList = implode(',', array_map('intval', Ork3::$Lib->kingdom->GetStatsKingdomIds($request['KingdomId'])));
+			$location_clause = " and m.kingdom_id IN ($kidList)";
 		} else {
 			$order = "k.name, ";
 		}
@@ -359,7 +363,8 @@ class Report  extends Ork3 {
 		$location_clause = '';
 		$order = '';
 		if (valid_id($request['KingdomId'])) {
-			$location_clause = " and m.kingdom_id = " . intval($request['KingdomId']);
+			$kidList = implode(',', array_map('intval', Ork3::$Lib->kingdom->GetStatsKingdomIds($request['KingdomId'])));
+			$location_clause = " and m.kingdom_id IN (" . $kidList . ")";
 		} else {
 			$order = "k.name, ";
 		}
@@ -438,7 +443,8 @@ class Report  extends Ork3 {
 			return $this->applyViewerFlags($cache, $viewer_id);
 
 		if (valid_id($request['KingdomId'])) {
-			$location_clause = " AND m.kingdom_id = $request[KingdomId]";
+			$kidList = implode(',', array_map('intval', Ork3::$Lib->kingdom->GetStatsKingdomIds($request['KingdomId'])));
+			$location_clause = " AND m.kingdom_id IN ($kidList)";
 		}
 		if (valid_id($request['ParkId'])) {
 			$location_clause = " AND m.park_id = $request[ParkId]";
@@ -692,7 +698,8 @@ class Report  extends Ork3 {
 
 		$location_clause = '';
 		if (valid_id($request['KingdomId'])) {
-			$location_clause = " AND m.kingdom_id = " . (int)$request['KingdomId'];
+			$kidList = implode(',', array_map('intval', Ork3::$Lib->kingdom->GetStatsKingdomIds($request['KingdomId'])));
+			$location_clause = " AND m.kingdom_id IN (" . $kidList . ")";
 		}
 		if (valid_id($request['ParkId'])) {
 			$location_clause = " AND m.park_id = " . (int)$request['ParkId'];
@@ -766,7 +773,10 @@ class Report  extends Ork3 {
 	}
 
 	public function Guilds($request) {
-		if (valid_id($request['KingdomId'])) $where = "and k.kingdom_id = '$request[KingdomId]'";
+		if (valid_id($request['KingdomId'])) {
+			$kidList = implode(',', array_map('intval', Ork3::$Lib->kingdom->GetStatsKingdomIds($request['KingdomId'])));
+			$where = "and k.kingdom_id IN ($kidList)";
+		}
 		if (valid_id($request['ParkId'])) $where = "and p.park_id = '$request[ParkId]'";
 		if (valid_id($request['MundaneId'])) $where = "and m.mundane_id = '$request[MundaneId]'";
 
@@ -817,7 +827,10 @@ class Report  extends Ork3 {
 			return $cache;
 		$has_mundane = valid_id($request['MundaneId']);
 		if ($has_mundane) $mid = (int)$request['MundaneId'];
-		if (valid_id($request['KingdomId'])) $kingdom = " and m.kingdom_id = '$request[KingdomId]'";
+		$kidList = valid_id($request['KingdomId'])
+			? implode(',', array_map('intval', Ork3::$Lib->kingdom->GetStatsKingdomIds($request['KingdomId'])))
+			: '';
+		if (valid_id($request['KingdomId'])) $kingdom = " and m.kingdom_id IN ($kidList)";
 		if (valid_id($request['ParkId'])) $park = " and m.park_id = '$request[ParkId]'";
 		if (valid_id($request['EventId'])) $event = " and e.event_id = '$request[EventId]'";
 		if (valid_id($request['IncludeCompanies'])) $companies = " or u.type = 'Company' ";
@@ -826,7 +839,7 @@ class Report  extends Ork3 {
 		if (valid_id($request['ActiveOnly'])) $active_only = " and um.active = 'Active' ";
 		// Hide retired units from listings unless explicitly requested.
 		$unit_active = valid_id($request['IncludeRetired']) ? '' : " and u.active = 'Active' ";
-		if (valid_id($request['KingdomId'])) $activity_scope = " and a.kingdom_id = '$request[KingdomId]'";
+		if (valid_id($request['KingdomId'])) $activity_scope = " and a.kingdom_id IN ($kidList)";
 		elseif (valid_id($request['ParkId'])) $activity_scope = " and a.park_id = '$request[ParkId]'";
 
 		$name_where = '';
@@ -881,7 +894,7 @@ class Report  extends Ork3 {
 			$inner_scope_where = '';
 			if (valid_id($request['KingdomId'])) {
 				$inner_scope_join  = "join " . DB_PREFIX . "mundane m on m.mundane_id = um.mundane_id";
-				$inner_scope_where = " and m.kingdom_id = '" . (int)$request['KingdomId'] . "'";
+				$inner_scope_where = " and m.kingdom_id IN ($kidList)";
 			} elseif (valid_id($request['ParkId'])) {
 				$inner_scope_join  = "join " . DB_PREFIX . "mundane m on m.mundane_id = um.mundane_id";
 				$inner_scope_where = " and m.park_id = '" . (int)$request['ParkId'] . "'";
@@ -951,9 +964,9 @@ class Report  extends Ork3 {
 
 	public function AttendanceSummary($request) {
 		if (valid_id($request['EventId'])) $where = "where ssa.event_id = '" . mysql_real_escape_string($request['EventId']) . "'";
-		if (valid_id($request['KingdomId'])) $where = "where ssa.kingdom_id = '" . mysql_real_escape_string($request['KingdomId']) . "'";
+		if (valid_id($request['KingdomId'])) $where = "where ssa.kingdom_id IN (" . implode(',', array_map('intval', Ork3::$Lib->kingdom->GetStatsKingdomIds($request['KingdomId']))) . ")";
 		if (valid_id($request['ParkId'])) $where = "where ssa.park_id = '" . mysql_real_escape_string($request['ParkId']) . "'";
-    	if (valid_id($request['PrincipalityId'])) $where = "where ssa.kingdom_id = '" . mysql_real_escape_string($request['PrincipalityId']) . "'";
+    	if (valid_id($request['PrincipalityId'])) $where = "where ssa.kingdom_id IN (" . implode(',', array_map('intval', Ork3::$Lib->kingdom->GetStatsKingdomIds($request['PrincipalityId']))) . ")";
 		if ($request['NativePopulace'] && (valid_id($request['KingdomId']) || valid_id($request['ParkId']))) $where .= " and m.park_id = '" . mysql_real_escape_string($request['ParkId']) . "'";
 		if ($request['Waivered']) $where = (strlen($where)>0)?" and m.waivered = 1":"where m.waivered = 1";
 		/*
@@ -1124,7 +1137,7 @@ class Report  extends Ork3 {
 						$unit_clause
 					where a.date = '" . mysql_real_escape_string($request['Date']) . "'
 				";
-		if (valid_id($request['KingdomId'])) $sql .= " and a.kingdom_id = $request[KingdomId]";
+		if (valid_id($request['KingdomId'])) $sql .= " and a.kingdom_id IN (" . implode(',', array_map('intval', Ork3::$Lib->kingdom->GetStatsKingdomIds($request['KingdomId']))) . ")";
 		if (valid_id($request['ParkId'])) $sql .= " and a.park_id = $request[ParkId]";
 		if (valid_id($request['UnitId'])) $sql .= " and a.unit_id = $request[UnitId]";
 		if (valid_id($request['MundandeId'])) $sql .= " and a.mundane_id = $request[MundaneId]";
@@ -1301,8 +1314,9 @@ class Report  extends Ork3 {
 				$order_by = "p.name";
 				break;
 			case AUTH_KINGDOM:
-				$restrict_clause[] = "k.kingdom_id = '" . mysql_real_escape_string($request['Id']) . "'";
-				$dues_restrict_clause = "and (a.kingdom_id = '" . mysql_real_escape_string($request['Id']) . "' or a.park_id = '" . mysql_real_escape_string($request['Id']) . "')";
+				$kidList = implode(',', array_map('intval', Ork3::$Lib->kingdom->GetStatsKingdomIds($request['Id'])));
+				$restrict_clause[] = "k.kingdom_id IN ($kidList)";
+				$dues_restrict_clause = "and (a.kingdom_id IN ($kidList) or a.park_id = '" . mysql_real_escape_string($request['Id']) . "')";
 				$order_by = "k.name, p.name";
 				break;
 			case AUTH_EVENT:
@@ -1429,6 +1443,7 @@ class Report  extends Ork3 {
 		}
 
 		$escaped_kingdom_id = mysql_real_escape_string($request['KingdomId']);
+		$kidList = (int)$request['KingdomId']; // park-LIST display stays parent-only; principalities shown in their own sections + aggregates roll up elsewhere
 
 		// Only join mundane table when NativePopulace or Waivered filters are active
 		$mundane_join = (!empty($native_populace) || !empty($waivered_peeps))
@@ -1449,12 +1464,12 @@ class Report  extends Ork3 {
 									where
 										$native_populace
 										$waivered_peeps
-										a.kingdom_id = '$escaped_kingdom_id'
+										a.kingdom_id IN ($kidList)
 										and date >= '$per_period'
 										and a.mundane_id > 0
 									group by date_year, date_week3, mundane_id, a.park_id) mundanesbyweek
 								on p.park_id = mundanesbyweek.park_id
-					where p.kingdom_id = '$escaped_kingdom_id' and p.active = 'Active'
+					where p.kingdom_id IN ($kidList) and p.active = 'Active'
 					group by park_id
 					order by name";
 		logtrace('Report: GetKingdomParkAverages', array($request,$sql));
@@ -1483,6 +1498,7 @@ class Report  extends Ork3 {
 		if (strlen($request['KingdomId']) == 0) $request['KingdomId'] = '0';
 		$monthly_period = date("Y-m-d", strtotime("-1 year"));
 		$escaped_kingdom_id = mysql_real_escape_string($request['KingdomId']);
+		$kidList = (int)$request['KingdomId']; // park-LIST display stays parent-only; principalities shown in their own sections + aggregates roll up elsewhere
 
 		// AVG(distinct players per month) per park — matches the Park page hero stat formula.
 		// Divides by the number of months with actual attendance, not a fixed 12,
@@ -1492,7 +1508,7 @@ class Report  extends Ork3 {
 						SELECT a.date_year, a.date_month, a.park_id,
 						       COUNT(DISTINCT a.mundane_id) AS monthly_unique
 						FROM " . DB_PREFIX . "attendance a
-						WHERE a.kingdom_id = '$escaped_kingdom_id'
+						WHERE a.kingdom_id IN ($kidList)
 						  AND a.date > '$monthly_period'
 						  AND a.mundane_id > 0
 						GROUP BY a.date_year, a.date_month, a.park_id
@@ -1664,9 +1680,9 @@ class Report  extends Ork3 {
 	public function GetDistinctPlayerStats($request) {
 		$where = '';
 		if (valid_id($request['EventId'])) $where = "AND a.event_id = '" . mysql_real_escape_string($request['EventId']) . "'";
-		if (valid_id($request['KingdomId'])) $where = "AND a.kingdom_id = '" . mysql_real_escape_string($request['KingdomId']) . "'";
+		if (valid_id($request['KingdomId'])) $where = "AND a.kingdom_id IN (" . implode(',', array_map('intval', Ork3::$Lib->kingdom->GetStatsKingdomIds($request['KingdomId']))) . ")";
 		if (valid_id($request['ParkId'])) $where = "AND a.park_id = '" . mysql_real_escape_string($request['ParkId']) . "'";
-		if (valid_id($request['PrincipalityId'])) $where = "AND a.kingdom_id = '" . mysql_real_escape_string($request['PrincipalityId']) . "'";
+		if (valid_id($request['PrincipalityId'])) $where = "AND a.kingdom_id IN (" . implode(',', array_map('intval', Ork3::$Lib->kingdom->GetStatsKingdomIds($request['PrincipalityId']))) . ")";
 
 		$report_to = (!empty($request['ReportFromDate']) && $request['ReportFromDate'] !== date('Y-m-d'))
 			? $request['ReportFromDate'] : date('Y-m-d');
@@ -1710,9 +1726,9 @@ class Report  extends Ork3 {
 
 	public function GetMonthlyChartData($request) {
 		$where = '';
-		if (valid_id($request['KingdomId'])) $where = "AND a.kingdom_id = '" . mysql_real_escape_string($request['KingdomId']) . "'";
+		if (valid_id($request['KingdomId'])) $where = "AND a.kingdom_id IN (" . implode(',', array_map('intval', Ork3::$Lib->kingdom->GetStatsKingdomIds($request['KingdomId']))) . ")";
 		if (valid_id($request['ParkId'])) $where = "AND a.park_id = '" . mysql_real_escape_string($request['ParkId']) . "'";
-		if (valid_id($request['PrincipalityId'])) $where = "AND a.kingdom_id = '" . mysql_real_escape_string($request['PrincipalityId']) . "'";
+		if (valid_id($request['PrincipalityId'])) $where = "AND a.kingdom_id IN (" . implode(',', array_map('intval', Ork3::$Lib->kingdom->GetStatsKingdomIds($request['PrincipalityId']))) . ")";
 
 		$report_to = (!empty($request['ReportFromDate']) && $request['ReportFromDate'] !== date('Y-m-d'))
 			? $request['ReportFromDate'] : date('Y-m-d');
@@ -1779,7 +1795,8 @@ class Report  extends Ork3 {
     		    $park_comparator = " and a.park_id = '" . mysql_real_escape_string($request['ParkId']) . "' ";
     		}
 		} else if (strlen($request['KingdomId']) > 0 && $request['KingdomId'] > 0) {
-			$location = " and m.kingdom_id = '" . mysql_real_escape_string($request['KingdomId']) . "'";
+			$kidList = implode(',', array_map('intval', Ork3::$Lib->kingdom->GetStatsKingdomIds($request['KingdomId'])));
+			$location = " and m.kingdom_id IN ($kidList)";
     		if (valid_id($request['ByKingdom'])) {
     		    $park_list = Ork3::$Lib->Kingdom->GetParks($request);
     		    $parks = array();
@@ -1798,7 +1815,7 @@ class Report  extends Ork3 {
 		if (valid_id($request['ParkId'])) {
 			$activity_location = " and a.park_id = '" . mysql_real_escape_string($request['ParkId']) . "'";
 		} else if (strlen($request['KingdomId']) > 0 && $request['KingdomId'] > 0) {
-			$activity_location = " and a.kingdom_id = '" . mysql_real_escape_string($request['KingdomId']) . "'";
+			$activity_location = " and a.kingdom_id IN (" . implode(',', array_map('intval', Ork3::$Lib->kingdom->GetStatsKingdomIds($request['KingdomId']))) . ")";
 		} else {
 			$activity_location = "";
 		}
@@ -1938,7 +1955,10 @@ class Report  extends Ork3 {
 
 	public function GetReeveQualified($request) {
 		$where = '';
-		if (valid_id($request['KingdomId'])) $where = "and k.kingdom_id = '$request[KingdomId]'";
+		if (valid_id($request['KingdomId'])) {
+			$kidList = implode(',', array_map('intval', Ork3::$Lib->kingdom->GetStatsKingdomIds($request['KingdomId'])));
+			$where = "and k.kingdom_id IN ($kidList)";
+		}
 		if (valid_id($request['ParkId'])) $where = "and p.park_id = '$request[ParkId]'";
 
 		$sql = "select m.persona, m.mundane_id, m.reeve_qualified_until, k.kingdom_id, k.name as kingdom_name, k.parent_kingdom_id, p.park_id, p.name as park_name
@@ -1976,7 +1996,10 @@ class Report  extends Ork3 {
 
 	public function GetCorporaQualified($request) {
 		$where = '';
-		if (valid_id($request['KingdomId'])) $where = "and k.kingdom_id = '$request[KingdomId]'";
+		if (valid_id($request['KingdomId'])) {
+			$kidList = implode(',', array_map('intval', Ork3::$Lib->kingdom->GetStatsKingdomIds($request['KingdomId'])));
+			$where = "and k.kingdom_id IN ($kidList)";
+		}
 		if (valid_id($request['ParkId'])) $where = "and p.park_id = '$request[ParkId]'";
 
 		$sql = "select m.persona, m.mundane_id, m.corpora_qualified_until, k.kingdom_id, k.name as kingdom_name, k.parent_kingdom_id, p.park_id, p.name as park_name
@@ -2125,6 +2148,7 @@ class Report  extends Ork3 {
 			return $cache;
 
 		$kingdom_id  = mysql_real_escape_string($request['KingdomId']);
+		$kidList = implode(',', array_map('intval', Ork3::$Lib->kingdom->GetStatsKingdomIds($request['KingdomId'])));
 		$start_date  = mysql_real_escape_string($request['StartDate']);
 		$end_date    = mysql_real_escape_string($request['EndDate']);
 		$period_expr = $this->_periodExpr($request['Period']);
@@ -2144,7 +2168,7 @@ class Report  extends Ork3 {
 				FROM " . DB_PREFIX . "attendance a
 					INNER JOIN " . DB_PREFIX . "park p ON a.park_id = p.park_id
 					LEFT JOIN " . DB_PREFIX . "mundane m ON a.mundane_id = m.mundane_id
-				WHERE a.kingdom_id = '$kingdom_id'
+				WHERE a.kingdom_id IN ($kidList)
 					AND a.date >= '$start_date'
 					AND a.date <= '$end_date'
 					AND a.park_id > 0
@@ -2179,7 +2203,7 @@ class Report  extends Ork3 {
 				FROM " . DB_PREFIX . "attendance a2
 					INNER JOIN " . DB_PREFIX . "park p2 ON a2.park_id = p2.park_id
 					LEFT JOIN " . DB_PREFIX . "mundane m2 ON a2.mundane_id = m2.mundane_id
-				WHERE a2.kingdom_id = '$kingdom_id'
+				WHERE a2.kingdom_id IN ($kidList)
 					AND a2.date >= '$start_date'
 					AND a2.date <= '$end_date'
 					AND a2.park_id > 0
@@ -2206,7 +2230,7 @@ class Report  extends Ork3 {
 						INNER JOIN " . DB_PREFIX . "park p ON a.park_id = p.park_id
 						INNER JOIN " . DB_PREFIX . "mundane m ON a.mundane_id = m.mundane_id
 							AND m.park_id = a.park_id
-					WHERE a.kingdom_id = '$kingdom_id'
+					WHERE a.kingdom_id IN ($kidList)
 						AND a.date >= '$start_date'
 						AND a.date <= '$end_date'
 						AND a.park_id > 0
@@ -2252,6 +2276,7 @@ class Report  extends Ork3 {
 			return $cache;
 
 		$kingdom_id     = intval($request['KingdomId']);
+		$kidList = implode(',', array_map('intval', Ork3::$Lib->kingdom->GetStatsKingdomIds($request['KingdomId'])));
 		$park_id        = intval($request['ParkId']);
 		$start_date     = mysql_real_escape_string($request['StartDate']);
 		$end_date       = mysql_real_escape_string($request['EndDate']);
@@ -2261,21 +2286,21 @@ class Report  extends Ork3 {
 		if ($park_id > 0) {
 			$scope_where = "AND fp.park_id = $park_id";
 		} else {
-			$scope_where = "AND pk.kingdom_id = $kingdom_id";
+			$scope_where = "AND pk.kingdom_id IN ($kidList)";
 		}
 
 		// Park scope applied to the outer parks table in the summary query.
 		if ($park_id > 0) {
 			$park_scope_where = "AND p.park_id = $park_id";
 		} else {
-			$park_scope_where = "AND p.kingdom_id = $kingdom_id";
+			$park_scope_where = "AND p.kingdom_id IN ($kidList)";
 		}
 
 		// Visit counts: only count visits at parks within the target kingdom during the range.
 		if ($park_id > 0) {
 			$visit_scope = "AND a_range.park_id = $park_id";
 		} else {
-			$visit_scope = "AND a_range.kingdom_id = $kingdom_id";
+			$visit_scope = "AND a_range.kingdom_id IN ($kidList)";
 		}
 
 		// Summary query: all active parks with new player stats; parks with no new players show zeros.
@@ -2496,6 +2521,7 @@ class Report  extends Ork3 {
 
 		$park_id    = mysql_real_escape_string($request['ParkId']);
 		$kingdom_id = mysql_real_escape_string($request['KingdomId']);
+		$kidList = implode(',', array_map('intval', Ork3::$Lib->kingdom->GetStatsKingdomIds($request['KingdomId'])));
 		$start_date = mysql_real_escape_string($request['StartDate']);
 		$end_date   = mysql_real_escape_string($request['EndDate']);
 		$min_signins = intval($request['MinimumSignIns']);
@@ -2511,7 +2537,7 @@ class Report  extends Ork3 {
 				FROM " . DB_PREFIX . "attendance a2" .
 				($local_only ? " INNER JOIN " . DB_PREFIX . "mundane m2 ON a2.mundane_id = m2.mundane_id AND m2.park_id = '$park_id'" : "") . "
 				WHERE a2.park_id = '$park_id'
-					AND a2.kingdom_id = '$kingdom_id'
+					AND a2.kingdom_id IN ($kidList)
 					AND a2.date >= '$start_date'
 					AND a2.date <= '$end_date'
 					AND a2.mundane_id > 0
@@ -2535,7 +2561,7 @@ class Report  extends Ork3 {
 						AND d.revoked != 1
 						AND (d.dues_for_life = 1 OR d.dues_until >= CURDATE())
 				WHERE a.park_id = '$park_id'
-					AND a.kingdom_id = '$kingdom_id'
+					AND a.kingdom_id IN ($kidList)
 					AND a.date >= '$start_date'
 					AND a.date <= '$end_date'
 					AND a.mundane_id > 0
@@ -2932,6 +2958,7 @@ class Report  extends Ork3 {
 		}
 
 		// Knights for the dropdown — kingdom-scoped so the selector stays useful.
+		$kidList = implode(',', array_map('intval', Ork3::$Lib->kingdom->GetStatsKingdomIds($kingdom_id)));
 		$knights_sql = "SELECT DISTINCT
 				m.mundane_id,
 				m.persona
@@ -2940,7 +2967,7 @@ class Report  extends Ork3 {
 				LEFT JOIN " . DB_PREFIX . "award alias ON alias.award_id = ma.alias_award_id
 				JOIN " . DB_PREFIX . "mundane m ON m.mundane_id = ma.mundane_id
 			WHERE COALESCE(alias.peerage, a.peerage) = 'Knight'
-				AND m.kingdom_id = $kingdom_id
+				AND m.kingdom_id IN ($kidList)
 				AND (ma.revoked = 0 OR ma.revoked IS NULL)
 			ORDER BY m.persona";
 
@@ -3002,7 +3029,7 @@ class Report  extends Ork3 {
 		if (valid_id($request['ParkId'])) {
 			$location = " and m.park_id = '" . mysql_real_escape_string($request['ParkId']) . "'";
 		} else if (valid_id($request['KingdomId'])) {
-			$location = " and m.kingdom_id = '" . mysql_real_escape_string($request['KingdomId']) . "'";
+			$location = " and m.kingdom_id IN (" . implode(',', array_map('intval', Ork3::$Lib->kingdom->GetStatsKingdomIds($request['KingdomId']))) . ")";
 		} else {
 			return array('Status' => InvalidParameter());
 		}
@@ -3545,7 +3572,7 @@ class Report  extends Ork3 {
 
 	public function GetInactiveParks($request) {
 		$kingdom_id = valid_id($request['KingdomId'] ?? 0) ? (int)$request['KingdomId'] : 0;
-		$kingdom_clause = $kingdom_id ? " AND p.kingdom_id = $kingdom_id" : '';
+		$kingdom_clause = $kingdom_id ? " AND p.kingdom_id IN (" . implode(',', array_map('intval', Ork3::$Lib->kingdom->GetStatsKingdomIds($kingdom_id))) . ")" : '';
 
 		$sql = "
 			SELECT p.park_id, p.name AS park_name, p.active, p.modified,
@@ -3839,7 +3866,7 @@ class Report  extends Ork3 {
 		$list  = "'" . implode("','", array_map('mysql_real_escape_string', $peerages)) . "'";
 		$start = mysql_real_escape_string($win['WeekStart']);
 		$end   = mysql_real_escape_string($win['WeekEnd']);
-		$kid_clause = $kingdom_id ? ' AND m.kingdom_id = ' . (int)$kingdom_id : '';
+		$kid_clause = $kingdom_id ? ' AND m.kingdom_id IN (' . implode(',', array_map('intval', Ork3::$Lib->kingdom->GetStatsKingdomIds($kingdom_id))) . ')' : '';
 		$sql = "SELECT ma.awards_id, ma.date, ma.mundane_id, m.persona,
 					   p.park_id, p.name AS park_name,
 					   k.kingdom_id, k.name AS kingdom_name,
@@ -3884,7 +3911,7 @@ class Report  extends Ork3 {
 		$start = mysql_real_escape_string($win['StartDt']);
 		$end   = mysql_real_escape_string($win['EndDt']);
 		$limit = intval($limit);
-		$kid_clause = $kingdom_id ? ' AND e.kingdom_id = ' . (int)$kingdom_id : '';
+		$kid_clause = $kingdom_id ? ' AND e.kingdom_id IN (' . implode(',', array_map('intval', Ork3::$Lib->kingdom->GetStatsKingdomIds($kingdom_id))) . ')' : '';
 		$sql = "SELECT e.event_id, e.name AS event_name,
 					   e.park_id, p.name AS park_name,
 					   e.kingdom_id, k.name AS kingdom_name,
@@ -3928,7 +3955,7 @@ class Report  extends Ork3 {
 		$start = mysql_real_escape_string($win['WeekStart']);
 		$end   = mysql_real_escape_string($win['WeekEnd']);
 		$limit = intval($limit);
-		$kid_clause = $kingdom_id ? ' AND a.kingdom_id = ' . (int)$kingdom_id : '';
+		$kid_clause = $kingdom_id ? ' AND a.kingdom_id IN (' . implode(',', array_map('intval', Ork3::$Lib->kingdom->GetStatsKingdomIds($kingdom_id))) . ')' : '';
 		$sql = "SELECT p.park_id, p.name AS park_name, p.has_heraldry,
 					   k.kingdom_id, k.name AS kingdom_name,
 					   COUNT(DISTINCT a.mundane_id) AS attendance
@@ -3967,7 +3994,7 @@ class Report  extends Ork3 {
 		// Kingdom filter applies to the in-window attendance (where they first
 		// signed in). The prior-history NOT EXISTS subquery stays global — we
 		// want "truly new players who started here", not "new to this kingdom".
-		$kid_clause = $kingdom_id ? ' AND a_in.kingdom_id = ' . (int)$kingdom_id : '';
+		$kid_clause = $kingdom_id ? ' AND a_in.kingdom_id IN (' . implode(',', array_map('intval', Ork3::$Lib->kingdom->GetStatsKingdomIds($kingdom_id))) . ')' : '';
 		$sql = "SELECT m.mundane_id, m.persona,
 					   p.park_id, p.name AS park_name,
 					   k.kingdom_id, k.name AS kingdom_name,
@@ -4013,7 +4040,7 @@ class Report  extends Ork3 {
 		// Kingdom filter applies to the in-window attendance. The "last prior
 		// attendance" subquery stays global so the gap reflects their TRUE last
 		// sign-in anywhere, not their last at this kingdom specifically.
-		$kid_clause = $kingdom_id ? ' AND a_in.kingdom_id = ' . (int)$kingdom_id : '';
+		$kid_clause = $kingdom_id ? ' AND a_in.kingdom_id IN (' . implode(',', array_map('intval', Ork3::$Lib->kingdom->GetStatsKingdomIds($kingdom_id))) . ')' : '';
 		$sql = "SELECT X.* FROM (
 				  SELECT m.mundane_id, m.persona,
 						 MIN(a_in.date) AS return_date,
@@ -4069,7 +4096,7 @@ class Report  extends Ork3 {
 		$end   = mysql_real_escape_string($win['EndDt']);
 		$mul   = intval($multiple);
 		if ($mul <= 0) $mul = 25;
-		$kid_clause = $kingdom_id ? ' AND e.kingdom_id = ' . (int)$kingdom_id : '';
+		$kid_clause = $kingdom_id ? ' AND e.kingdom_id IN (' . implode(',', array_map('intval', Ork3::$Lib->kingdom->GetStatsKingdomIds($kingdom_id))) . ')' : '';
 		$sql = "SELECT * FROM (
 				  SELECT e.event_id, e.name AS event_name,
 						 e.park_id, p.name AS park_name,

--- a/system/lib/ork3/common.php
+++ b/system/lib/ork3/common.php
@@ -503,13 +503,6 @@ class Common
 		$this->create_officer( $kingdom_id, $park_id, 'Prime Minister', 'create' );
 		$this->create_officer( $kingdom_id, $park_id, 'Champion', null );
 		$this->create_officer( $kingdom_id, $park_id, 'GMR', null );
-		if ( valid_id( $for_principality ) ) {
-			$this->create_officer( $kingdom_id, $park_id, 'Monarch', 'create', 1, $principality_id );
-			$this->create_officer( $kingdom_id, $park_id, 'Regent', 'create', 1, $principality_id );
-			$this->create_officer( $kingdom_id, $park_id, 'Prime Minister', 'create', 1, $principality_id );
-			$this->create_officer( $kingdom_id, $park_id, 'Champion', null, 1, $principality_id );
-			$this->create_officer( $kingdom_id, $park_id, 'GMR', null, 1, $principality_id );
-		}
 	}
 
 	private function create_officer( $kingdom_id, $park_id, $role, $authorization, $system = 0, $principality_id = 0 )


### PR DESCRIPTION
## Summary

A batch of Kingdom-profile enhancements and bugfixes (the `misc-fixes-06-03` branch), centered on principalities, statistics rollups, and the revised Kingdom profile.

## Enhancements
- **Include Principality in Statistics** — per-kingdom admin toggle (`IncludePrincipalityInStatistics`); when on, kingdom-scoped stats/reports/counts fold in active child-principality data. Park-list display methods stay parent-only (only aggregates roll up) to avoid double-counting.
- **Principalities in the Kingdom Parks tab** — principality parks render in their own grouped tile/table sections under the Parks tab, with per-principality full-stats rollups and steel-blue map pins + legend.
- **Kingdom profile polish** — Recommendations panel lazy-loads with first-paint count badges; rec Park column; awards-config admin UX improvements.
- **ORKremental** — a hidden incremental game at `Reports/orkremental`.

## Bugfixes
- **Principality officer authority** — parent-kingdom officers now hold authority over principalities (and their parks) via `HasAuthority` `AUTH_KINGDOM` → `parent_kingdom_id` traversal, guarded against cyclic/corrupt parent references with a visited-set + depth cap.
- **Kingdom award Title (`is_title`) override** — per-kingdom override now persists and is read authoritatively (`ka.is_title`/`ka.title_class`), with backfill migration.
- **Principality officer/award defects** and **Kingdom awards-config tab UX** fixes.

## Notes
- Includes two SQL migrations under `docs/superpowers/migrations/` (principality-in-statistics config; kingdomaward is-title authoritative + backfill).
- No schema-breaking changes to existing columns; new behavior is opt-in per kingdom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
