### PR TITLE
Move Player fixes

### DIFF
--- a/db-migrations/2026-06-06-trim-persona-whitespace.sql
+++ b/db-migrations/2026-06-06-trim-persona-whitespace.sql
@@ -1,0 +1,9 @@
+-- Trim stray leading/trailing whitespace from player personas.
+-- Leading spaces (~60 rows) sorted a persona ahead of every letter, so e.g.
+-- " Sir Baron Rigor Stormblade" floated to the top of alphabetical player-search
+-- dropdowns (Move Player). Trailing spaces (~1500 rows) were cosmetic but are
+-- cleaned here too. Re-runnable: once trimmed, the WHERE clause matches nothing.
+UPDATE ork_mundane
+   SET persona = TRIM(persona)
+ WHERE persona <> TRIM(persona)
+    OR persona LIKE '% ';

--- a/orkui/controller/controller.KingdomAjax.php
+++ b/orkui/controller/controller.KingdomAjax.php
@@ -361,12 +361,22 @@ class Controller_KingdomAjax extends Controller {
 			$dest_park_id = (int)($_POST['DestParkId'] ?? 0);
 			if (!valid_id($mundane_id))   { echo json_encode(['status' => 1, 'error' => 'Select a player.']);           exit; }
 			if (!valid_id($dest_park_id)) { echo json_encode(['status' => 1, 'error' => 'Select a destination park.']); exit; }
-			// Auth: look up player's current kingdom and require kingdom-level authority over it
+			// Auth: allow the move when the actor has kingdom-level authority over EITHER the
+			// player's current (source) kingdom — moving/releasing one of your own members — OR
+			// the destination park's kingdom — claiming a player into your kingdom. This mirrors
+			// Player::MovePlayer (and the Park/Player move endpoints), which authorize on
+			// destination OR source. A source-only check wrongly blocked officers from claiming
+			// players who belong to another kingdom.
 			global $DB;
 			$DB->Clear();
 			$plrKingdom = $DB->DataSet("SELECT kingdom_id FROM " . DB_PREFIX . "mundane WHERE mundane_id = {$mundane_id} LIMIT 1");
 			$player_kingdom_id = ($plrKingdom && $plrKingdom->Next()) ? (int)$plrKingdom->kingdom_id : 0;
-			if (!$player_kingdom_id || !Ork3::$Lib->authorization->HasAuthority($uid, AUTH_KINGDOM, $player_kingdom_id, AUTH_EDIT)) {
+			$DB->Clear();
+			$destKingdom = $DB->DataSet("SELECT kingdom_id FROM " . DB_PREFIX . "park WHERE park_id = {$dest_park_id} LIMIT 1");
+			$dest_kingdom_id = ($destKingdom && $destKingdom->Next()) ? (int)$destKingdom->kingdom_id : 0;
+			$canSource = $player_kingdom_id && Ork3::$Lib->authorization->HasAuthority($uid, AUTH_KINGDOM, $player_kingdom_id, AUTH_EDIT);
+			$canDest   = $dest_kingdom_id   && Ork3::$Lib->authorization->HasAuthority($uid, AUTH_KINGDOM, $dest_kingdom_id, AUTH_EDIT);
+			if (!$canSource && !$canDest) {
 				echo json_encode(['status' => 5, 'error' => 'Not authorized to move this player.']); exit;
 			}
 			$r = $this->Player->move_player(['Token' => $this->session->token, 'MundaneId' => $mundane_id, 'ParkId' => $dest_park_id]);
@@ -605,6 +615,8 @@ class Controller_KingdomAjax extends Controller {
 			foreach ($r['Parks'] ?? [] as $park) {
 				$parks[] = ['ParkId' => $park['ParkId'], 'Name' => $park['Name']];
 			}
+			// Sort alphabetically by name so the dropdowns are easy to scan.
+			usort($parks, function ($a, $b) { return strcasecmp($a['Name'], $b['Name']); });
 			echo json_encode(['status' => 0, 'parks' => $parks]);
 		} elseif ($action === 'parktitles') {
 			$result = Ork3::$Lib->kingdom->GetKingdomParkTitles(['KingdomId' => $kingdom_id]);

--- a/orkui/template/revised-frontend/script/revised.js
+++ b/orkui/template/revised-frontend/script/revised.js
@@ -11109,7 +11109,7 @@ window.pnCloseUnitCreateModal = function() {
             } else {
                 kid = KnConfig.kingdomId; scope = 'own';                     // within/out: locked to this kingdom
             }
-            return PSEARCH_BASE + kid + '&scope=' + scope + '&include_inactive=1'
+            return PSEARCH_BASE + kid + '&scope=' + scope + '&include_inactive=1&include_suspended=1'
                 + (sel.parkId ? '&park_id=' + sel.parkId : '')
                 + '&q=' + encodeURIComponent(term);
         }
@@ -11123,8 +11123,9 @@ window.pnCloseUnitCreateModal = function() {
                     el.innerHTML = (data && data.length)
                         ? data.map(function(p) {
                             var inactive = p.Active === 0 ? ' <span style="color:#e53e3e;font-size:10px;font-weight:600">inactive</span>' : '';
-                            return '<div class="kn-ac-item" data-id="' + p.MundaneId + '" data-name="' + encodeURIComponent(p.Persona) + '">'
-                                + escHtml(p.Persona) + ' <span style="color:#a0aec0;font-size:11px">(' + escHtml(p.KAbbr || '') + ':' + escHtml(p.PAbbr || '') + ')</span>' + inactive + '</div>';
+                            var suspended = p.Suspended === 1 ? ' <span style="margin-left:6px;background:#c53030;color:#fff;font-size:10px;font-weight:600;padding:1px 5px;border-radius:3px">suspended</span>' : '';
+                            return '<div class="kn-ac-item' + (p.Suspended === 1 ? ' kn-ac-suspended' : '') + '" data-id="' + p.MundaneId + '" data-name="' + encodeURIComponent(p.Persona) + '">'
+                                + escHtml(p.Persona) + ' <span style="color:#a0aec0;font-size:11px">(' + escHtml(p.KAbbr || '') + ':' + escHtml(p.PAbbr || '') + ')</span>' + suspended + inactive + '</div>';
                         }).join('')
                         : '<div class="kn-ac-item" style="color:#a0aec0;cursor:default">No players found</div>';
                     el.classList.add('kn-ac-open');
@@ -11489,8 +11490,8 @@ window.pnCloseUnitCreateModal = function() {
     if (typeof PkConfig === 'undefined' || !PkConfig.canAdmin) return;
 
     var MOVE_URL        = PkConfig.uir + 'ParkAjax/park/' + PkConfig.parkId + '/moveplayer';
-    var PSEARCH_EXCLUDE = PkConfig.uir + 'ParkAjax/park/' + PkConfig.parkId + '/playersearch&scope=exclude&include_inactive=1&q=';
-    var PSEARCH_OWN     = PkConfig.uir + 'ParkAjax/park/' + PkConfig.parkId + '/playersearch&scope=own&include_inactive=1&q=';
+    var PSEARCH_EXCLUDE = PkConfig.uir + 'ParkAjax/park/' + PkConfig.parkId + '/playersearch&scope=exclude&include_inactive=1&include_suspended=1&q=';
+    var PSEARCH_OWN     = PkConfig.uir + 'ParkAjax/park/' + PkConfig.parkId + '/playersearch&scope=own&include_inactive=1&include_suspended=1&q=';
     var KPSEARCH_BASE   = PkConfig.uir + 'KingdomAjax/playersearch/';
 
     var pkPlayerCascade = null, pkDestCascade = null;
@@ -11583,7 +11584,7 @@ window.pnCloseUnitCreateModal = function() {
         if (mpMode === 'in') {
             var sel = pkPlayerCascade ? pkPlayerCascade.get() : { kingdomId: 0, parkId: 0 };
             if (sel.kingdomId) {
-                return KPSEARCH_BASE + sel.kingdomId + '&scope=own&include_inactive=1'
+                return KPSEARCH_BASE + sel.kingdomId + '&scope=own&include_inactive=1&include_suspended=1'
                     + (sel.parkId ? '&park_id=' + sel.parkId : '') + '&q=' + encodeURIComponent(term);
             }
             return PSEARCH_EXCLUDE + encodeURIComponent(term);
@@ -11646,10 +11647,17 @@ window.pnCloseUnitCreateModal = function() {
                             results.forEach(function(player) {
                                 var item = document.createElement('div');
                                 item.className = 'pk-ac-item';
+                                if (player.Suspended === 1) item.classList.add('pk-ac-suspended');
                                 var abbr = (player.PAbbr && player.KAbbr)
                                     ? ' — ' + player.PAbbr + ' (' + player.KAbbr + ')'
                                     : (player.ParkName ? ' — ' + player.ParkName : '');
                                 item.textContent = player.Persona + abbr;
+                                if (player.Suspended === 1) {
+                                    var sbadge = document.createElement('span');
+                                    sbadge.textContent = 'suspended';
+                                    sbadge.style.cssText = 'margin-left:6px;background:#c53030;color:#fff;font-size:10px;font-weight:600;padding:1px 5px;border-radius:3px';
+                                    item.appendChild(sbadge);
+                                }
                                 if (player.Active === 0) {
                                     var badge = document.createElement('span');
                                     badge.textContent = ' inactive';

--- a/orkui/template/revised-frontend/style/revised.css
+++ b/orkui/template/revised-frontend/style/revised.css
@@ -2805,6 +2805,11 @@ html[data-theme="dark"] .kn-award-type-btn.kn-active { border-color:#63b3ed; bac
 }
 .kn-ac-item { padding:8px 12px; font-size:13px; cursor:pointer; color:#2d3748; border-bottom:1px solid #f7fafc; }
 .kn-ac-item:hover, .kn-ac-item:focus, .kn-ac-item.kn-ac-focused { background:#ebf4ff; color:var(--kn-accent-mid, #276749); outline:none; }
+/* Suspended players in the Move Player search: light-red row tint */
+.kn-ac-item.kn-ac-suspended { background:#fff5f5; }
+.kn-ac-item.kn-ac-suspended:hover, .kn-ac-item.kn-ac-suspended:focus, .kn-ac-item.kn-ac-suspended.kn-ac-focused { background:#fed7d7; color:#9b2c2c; }
+html[data-theme="dark"] .kn-ac-item.kn-ac-suspended { background:rgba(197,48,48,0.18); }
+html[data-theme="dark"] .kn-ac-item.kn-ac-suspended:hover, html[data-theme="dark"] .kn-ac-item.kn-ac-suspended:focus, html[data-theme="dark"] .kn-ac-item.kn-ac-suspended.kn-ac-focused { background:rgba(197,48,48,0.30); color:#feb2b2; }
 .kn-award-success { background:#f0fff4; border:1px solid #9ae6b4; border-radius:6px; padding:8px 12px; margin-bottom:12px; color:var(--kn-accent, #276749); font-size:13px; }
 .kn-btn-ghost { background:transparent; border:1px solid transparent; color:#4a5568; padding:7px 14px; border-radius:6px; cursor:pointer; font-size:13px; }
 .kn-btn-ghost:hover { background:#f7fafc; border-color:#e2e8f0; }
@@ -3866,6 +3871,11 @@ html[data-theme="dark"] .pk-stat-tip-text::after { border-top-color: #e2e8f0; }
 .pk-officer-chip.pk-selected { background:#ebf4ff; border-color:#90cdf4; color:#0891b2; font-weight:600; }
 .pk-ac-item { padding:8px 12px; font-size:13px; cursor:pointer; color:#2d3748; border-bottom:1px solid #f7fafc; }
 .pk-ac-item:hover, .pk-ac-item:focus { background:#ebf4ff; color:#0891b2; outline:none; }
+/* Suspended players in the Move Player search: light-red row tint */
+.pk-ac-item.pk-ac-suspended { background:#fff5f5; }
+.pk-ac-item.pk-ac-suspended:hover, .pk-ac-item.pk-ac-suspended:focus, .pk-ac-item.pk-ac-suspended.pk-ac-focused { background:#fed7d7; color:#9b2c2c; }
+html[data-theme="dark"] .pk-ac-item.pk-ac-suspended { background:rgba(197,48,48,0.18); }
+html[data-theme="dark"] .pk-ac-item.pk-ac-suspended:hover, html[data-theme="dark"] .pk-ac-item.pk-ac-suspended:focus, html[data-theme="dark"] .pk-ac-item.pk-ac-suspended.pk-ac-focused { background:rgba(197,48,48,0.30); color:#feb2b2; }
 .pk-award-success { background:#f0fff4; border:1px solid #9ae6b4; border-radius:6px; padding:8px 12px; margin-bottom:12px; color:#276749; font-size:13px; }
 .pk-btn-ghost { background:transparent; border:1px solid transparent; color:#4a5568; padding:7px 14px; border-radius:6px; cursor:pointer; font-size:13px; }
 .pk-btn-ghost:hover { background:#f7fafc; border-color:#e2e8f0; }

--- a/system/lib/ork3/class.Player.php
+++ b/system/lib/ork3/class.Player.php
@@ -628,7 +628,7 @@ class Player extends Ork3 {
 				$this->mundane->surname = $request['Surname'];
 				$this->mundane->other_name = $request['OtherName'];
 				$this->mundane->username = trim($request['UserName']);
-				$this->mundane->persona = $request['Persona'];
+				$this->mundane->persona = trim($request['Persona']);
 				$this->mundane->email = $request['Email'];
 				$this->mundane->park_id = $request['ParkId'];
 				$this->mundane->kingdom_id = $park->kingdom_id;
@@ -1182,7 +1182,7 @@ class Player extends Ork3 {
 						return InvalidParameter('Persona', ProfanityFilter::ERROR_MESSAGE);
 					}
 				}
-				$this->mundane->persona = is_null($request['Persona'])?$this->mundane->persona:$request['Persona'];
+				$this->mundane->persona = is_null($request['Persona'])?$this->mundane->persona:trim($request['Persona']);
 				$this->mundane->pronoun_id = is_null($request['PronounId'])?$this->mundane->pronoun_id:$request['PronounId'];
 				$this->mundane->pronoun_custom = is_null($request['PronounCustom'])?$this->mundane->pronoun_custom:$request['PronounCustom'];
 


### PR DESCRIPTION
Move Player fixes: allow claiming outside players, list suspended, sort dropdowns, clean personas

- KingdomAjax/moveplayer: authorize on source OR destination kingdom (was source-only), so officers can claim players from another kingdom into their own. Mirrors Player::MovePlayer and the Park/Player move endpoints.
- Park & Kingdom Move Player search: include suspended players (the backends already supported include_suspended) with a light-red row tint + badge.
- KingdomAjax/getparks: sort parks alphabetically so all move dropdowns scan cleanly (in-kingdom, within-kingdom, outside-kingdom).
- Player create/update: trim persona on save to stop stray leading/trailing whitespace (a leading space sorted personas above every letter).
- Add migration to trim existing persona whitespace (~1,555 rows, re-runnable).