### PR TITLE
Enhancement: Award admin subsections, recommendation circle filters, and State of Amtgard 12-month cap

### DIFF
--- a/orkui/controller/controller.Admin.php
+++ b/orkui/controller/controller.Admin.php
@@ -2654,6 +2654,9 @@ class Controller_Admin extends Controller {
 			$this->data['MinDate'] = (string)$_rng->mn;
 			$this->data['MaxDate'] = (string)$_rng->mx;
 		}
+		// 12-month cap on the reporting window in production (server-crash guard);
+		// 0 = unlimited for local/dev. Mirrors the hard limit in AdminAjax::stateofamtgard.
+		$this->data['RangeLimitMonths'] = (getenv('ENVIRONMENT') === 'DEV') ? 0 : 12;
 		$this->data['page_title'] = 'State of Amtgard Report';
 		$this->template = '../revised-frontend/StateOfAmtgard_index.tpl';
 	}

--- a/orkui/controller/controller.AdminAjax.php
+++ b/orkui/controller/controller.AdminAjax.php
@@ -117,6 +117,19 @@ class Controller_AdminAjax extends Controller {
 			exit;
 		}
 
+		// Cap the reporting window at 12 months in production to protect the server
+		// from multi-year scans that can exhaust the DB. Local/dev (ENVIRONMENT=DEV)
+		// is unrestricted, matching the env gate used for the Server Health load test.
+		$limit_months = (getenv('ENVIRONMENT') === 'DEV') ? 0 : 12;
+		if ($limit_months > 0) {
+			$max_end = (new DateTime($start))->modify('+' . $limit_months . ' months')->format('Y-m-d');
+			if ($end > $max_end) {
+				http_response_code(400);
+				echo json_encode(['error' => 'The reporting window cannot exceed ' . $limit_months . ' months. Please narrow the date range.']);
+				exit;
+			}
+		}
+
 		$raw_kingdoms = isset($_GET['kingdoms']) && is_array($_GET['kingdoms']) ? $_GET['kingdoms'] : [];
 		// Reject 0/negative and absurd IDs (real kingdom_ids fit well under 100000).
 		$kingdom_ids = array_values(array_filter(

--- a/orkui/controller/controller.Kingdom.php
+++ b/orkui/controller/controller.Kingdom.php
@@ -315,6 +315,11 @@ class Controller_Kingdom extends Controller {
 		$CanManageKingdom = $canManageKingdom;
 		$kingdom_name     = $this->Kingdom->get_kingdom_name($kingdom_id);
 
+		// "My Circles" filter: the viewer's peerage voting circle, as a set of award_ids.
+		// Empty for non-peers (the button is then not rendered).
+		$ViewerCircleAwardIds = $uid > 0 ? Ork3::$Lib->player->GetCircleAwardIds($uid) : array();
+		$ViewerHasCircle      = !empty($ViewerCircleAwardIds);
+
 		header('Content-Type: text/html; charset=utf-8');
 		header('X-Recs-Count: ' . count($AwardRecommendations)); // JS uses this for the tab badge
 		include DIR_TEMPLATE . 'revised-frontend/Kingdomnew_recommendations_panel.tpl';

--- a/orkui/controller/controller.Park.php
+++ b/orkui/controller/controller.Park.php
@@ -319,6 +319,11 @@ class Controller_Park extends Controller
 			$this->data['ShowRecsTab'] = false;
 		}
 
+		// "My Circles" filter: the viewer's peerage voting circle, as a set of award_ids.
+		// Empty for non-peers (the button is then not rendered).
+		$this->data['ViewerCircleAwardIds'] = $uid > 0 ? Ork3::$Lib->player->GetCircleAwardIds($uid) : array();
+		$this->data['ViewerHasCircle']      = !empty($this->data['ViewerCircleAwardIds']);
+
 		$this->data['PronounList']          = $this->Pronoun->fetch_pronoun_list();
 		$this->data['PronounOptionsCreate'] = $this->Pronoun->fetch_pronoun_option_list(null);
 	}

--- a/orkui/template/revised-frontend/Kingdomnew_index.tpl
+++ b/orkui/template/revised-frontend/Kingdomnew_index.tpl
@@ -2456,6 +2456,11 @@ $.fn.dataTable.ext.search.push(function(settings, data, dataIndex) {
 	var row = settings.aoData[dataIndex].nTr;
 	var rowFilter = row ? row.getAttribute('data-filter') : '';
 	if (filter === 'open') return rowFilter !== 'already';
+	if (filter === 'mycircles') {
+		if (rowFilter === 'already') return false;
+		var aid = parseInt(row.getAttribute('data-award-id') || '0', 10);
+		return (window.knRecCircleAwardIds || []).indexOf(aid) !== -1;
+	}
 	return rowFilter === filter;
 });
 // Initialise the rec-table DataTable + filter bar. Idempotent so the lazy-loader
@@ -2463,6 +2468,7 @@ $.fn.dataTable.ext.search.push(function(settings, data, dataIndex) {
 window.knInitRecsTab = function() {
 	var $tbl = $('#kn-rec-table');
 	if (!$tbl.length) return;
+	window.knRecCircleAwardIds = (function() { try { return JSON.parse($tbl.attr('data-circle-ids') || '[]'); } catch (e) { return []; } })();
 	if ($.fn.dataTable.isDataTable('#kn-rec-table')) {
 		$tbl.DataTable().destroy();
 	}

--- a/orkui/template/revised-frontend/Kingdomnew_recommendations_panel.tpl
+++ b/orkui/template/revised-frontend/Kingdomnew_recommendations_panel.tpl
@@ -16,13 +16,16 @@
 			<?php if (empty($AwardRecommendations)): ?>
 			<div class="pk-recs-empty">There are no open award recommendations for <?= htmlspecialchars($kingdom_name) ?>.</div>
 			<?php else: ?>
-			<?php if ($CanManageKingdom ?? false): ?>
+			<?php if (($CanManageKingdom ?? false) || !empty($ViewerHasCircle)): ?>
 			<div class="kn-rec-filter-bar">
 				<button class="kn-rec-filter-btn kn-rec-filter-active" data-filter="open">Open Recs</button>
-				<button class="kn-rec-filter-btn" data-filter="below">Below Recommended</button>
+				<button class="kn-rec-filter-btn" data-filter="below">Below Rec'd</button>
 				<button class="kn-rec-filter-btn" data-filter="nonladder">Non-Ladder</button>
-				<button class="kn-rec-filter-btn" data-filter="already">At or Above Recommended</button>
+				<button class="kn-rec-filter-btn" data-filter="already">At or Above Rec'd</button>
 				<button class="kn-rec-filter-btn" data-filter="all">All</button>
+				<?php if (!empty($ViewerHasCircle)): ?>
+				<button class="kn-rec-filter-btn" data-filter="mycircles"><i class="fas fa-users"></i> My Circles</button>
+				<?php endif; ?>
 				<span class="kn-rec-filter-info">
 					<button class="kn-rec-filter-info-btn" type="button" aria-label="Filter help"><i class="fas fa-question-circle"></i></button>
 					<div class="kn-rec-filter-popover">
@@ -30,14 +33,18 @@
 						<dl>
 							<dt>Open Recs <small style="font-weight:400;color:#718096">(default)</small></dt>
 							<dd>All pending recommendations &mdash; both rank-based and flat awards. Hides recs that have already been fulfilled.</dd>
-							<dt>Below Recommended</dt>
+							<dt>Below Rec'd</dt>
 							<dd>Players who haven&rsquo;t yet reached the recommended rank. The core action list &mdash; Grant these.</dd>
 							<dt>Non-Ladder</dt>
 							<dd>Includes titles such as Master, Noble, or Knight, custom awards, and other non-ranked options. Grant or Delete as appropriate.</dd>
-							<dt>At or Above Recommended</dt>
+							<dt>At or Above Rec'd</dt>
 							<dd>Players who already hold this award at or above the recommended rank. The rec has been fulfilled &mdash; Delete these to keep the list tidy.</dd>
 							<dt>All</dt>
 							<dd>Every recommendation regardless of status. Use for a full audit.</dd>
+							<?php if (!empty($ViewerHasCircle)): ?>
+							<dt>My Circles</dt>
+							<dd>Open recommendations your peerage circle votes on &mdash; all knighthood recs (knights vote as a group) plus recs for each Paragon you hold.</dd>
+							<?php endif; ?>
 						</dl>
 					</div>
 				</span>
@@ -48,7 +55,7 @@
 			</div>
 			<?php endif; ?>
 				<div class="pk-recs-table-wrap">
-				<table id="kn-rec-table" class="pk-recs-table display">
+				<table id="kn-rec-table" class="pk-recs-table display" data-circle-ids="<?= htmlspecialchars(json_encode($ViewerCircleAwardIds ?? array())) ?>">
 					<thead>
 						<tr>
 							<th>Player</th>
@@ -64,7 +71,7 @@
 					<tbody id="kn-recs-tbody">
 					<?php foreach ($AwardRecommendations as $rec): ?>
 					<tr class="pk-rec-row"
-						data-rec-id="<?= (int)$rec['RecommendationsId'] ?>"
+						data-rec-id="<?= (int)$rec['RecommendationsId'] ?>" data-award-id="<?= (int)$rec['AwardId'] ?>"
 						data-filter="<?= !empty($rec['AlreadyHas']) ? 'already' : ((int)$rec['Rank'] > 0 ? 'below' : 'nonladder') ?>">
 						<td><a href="<?= UIR ?>Player/profile/<?= (int)$rec['MundaneId'] ?>"><?= htmlspecialchars($rec['Persona']) ?></a></td>
 						<td><?php if (!empty($rec['ParkId'])): ?><a href="<?= UIR ?>Park/profile/<?= (int)$rec['ParkId'] ?>"><?= htmlspecialchars($rec['ParkName']) ?></a><?php else: ?>&mdash;<?php endif; ?></td>

--- a/orkui/template/revised-frontend/Parknew_index.tpl
+++ b/orkui/template/revised-frontend/Parknew_index.tpl
@@ -1171,13 +1171,16 @@
 				<?php if (empty($AwardRecommendations)): ?>
 				<div class="pk-recs-empty">There are no open award recommendations for <?= htmlspecialchars($park_name) ?>.</div>
 				<?php else: ?>
-				<?php if (!empty($CanAdminPark)): ?>
+				<?php if (!empty($CanAdminPark) || !empty($ViewerHasCircle)): ?>
 				<div class="kn-rec-filter-bar">
 					<button class="kn-rec-filter-btn kn-rec-filter-active" data-filter="open">Open Recs</button>
-					<button class="kn-rec-filter-btn" data-filter="below">Below Recommended</button>
+					<button class="kn-rec-filter-btn" data-filter="below">Below Rec'd</button>
 					<button class="kn-rec-filter-btn" data-filter="nonladder">Non-Ladder</button>
-					<button class="kn-rec-filter-btn" data-filter="already">At or Above Recommended</button>
+					<button class="kn-rec-filter-btn" data-filter="already">At or Above Rec'd</button>
 					<button class="kn-rec-filter-btn" data-filter="all">All</button>
+					<?php if (!empty($ViewerHasCircle)): ?>
+					<button class="kn-rec-filter-btn" data-filter="mycircles"><i class="fas fa-users"></i> My Circles</button>
+					<?php endif; ?>
 					<span class="kn-rec-filter-info">
 						<button class="kn-rec-filter-info-btn" type="button" aria-label="Filter help"><i class="fas fa-question-circle"></i></button>
 						<div class="kn-rec-filter-popover">
@@ -1185,14 +1188,18 @@
 							<dl>
 								<dt>Open Recs <small style="font-weight:400;color:#718096">(default)</small></dt>
 								<dd>All pending recommendations &mdash; both rank-based and flat awards. Hides recs that have already been fulfilled.</dd>
-								<dt>Below Recommended</dt>
+								<dt>Below Rec'd</dt>
 								<dd>Players who haven&rsquo;t yet reached the recommended rank. The core action list &mdash; Grant these.</dd>
 								<dt>Non-Ladder</dt>
 								<dd>Includes titles such as Master, Noble, or Knight, custom awards, and other non-ranked options. Grant or Delete as appropriate.</dd>
-								<dt>At or Above Recommended</dt>
+								<dt>At or Above Rec'd</dt>
 								<dd>Players who already hold this award at or above the recommended rank. The rec has been fulfilled &mdash; Delete these to keep the list tidy.</dd>
 								<dt>All</dt>
 								<dd>Every recommendation regardless of status. Use for a full audit.</dd>
+								<?php if (!empty($ViewerHasCircle)): ?>
+								<dt>My Circles</dt>
+								<dd>Open recommendations your peerage circle votes on &mdash; all knighthood recs (knights vote as a group) plus recs for each Paragon you hold.</dd>
+								<?php endif; ?>
 							</dl>
 						</div>
 					</span>
@@ -1203,7 +1210,7 @@
 				</div>
 				<?php endif; ?>
 				<div class="pk-recs-table-wrap">
-					<table id="pk-rec-table" class="pk-recs-table display">
+					<table id="pk-rec-table" class="pk-recs-table display" data-circle-ids="<?= htmlspecialchars(json_encode($ViewerCircleAwardIds ?? array())) ?>">
 						<thead>
 							<tr>
 								<th>Player</th>
@@ -1218,7 +1225,7 @@
 						<tbody id="pk-recs-tbody">
 						<?php foreach ($AwardRecommendations as $rec): ?>
 						<tr class="pk-rec-row"
-							data-rec-id="<?= (int)$rec['RecommendationsId'] ?>"
+							data-rec-id="<?= (int)$rec['RecommendationsId'] ?>" data-award-id="<?= (int)$rec['AwardId'] ?>"
 							data-filter="<?= !empty($rec['AlreadyHas']) ? 'already' : ((int)$rec['Rank'] > 0 ? 'below' : 'nonladder') ?>">
 							<td><a href="<?= UIR ?>Player/profile/<?= (int)$rec['MundaneId'] ?>"><?= htmlspecialchars($rec['Persona']) ?></a></td>
 							<td><?= htmlspecialchars($rec['AwardName']) ?></td>
@@ -2304,6 +2311,7 @@ html[data-theme="dark"] .pk-wx-warning { background:#450a0a; color:#fca5a5; bord
 <script src="https://cdn.datatables.net/1.13.8/js/jquery.dataTables.min.js"></script>
 <script>
 window.pkRecActiveFilter = 'open';
+window.pkRecCircleAwardIds = <?= json_encode($ViewerCircleAwardIds ?? array()) ?>;
 $.fn.dataTable.ext.search.push(function(settings, data, dataIndex) {
 	if (settings.nTable.id !== 'pk-rec-table') return true;
 	var filter = window.pkRecActiveFilter || 'all';
@@ -2311,6 +2319,11 @@ $.fn.dataTable.ext.search.push(function(settings, data, dataIndex) {
 	var row = settings.aoData[dataIndex].nTr;
 	var rowFilter = row ? row.getAttribute('data-filter') : '';
 	if (filter === 'open') return rowFilter !== 'already';
+	if (filter === 'mycircles') {
+		if (rowFilter === 'already') return false;
+		var aid = parseInt(row.getAttribute('data-award-id') || '0', 10);
+		return (window.pkRecCircleAwardIds || []).indexOf(aid) !== -1;
+	}
 	return rowFilter === filter;
 });
 $(function() {

--- a/orkui/template/revised-frontend/StateOfAmtgard_index.tpl
+++ b/orkui/template/revised-frontend/StateOfAmtgard_index.tpl
@@ -6,6 +6,7 @@ $defaultStart = $prevYear . '-01-01';
 $defaultEnd   = $prevYear . '-12-31';
 $minDate      = (string)($MinDate ?? '');  // earliest attendance date (for "All Time")
 $maxDate      = (string)($MaxDate ?? '');  // latest attendance date
+$rangeLimitMonths = (int)($RangeLimitMonths ?? 0);  // 12 in production, 0 = unlimited (local/dev)
 ?>
 <link rel="stylesheet" href="<?= HTTP_TEMPLATE ?>revised-frontend/style/revised.css?v=20240101">
 
@@ -42,7 +43,7 @@ $maxDate      = (string)($MaxDate ?? '');  // latest attendance date
       <label for="sor-end">End Date</label>
       <input type="date" id="sor-end" value="<?= htmlspecialchars($defaultEnd) ?>">
     </div>
-    <?php if ($minDate !== '' && $maxDate !== ''): ?>
+    <?php if ($minDate !== '' && $maxDate !== '' && $rangeLimitMonths === 0): ?>
     <div class="sor-filter-group sor-filter-quick">
       <label>&nbsp;</label>
       <button type="button" id="sor-btn-all-time" class="sor-btn-sm"
@@ -79,6 +80,8 @@ $maxDate      = (string)($MaxDate ?? '');  // latest attendance date
 <!-- Kingdom multi-select helpers — isolated script so any error in the
      main orchestrator IIFE cannot prevent these buttons from working. -->
 <script>
+// Max reporting-window span enforced in production (server-crash guard); 0 = unlimited (local/dev).
+window.SOR_RANGE_LIMIT_MONTHS = <?= (int)$rangeLimitMonths ?>;
 (function () {
 	function sorKingdomSelect(predicate) {
 		var sel = document.getElementById('sor-kingdoms');
@@ -4561,6 +4564,18 @@ html[data-theme="dark"] .sor-awards-skeleton-pie {
     if (start > end) {
       sorSetStatus('Start date must be before end date.', 'sor-status-error');
       return;
+    }
+
+    // Mirror the server's 12-month cap (production only). Computed via calendar-month
+    // math so it matches PHP's strtotime('+12 months'); 0 = unlimited (local/dev).
+    var limitMonths = (typeof window.SOR_RANGE_LIMIT_MONTHS === 'number') ? window.SOR_RANGE_LIMIT_MONTHS : 0;
+    if (limitMonths > 0) {
+      var _sd = new Date(start + 'T00:00:00');
+      var _maxEnd = new Date(_sd.getFullYear(), _sd.getMonth() + limitMonths, _sd.getDate());
+      if (new Date(end + 'T00:00:00') > _maxEnd) {
+        sorSetStatus('The reporting window cannot exceed ' + limitMonths + ' months. Please narrow the date range.', 'sor-status-error');
+        return;
+      }
     }
 
     // Check at least one kingdom selected

--- a/orkui/template/revised-frontend/script/revised.js
+++ b/orkui/template/revised-frontend/script/revised.js
@@ -12831,9 +12831,15 @@ window.initEmailSpellCheck = function(inputId, suggestionId) {
     function wirePanel(panelId, listUrl, restoreUrl) {
         var panel = document.getElementById(panelId);
         if (!panel) return;
+        // Guard against double-wiring. The kingdom panel is lazy-loaded
+        // (see kn:recs-loaded handler below) — we want one call from there
+        // and a no-op from DOMContentLoaded. Without this, the click handler
+        // attaches twice and the toggle opens-and-closes in the same click.
+        if (panel.dataset.wired === '1') return;
         var toggle = panel.querySelector('.pk-deleted-recs-toggle');
         var body   = panel.querySelector('.pk-deleted-recs-body');
         if (!toggle || !body) return;
+        panel.dataset.wired = '1';
 
         toggle.addEventListener('click', function () {
             var open = panel.classList.toggle('pk-deleted-open');
@@ -12936,11 +12942,17 @@ window.initEmailSpellCheck = function(inputId, suggestionId) {
             );
         }
         if (typeof KnConfig !== 'undefined' && KnConfig.kingdomId) {
-            wirePanel(
-                'kn-deleted-recs',
-                KnConfig.uir + 'KingdomAjax/kingdom/' + KnConfig.kingdomId + '/deletedrecommendations',
-                KnConfig.uir + 'KingdomAjax/kingdom/' + KnConfig.kingdomId + '/restorerecommendation'
-            );
+            // The Kingdom recommendations panel — which contains the
+            // kn-deleted-recs markup — is lazy-loaded via Kingdom::
+            // recommendations_panel after the user opens the Recs tab. Call
+            // wirePanel here for the lucky case where it's already in the
+            // DOM, and again on `kn:recs-loaded` once the markup arrives.
+            var knListUrl    = KnConfig.uir + 'KingdomAjax/kingdom/' + KnConfig.kingdomId + '/deletedrecommendations';
+            var knRestoreUrl = KnConfig.uir + 'KingdomAjax/kingdom/' + KnConfig.kingdomId + '/restorerecommendation';
+            wirePanel('kn-deleted-recs', knListUrl, knRestoreUrl);
+            document.addEventListener('kn:recs-loaded', function () {
+                wirePanel('kn-deleted-recs', knListUrl, knRestoreUrl);
+            });
         }
     });
 })();

--- a/orkui/template/revised-frontend/script/revised.js
+++ b/orkui/template/revised-frontend/script/revised.js
@@ -4790,6 +4790,34 @@ $(document).ready(function() {
     // Filters the rendered admin-awards table based on the search input's value.
     // O(rows) per keystroke — fine up to a few hundred. Each row carries the
     // pre-lowered haystack on its dataset, set in makeAwardRow().
+    // Duplicate-name guard: soft, override-able warning before saving an award whose
+    // name collides with an existing one (normalized: case- and whitespace-insensitive).
+    function knNormalizeAwardName(s) {
+        return String(s || '').trim().toLowerCase().replace(/\s+/g, ' ');
+    }
+    function knFindAwardNameCollision(name, excludeKawId) {
+        var norm = knNormalizeAwardName(name);
+        if (!norm) return null;
+        var list = (window.KnConfig && KnConfig.adminAwards) || [];
+        var ex = parseInt(excludeKawId || 0, 10);
+        for (var i = 0; i < list.length; i++) {
+            if (ex && parseInt(list[i].KingdomAwardId, 10) === ex) continue;
+            if (knNormalizeAwardName(list[i].KingdomAwardName) === norm) return list[i].KingdomAwardName;
+        }
+        return null;
+    }
+    function knGuardDuplicateName(name, excludeKawId, proceed) {
+        var existing = knFindAwardNameCollision(name, excludeKawId);
+        if (!existing) { proceed(); return; }
+        knConfirm(
+            'It looks like you already have an award called "' + existing + '" in your awards list. ' +
+            'Did you mean to set an alias of it, or create a different award? Duplicate awards can cause ' +
+            'data-integrity issues, so we don\'t recommend saving this. Continue anyway?',
+            proceed,
+            'Possible Duplicate Award'
+        );
+    }
+
     function applyAdminAwardFilter() {
         var inp = gid('kn-admin-award-search');
         if (!inp) return;
@@ -4801,11 +4829,21 @@ $(document).ready(function() {
         if (!tbody) return;
         var rows = tbody.querySelectorAll('tr');
         var visible = 0;
+        var groupVisible = {};
         rows.forEach(function(tr) {
+            if (tr.dataset.groupHeader) return;
             var hay  = tr.dataset.searchHaystack || '';
             var show = !q || hay.indexOf(q) !== -1;
             tr.style.display = show ? '' : 'none';
-            if (show) visible++;
+            if (show) {
+                visible++;
+                var g = tr.dataset.group || '';
+                groupVisible[g] = (groupVisible[g] || 0) + 1;
+            }
+        });
+        rows.forEach(function(tr) {
+            if (!tr.dataset.groupHeader) return;
+            tr.style.display = (groupVisible[tr.dataset.group] > 0) ? '' : 'none';
         });
         if (empty) empty.style.display = (q && visible === 0) ? '' : 'none';
     }
@@ -4825,6 +4863,28 @@ $(document).ready(function() {
         });
     }
 
+    function classifyAdminAward(aw) {
+        var awardId = parseInt(aw.AwardId || 0, 10);
+        var sysName = String(aw.AwardName || '').trim();
+        var knName  = String(aw.KingdomAwardName || '').trim();
+        if (awardId === 94) return 'specific';
+        if (sysName === '')  return 'specific';
+        if (sysName === knName) return 'standard';
+        return 'alias';
+    }
+
+    function makeAwardGroupHeader(label, count, key) {
+        var tr = document.createElement('tr');
+        tr.className = 'kn-admin-award-group';
+        tr.dataset.groupHeader = '1';
+        tr.dataset.group = key;
+        var td = document.createElement('td');
+        td.colSpan = 6;
+        td.textContent = label + ' (' + count + ')';
+        tr.appendChild(td);
+        return tr;
+    }
+
     var awardsBuilt = false;
     function buildAwards() {
         if (awardsBuilt) return;
@@ -4832,8 +4892,27 @@ $(document).ready(function() {
         var tbody = gid('kn-admin-awards-tbody');
         if (!tbody) return;
         tbody.innerHTML = '';
+        var groups = { standard: [], alias: [], specific: [] };
         (KnConfig.adminAwards || []).forEach(function(aw) {
-            tbody.appendChild(makeAwardRow(aw));
+            groups[classifyAdminAward(aw)].push(aw);
+        });
+        var orgName = String(KnConfig.kingdomName || 'Kingdom');
+        [
+            { key: 'standard', label: 'System Standard Awards' },
+            { key: 'alias',    label: 'Aliases of System Awards' },
+            { key: 'specific', label: orgName + ' \u2014 Specific Awards' }
+        ].forEach(function(sec) {
+            var list = groups[sec.key];
+            if (!list.length) return;
+            list.sort(function(a, b) {
+                return String(a.KingdomAwardName || '').localeCompare(String(b.KingdomAwardName || ''));
+            });
+            tbody.appendChild(makeAwardGroupHeader(sec.label, list.length, sec.key));
+            list.forEach(function(aw) {
+                var tr = makeAwardRow(aw);
+                tr.dataset.group = sec.key;
+                tbody.appendChild(tr);
+            });
         });
         wireAwardSearch();
     }
@@ -4908,7 +4987,8 @@ $(document).ready(function() {
         (function(btn, nc, rc, mc, cb, cc, kawId) {
             btn.addEventListener('click', function() {
                 clearFeedback('kn-admin-awards-feedback');
-                btn.disabled = true;
+                knGuardDuplicateName(nc.value.trim(), kawId, function() {
+                    btn.disabled = true;
                 $.post(BASE_URL + 'setaward', {
                     KingdomAwardId:   kawId,
                     KingdomAwardName: nc.value.trim(),
@@ -4928,6 +5008,7 @@ $(document).ready(function() {
                         feedback('kn-admin-awards-feedback', (r && r.error) ? r.error : 'Save failed.', false);
                     }
                 }, 'json').fail(function() { btn.disabled = false; feedback('kn-admin-awards-feedback', 'Request failed.', false); });
+                    });
             });
         })(saveBtn, nameCell.inp, reignCell.inp, monthCell.inp, titleCb, classCell.inp, aw.KingdomAwardId);
 
@@ -5120,6 +5201,7 @@ $(document).ready(function() {
                 if (!awardId) { feedback('kn-admin-awards-feedback', 'Please select a system award.', false); return; }
                 if (!name)    { feedback('kn-admin-awards-feedback', 'Award name is required.', false); return; }
 
+                knGuardDuplicateName(name, 0, function() {
                 saveNewBtn.disabled = true;
                 $.post(BASE_URL + 'setaward', {
                     KingdomAwardId:   0,
@@ -5138,6 +5220,7 @@ $(document).ready(function() {
                         feedback('kn-admin-awards-feedback', (r && r.error) ? r.error : 'Create failed.', false);
                     }
                 }, 'json').fail(function() { saveNewBtn.disabled = false; feedback('kn-admin-awards-feedback', 'Request failed.', false); });
+                });
             });
         }
 
@@ -5171,6 +5254,7 @@ $(document).ready(function() {
 
                 if (!name) { feedback('kn-admin-awards-feedback', 'Award name is required.', false); return; }
 
+                knGuardDuplicateName(name, 0, function() {
                 saveCustomBtn.disabled = true;
                 $.post(BASE_URL + 'setaward', {
                     KingdomAwardId:   0,
@@ -5189,6 +5273,7 @@ $(document).ready(function() {
                         feedback('kn-admin-awards-feedback', (r && r.error) ? r.error : 'Create failed.', false);
                     }
                 }, 'json').fail(function() { saveCustomBtn.disabled = false; feedback('kn-admin-awards-feedback', 'Request failed.', false); });
+                });
             });
         }
     }

--- a/orkui/template/revised-frontend/style/revised.css
+++ b/orkui/template/revised-frontend/style/revised.css
@@ -5525,6 +5525,8 @@ html[data-theme="dark"] .pk-ac-item.pk-ac-suspended:hover, html[data-theme="dark
 .kn-admin-awards-table .kn-admin-tnumeric { width:54px; }
 .kn-admin-awards-table td:first-child { overflow:visible; position:relative; display:flex; align-items:center; gap:4px; }
 .kn-admin-awards-table td:nth-child(n+2) { white-space:nowrap; width:1%; }
+.kn-admin-awards-table tr.kn-admin-award-group td { display:table-cell; padding:11px 8px 4px; font-size:11px; font-weight:700; color:#4a5568; text-transform:uppercase; letter-spacing:0.04em; background:#eef2f7; border-bottom:1px solid #cbd5e0; }
+.kn-admin-awards-table tr.kn-admin-award-group:first-child td { padding-top:4px; }
 .kn-admin-config-row { display:flex; align-items:center; gap:12px; padding:8px 0; border-bottom:1px solid #f0f4f8; }
 .kn-admin-config-row:last-child { border-bottom:none; }
 .kn-admin-config-label { width:200px; flex-shrink:0; font-size:12px; font-weight:600; color:#4a5568; }
@@ -7435,6 +7437,7 @@ html[data-theme="dark"] .kn-admin-panel-body { border-top-color: var(--ork-borde
 html[data-theme="dark"] .kn-admin-field input { background: var(--ork-input-bg); border-color: var(--ork-input-border); color: var(--ork-text); }
 html[data-theme="dark"] .kn-admin-table th { background: var(--ork-bg-tertiary); color: var(--ork-text-muted); border-color: var(--ork-border); }
 html[data-theme="dark"] .kn-admin-table td { border-color: var(--ork-border); color: var(--ork-text-secondary); }
+html[data-theme="dark"] .kn-admin-awards-table tr.kn-admin-award-group td { background: var(--ork-bg-tertiary); color: var(--ork-text-secondary); border-color: var(--ork-border); }
 html[data-theme="dark"] .kn-admin-table tfoot td { background: var(--ork-bg-secondary) !important; border-color: var(--ork-border); }
 html[data-theme="dark"] .kn-admin-tinput,
 html[data-theme="dark"] .kn-admin-tnumeric,

--- a/system/lib/ork3/class.Player.php
+++ b/system/lib/ork3/class.Player.php
@@ -515,6 +515,40 @@ class Player extends Ork3 {
 		return $response;
 	}
 
+	// Peerage voting "circles" the given player belongs to, expressed as a set of
+	// award_ids. Knighthoods vote as ONE group: holding any knighthood (award_id in
+	// 17,18,19,20,245) puts all five in the circle. Paragons vote in SEPARATE
+	// per-type circles: each Paragon held adds only that exact award_id. Masters are
+	// intentionally excluded. Returns [] when the player holds no knighthood/paragon.
+	public function GetCircleAwardIds($mundane_id) {
+		$mundane_id = (int)$mundane_id;
+		if ($mundane_id <= 0) return array();
+		$knightSet = array(17, 18, 19, 20, 245);
+		$sql = "select distinct a.award_id, a.peerage
+				from " . DB_PREFIX . "awards aw
+				join " . DB_PREFIX . "kingdomaward ka on ka.kingdomaward_id = aw.kingdomaward_id
+				join " . DB_PREFIX . "award a on a.award_id = ka.award_id
+				where aw.mundane_id = " . $mundane_id . "
+				  and (a.peerage = 'Paragon' or a.award_id in (" . implode(',', $knightSet) . "))";
+		$r = $this->db->query($sql);
+		$set = array();
+		$hasKnight = false;
+		if ($r !== false && $r->size() > 0) {
+			while ($r->next()) {
+				$aid = (int)$r->award_id;
+				if (in_array($aid, $knightSet, true)) {
+					$hasKnight = true;
+				} elseif ($r->peerage === 'Paragon') {
+					$set[$aid] = true;
+				}
+			}
+		}
+		if ($hasKnight) {
+			foreach ($knightSet as $k) $set[$k] = true;
+		}
+		return array_values(array_map('intval', array_keys($set)));
+	}
+
 	public function GetPlayerClasses($request) {
 		// Cold-cache the dedupe-by-date subquery costs ~185ms for the busiest player
 		// in the DB (1500+ attendance rows). Memcache to convert most loads to ~1ms.


### PR DESCRIPTION
## Summary

Award-admin enhancements plus a server-protection cap on the State of Amtgard report.

### 1. Awards admin tab subsections
The Awards admin tab is grouped into three labeled subsections — **System Standard**, **Aliases of System Awards**, and **{Kingdom}-Specific** — derived client-side, alphabetically sorted, with group-aware search and dark-mode styling. (Front-end only.)

### 2. Duplicate-name save guard
Saving an award whose name collides with an existing one prompts a soft, override-able confirm (normalized, case/space-insensitive) across all three save paths — add alias, add custom, and inline rename (self-excluded).

### 3. Recommendation circle filters
- 'Recommended' abbreviated to **'Rec'd'**.
- New **'My Circles'** filter (Kingdom + Park) that narrows open recs to the viewer's peerage voting circle — all knighthoods for any knight, matching per-type paragon circles for paragons.
- New `Player::GetCircleAwardIds` helper.

### 4. State of Amtgard report — 12-month window cap (production)
The report scans attendance/award data across the selected start/end range; an unbounded multi-year range can exhaust the DB and crash the server.
- **Hard server-side guard** in `AdminAjax::stateofamtgard()` rejects spans > 12 months with HTTP 400 before any query runs.
- **Client-side mirror** in `sorGenerate()` for instant feedback; the "All Time" quick-range button is hidden in production (it always sets a multi-year span).
- **Env-gated**: local/dev (`ENVIRONMENT=DEV`) runs unrestricted — matching the existing Server Health load-test gate; production is capped at 12 months. "12 months" = `start + 12 calendar months`, so the default Jan 1 – Dec 31 range always passes.

## Files changed
- `orkui/controller/controller.Admin.php`, `controller.AdminAjax.php`, `controller.Park.php`, `controller.Kingdom.php`
- `orkui/template/revised-frontend/StateOfAmtgard_index.tpl`, `Kingdomnew_index.tpl`, `Kingdomnew_recommendations_panel.tpl`, `Parknew_index.tpl`
- `orkui/template/revised-frontend/script/revised.js`, `style/revised.css`
- `system/lib/ork3/class.Player.php`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
