### PR TITLE
Megiddo: frontend model hop + Player aggregate APIs

### DIFF
--- a/docs/megiddo/refactor/04-milestone-checklist.md
+++ b/docs/megiddo/refactor/04-milestone-checklist.md
@@ -13,9 +13,9 @@ The complete historical milestone checklist is preserved in [archive/04-mileston
 
 ## Player first-class API residual (P3-R)
 
-See plan detail in [11-phase-3-closeout.md](./11-phase-3-closeout.md) § P3-R.
+**Plan home:** [player-aggregates/](./player-aggregates/) (inventory, contract, milestones, orchestrator). Summary also in [11-phase-3-closeout.md](./11-phase-3-closeout.md) § P3-R.
 
-- [ ] **P3-R0:** Inventory + API contract (milestones, class progress, award maps, reconcile suggestions).
+- [x] **P3-R0:** Inventory + API contract ([player-aggregates/](./player-aggregates/)).
 - [ ] **P3-R1:** Class level / progress via domain (`ClassLevel` / Player); thin controller.
 - [ ] **P3-R2:** Milestones + award maps API; remove maps from Player templates.
 - [ ] **P3-R3:** Reconcile suggestions API; template display-only.
@@ -23,4 +23,4 @@ See plan detail in [11-phase-3-closeout.md](./11-phase-3-closeout.md) § P3-R.
 
 **Non-blocking (done):** bootstrap `class.Controller` Lib→model hop; `Authorization->audit` for Dangeraudit; `index.php` via `Model_Health` / `Model_Event`.
 
-See [11-phase-3-closeout.md](./11-phase-3-closeout.md) for context and [README.md](./README.md) for active navigation.
+See [11-phase-3-closeout.md](./11-phase-3-closeout.md) for Phase 3 human close-out and [README.md](./README.md) for active navigation.

--- a/docs/megiddo/refactor/04-milestone-checklist.md
+++ b/docs/megiddo/refactor/04-milestone-checklist.md
@@ -18,7 +18,7 @@ The complete historical milestone checklist is preserved in [archive/04-mileston
 - [x] **P3-R0:** Inventory + API contract ([player-aggregates/](./player-aggregates/)).
 - [x] **P3-R1:** Class level / progress via domain (`ClassLevel` / Player); thin controller.
 - [x] **P3-R2:** Milestones + award maps API; remove maps from Player templates.
-- [ ] **P3-R3:** Reconcile suggestions API; template display-only.
+- [x] **P3-R3:** Reconcile suggestions API; template display-only.
 - [ ] **P3-R4:** Wire controller/templates; fuzzy player-profile canaries; optional orkservice exposure.
 
 **Non-blocking (done):** bootstrap `class.Controller` Lib→model hop; `Authorization->audit` for Dangeraudit; `index.php` via `Model_Health` / `Model_Event`.

--- a/docs/megiddo/refactor/04-milestone-checklist.md
+++ b/docs/megiddo/refactor/04-milestone-checklist.md
@@ -16,7 +16,7 @@ The complete historical milestone checklist is preserved in [archive/04-mileston
 **Plan home:** [player-aggregates/](./player-aggregates/) (inventory, contract, milestones, orchestrator). Summary also in [11-phase-3-closeout.md](./11-phase-3-closeout.md) § P3-R.
 
 - [x] **P3-R0:** Inventory + API contract ([player-aggregates/](./player-aggregates/)).
-- [ ] **P3-R1:** Class level / progress via domain (`ClassLevel` / Player); thin controller.
+- [x] **P3-R1:** Class level / progress via domain (`ClassLevel` / Player); thin controller.
 - [ ] **P3-R2:** Milestones + award maps API; remove maps from Player templates.
 - [ ] **P3-R3:** Reconcile suggestions API; template display-only.
 - [ ] **P3-R4:** Wire controller/templates; fuzzy player-profile canaries; optional orkservice exposure.

--- a/docs/megiddo/refactor/04-milestone-checklist.md
+++ b/docs/megiddo/refactor/04-milestone-checklist.md
@@ -17,7 +17,7 @@ The complete historical milestone checklist is preserved in [archive/04-mileston
 
 - [x] **P3-R0:** Inventory + API contract ([player-aggregates/](./player-aggregates/)).
 - [x] **P3-R1:** Class level / progress via domain (`ClassLevel` / Player); thin controller.
-- [ ] **P3-R2:** Milestones + award maps API; remove maps from Player templates.
+- [x] **P3-R2:** Milestones + award maps API; remove maps from Player templates.
 - [ ] **P3-R3:** Reconcile suggestions API; template display-only.
 - [ ] **P3-R4:** Wire controller/templates; fuzzy player-profile canaries; optional orkservice exposure.
 

--- a/docs/megiddo/refactor/04-milestone-checklist.md
+++ b/docs/megiddo/refactor/04-milestone-checklist.md
@@ -1,14 +1,26 @@
 # Megiddo Refactor — Remaining Work Checklist
 
-**Status:** All implementation work (R-01 … R-19d), the Phase 3 automated audit and gate fixes, idiom enforcement, and the post-refactor rebase are complete.
+**Status:** All implementation work (R-01 … R-19d), the Phase 3 automated audit and gate fixes, idiom enforcement, and the post-refactor rebase are complete. Human close-out and Player API residual remain.
 
 The complete historical milestone checklist is preserved in [archive/04-milestone-checklist-complete.md](./archive/04-milestone-checklist-complete.md).
 
 ## Final close-out
 
-- [x] Rebase onto `origin/master` @ `7631d0baad65b573d4d53f115c84d20af09b046e` on `megiddo/rebase-20260717`: RB-0…RB-Z complete; gold fuzzy `20260718T030809Z-7631d0ba-fd37ea34a9523a28.zip` validated test + mirror 40/40. Future runs: [skills/rebase-and-redocument/orchestrator.prompt](./skills/rebase-and-redocument/orchestrator.prompt).
+- [x] Rebase onto `origin/master` @ `7631d0baad65b573d4d53f115c84d20af09b046e` on `megiddo/rebase-20260717`: RB-0…RB-Z complete; gold fuzzy validated test + mirror. Later tip: `megiddo/fuzzy-validator-v2`. Future runs: [skills/rebase-and-redocument/orchestrator.prompt](./skills/rebase-and-redocument/orchestrator.prompt).
 - [ ] **P3-4:** Complete the human walk-through in [validations/r-milestone-smoke-matrix.html](./validations/r-milestone-smoke-matrix.html).
 - [ ] **P3-5:** Record the retrospective.
 - [ ] **P3-6 (optional):** Merge after rebase and human close-out acceptance.
 
-See [11-phase-3-closeout.md](./11-phase-3-closeout.md) for the close-out context and [README.md](./README.md) for active navigation.
+## Player first-class API residual (P3-R)
+
+See plan detail in [11-phase-3-closeout.md](./11-phase-3-closeout.md) § P3-R.
+
+- [ ] **P3-R0:** Inventory + API contract (milestones, class progress, award maps, reconcile suggestions).
+- [ ] **P3-R1:** Class level / progress via domain (`ClassLevel` / Player); thin controller.
+- [ ] **P3-R2:** Milestones + award maps API; remove maps from Player templates.
+- [ ] **P3-R3:** Reconcile suggestions API; template display-only.
+- [ ] **P3-R4:** Wire controller/templates; fuzzy player-profile canaries; optional orkservice exposure.
+
+**Non-blocking (done):** bootstrap `class.Controller` Lib→model hop; `Authorization->audit` for Dangeraudit; `index.php` via `Model_Health` / `Model_Event`.
+
+See [11-phase-3-closeout.md](./11-phase-3-closeout.md) for context and [README.md](./README.md) for active navigation.

--- a/docs/megiddo/refactor/04-milestone-checklist.md
+++ b/docs/megiddo/refactor/04-milestone-checklist.md
@@ -19,7 +19,7 @@ The complete historical milestone checklist is preserved in [archive/04-mileston
 - [x] **P3-R1:** Class level / progress via domain (`ClassLevel` / Player); thin controller.
 - [x] **P3-R2:** Milestones + award maps API; remove maps from Player templates.
 - [x] **P3-R3:** Reconcile suggestions API; template display-only.
-- [ ] **P3-R4:** Wire controller/templates; fuzzy player-profile canaries; optional orkservice exposure.
+- [x] **P3-R4:** Wire controller/templates; fuzzy player-profile canaries (test+mirror PASS). Optional orkservice exposure skipped.
 
 **Non-blocking (done):** bootstrap `class.Controller` Lib→model hop; `Authorization->audit` for Dangeraudit; `index.php` via `Model_Health` / `Model_Event`.
 

--- a/docs/megiddo/refactor/11-phase-3-closeout.md
+++ b/docs/megiddo/refactor/11-phase-3-closeout.md
@@ -1,6 +1,6 @@
 # Phase 3 — Audit and Close-out
 
-**Status:** Automated work complete; human close-out remains open. A post-gate residual (Player first-class APIs) is tracked below.
+**Status:** Automated work complete; human close-out remains open. A post-gate residual (Player first-class APIs) is planned under [player-aggregates/](./player-aggregates/) and summarized below.
 **Completed:** P3-2/P3-3 automated audit and gate fixes, I-0 … I-VALIDATE idiom enforcement, and RB-0 … RB-Z are complete, with `$DB` and `Ork3::$Lib` at zero in `orkui/`.
 **Current tip:** `megiddo/fuzzy-validator-v2` (stacked on post-rebase Megiddo tip). See [PR #492](https://github.com/amtgard/ORK3/pull/492).
 
@@ -54,19 +54,21 @@ Sign-in already uses migrated class-progress enrichment via the Attendance model
 
 ---
 
-## P3-R — Player first-class API residual (plan)
+## P3-R — Player first-class API residual
 
 **Goal:** Player profile chrome consumes domain/model DTOs only; award ladders, class levels, milestones, and reconcile suggestions are callable without opening `orkui/`.
 
+**Canonical plan package:** [player-aggregates/](./player-aggregates/) (nickname: play-aggregates) — inventory, API contract, executable milestones, orchestrator prompts. Implementation starts at **P3-R1**.
+
 | ID | Deliverable | Notes |
 |----|-------------|-------|
-| **P3-R0** | Inventory + contract | List current controller/template rule sites; draft API shapes (milestones, class progress summary, order/class→award maps, reconcile suggestions). Confirm what `ClassLevel` / `Player` already expose vs net-new. |
+| **P3-R0** | Inventory + contract | **Done** in [player-aggregates/](./player-aggregates/). |
 | **P3-R1** | Class level / progress API | Replace controller threshold block with domain/`ClassLevel` (mirror SignIn enrichment). PHPUnit characterization. |
 | **P3-R2** | Milestones + award maps API | Move AwardId lists and peerage dedup into domain; thin controller; remove maps from `Playernew_index.tpl`. |
 | **P3-R3** | Reconcile suggestions API | Move smart-rank logic out of `Playernew_reconcile.tpl` into model/domain; template display-only. |
 | **P3-R4** | Wire + gate | Point `Controller_Player` + templates at the new APIs; fuzzy canaries for player-profile (test + mirror); optional thin orkservice exposure if external clients need the same DTOs. |
 
-**Out of scope for P3-R:** reopening R-* for unrelated controllers. Bootstrap Lib / Dangeraudit / index Health·Event hop is **done** (see above).
+**Out of scope for P3-R:** reopening R-* for unrelated controllers. Bootstrap Lib / Dangeraudit / index Health·Event hop is **done** (see above). Human P3-4 / P3-5 / P3-6 remain separate.
 
 ---
 
@@ -86,5 +88,6 @@ Use [06-test-framework.md](./06-test-framework.md) for local test and login prer
 - Post-refactor rebase RB-0 … RB-Z (and later stacked tip including fuzzy-validator v2) validated on the Megiddo line.
 - 2026-07-19 frontend residual hunt: `orkui/` gates clean; Player aggregate APIs tracked as **P3-R\***.
 - 2026-07-19 bootstrap/API-coupling hop: `class.Controller`, auth audit call sites, and `index.php` Health/Event now go through models (no `Ork3::$Lib` / no controller `new Dangeraudit()`).
+- 2026-07-19 P3-R0 plan package: [player-aggregates/](./player-aggregates/) (inventory, contract, milestones, orchestrator).
 
 Track human close-out checkboxes in [04-milestone-checklist.md](./04-milestone-checklist.md).

--- a/docs/megiddo/refactor/11-phase-3-closeout.md
+++ b/docs/megiddo/refactor/11-phase-3-closeout.md
@@ -1,10 +1,12 @@
 # Phase 3 — Audit and Close-out
 
-**Status:** Automated work complete; human close-out remains open.
+**Status:** Automated work complete; human close-out remains open. A post-gate residual (Player first-class APIs) is tracked below.
 **Completed:** P3-2/P3-3 automated audit and gate fixes, I-0 … I-VALIDATE idiom enforcement, and RB-0 … RB-Z are complete, with `$DB` and `Ork3::$Lib` at zero in `orkui/`.
-**Current tip:** `megiddo/rebase-20260717` @ `729cc577`, rebased onto `origin/master` @ `7631d0ba`.
+**Current tip:** `megiddo/fuzzy-validator-v2` (stacked on post-rebase Megiddo tip). See [PR #492](https://github.com/amtgard/ORK3/pull/492).
 
 Historical audit reports, execution skills, and remediation prompts are in [archive/README.md](./archive/README.md).
+
+---
 
 ## Remaining close-out work
 
@@ -14,17 +16,75 @@ Historical audit reports, execution skills, and remediation prompts are in [arch
 | **P3-5** | Human | Record the retrospective. | [ ] |
 | **P3-6** | Human (optional) | Merge after the rebase and human close-out are accepted. | [ ] |
 
+These are the original Phase 3 human gates — not dangling chores. Automated migration and audit already passed; eyes-on smoke and retrospective still close the phase.
+
+---
+
+## Frontend residual hunt (2026-07-19)
+
+Static re-hunt of `orkui/` after the stacked tip: **zero** `$DB->`, **zero** `Ork3::$Lib`, **zero** raw DML in `orkui/`. Auth grants remain on `Authorization->add_auth` / `del_auth`.
+
+Findings fall into three classes against the product goal: *anything the frontend needs should be reachable as a first-class API (domain / orkservice), not encoded in controllers or templates.*
+
+### Non-blocking residual — resolved (bootstrap / idiom API hop)
+
+**2026-07-19:** Decoupled so frontend code does not bypass models:
+
+| Before | After |
+|--------|-------|
+| `class.Controller` → `Ork3::$Lib->sessiontoken/player` | `Model_SessionToken` / `Model_Player` snake_case wrappers |
+| `global $DB; $DB->Clear()` after nav auth | `Model_Authorization::clear_db_after_auth_checks()` |
+| Controllers → `(new Dangeraudit())->audit` | `$this->Authorization->audit(…)` |
+| `index.php` → `(new Health())` / `(new Event())` | `Model_Health::ping_db` / `Model_Event::get_event_summary_for_redirect` |
+
+Domain methods were already first-class; this hop removes Lib/direct-domain **call-site** coupling so future work cannot casually reintroduce frontend Lib habits. Static gates now also cover `class.Controller.php` and ban `(new Dangeraudit())` in `orkui/controller/`. See [idioms-00-charter.md](./idioms-00-charter.md) §1.3 / §1.6 / §2.
+
+### Blocking for the API goal — Player aggregates still in the UI layer
+
+These rules still live in `Controller_Player` and revised Player templates. They are **real domain knowledge** and affect any future first-class player API / mobile / embed clients. Track as **P3-R\*** below (residual after R-19d gates; not a reopen of `$DB` migration).
+
+| Surface today | Problem | First-class target |
+|---------------|---------|-------------------|
+| `controller.Player.php` class-level thresholds (5 / 12 / 21 / 34 / 53) | Duplicates `ClassLevel` rules in the controller | Domain (or existing `ClassLevel::computeClassLevel`) → model DTO; controller only assigns |
+| `controller.Player.php` milestone timeline (knight / master / paragon AwardId lists, peerage dedup) | Award ladder encoded in UI | `Player` (or Award) API: e.g. `GetPlayerMilestones(mundaneId)` → ready timeline DTO |
+| `Playernew_index.tpl` `$pnOrderToMaster` / `$pnClassToParagon` | Templates own award maps | Same APIs; template only iterates |
+| `Playernew_reconcile.tpl` historical vs real ranks + “smart rank” suggestion | Ranking algorithm in a template | Player reconcile service / model method; template renders suggestions |
+
+Sign-in already uses migrated class-progress enrichment via the Attendance model — Player profile should match that pattern.
+
+---
+
+## P3-R — Player first-class API residual (plan)
+
+**Goal:** Player profile chrome consumes domain/model DTOs only; award ladders, class levels, milestones, and reconcile suggestions are callable without opening `orkui/`.
+
+| ID | Deliverable | Notes |
+|----|-------------|-------|
+| **P3-R0** | Inventory + contract | List current controller/template rule sites; draft API shapes (milestones, class progress summary, order/class→award maps, reconcile suggestions). Confirm what `ClassLevel` / `Player` already expose vs net-new. |
+| **P3-R1** | Class level / progress API | Replace controller threshold block with domain/`ClassLevel` (mirror SignIn enrichment). PHPUnit characterization. |
+| **P3-R2** | Milestones + award maps API | Move AwardId lists and peerage dedup into domain; thin controller; remove maps from `Playernew_index.tpl`. |
+| **P3-R3** | Reconcile suggestions API | Move smart-rank logic out of `Playernew_reconcile.tpl` into model/domain; template display-only. |
+| **P3-R4** | Wire + gate | Point `Controller_Player` + templates at the new APIs; fuzzy canaries for player-profile (test + mirror); optional thin orkservice exposure if external clients need the same DTOs. |
+
+**Out of scope for P3-R:** reopening R-* for unrelated controllers. Bootstrap Lib / Dangeraudit / index Health·Event hop is **done** (see above).
+
+---
+
 ## P3-4 manual smoke matrix
 
 The [HTML smoke matrix](./validations/r-milestone-smoke-matrix.html) provides one manual smoke for each R-* milestone. Open it in a browser, walk the listed flows, and mark the results. This eyes-on check remains necessary for UI behavior that automated gates cannot judge.
 
 Use [06-test-framework.md](./06-test-framework.md) for local test and login prerequisites when preparing the environment.
 
+---
+
 ## Completion record
 
 - R-01 … R-19d completed the logic migration and eliminated direct `$DB` / `Ork3::$Lib` access from `orkui/`.
 - Phase 3 automated audit VALIDATE-20 passed after FIX-06 … FIX-10.
 - Idiom enforcement I-0 … I-VALIDATE completed with `status: ok`.
-- Post-refactor rebase RB-0 … RB-Z validated against gold fuzzy bundle `20260718T030809Z-7631d0ba-fd37ea34a9523a28.zip` (test + mirror 40/40).
+- Post-refactor rebase RB-0 … RB-Z (and later stacked tip including fuzzy-validator v2) validated on the Megiddo line.
+- 2026-07-19 frontend residual hunt: `orkui/` gates clean; Player aggregate APIs tracked as **P3-R\***.
+- 2026-07-19 bootstrap/API-coupling hop: `class.Controller`, auth audit call sites, and `index.php` Health/Event now go through models (no `Ork3::$Lib` / no controller `new Dangeraudit()`).
 
-Track the remaining checkboxes in [04-milestone-checklist.md](./04-milestone-checklist.md).
+Track human close-out checkboxes in [04-milestone-checklist.md](./04-milestone-checklist.md).

--- a/docs/megiddo/refactor/README.md
+++ b/docs/megiddo/refactor/README.md
@@ -4,7 +4,7 @@ Migrate business logic and `$DB` / `Ork3::$Lib` access out of `orkui/` into `sys
 
 **Status:** Implementation, automated Phase 3 audit, gate fixes, idiom enforcement, and the post-refactor rebase are complete. Human Phase 3 close-out and a Player first-class API residual remain.
 **Current tip:** `megiddo/fuzzy-validator-v2` (see [PR #492](https://github.com/amtgard/ORK3/pull/492)).
-**Remaining:** P3-4 manual smoke, P3-5 retrospective, optional P3-6 merge, and **P3-R\*** Player aggregate APIs ([11-phase-3-closeout.md](./11-phase-3-closeout.md)).
+**Remaining:** P3-4 manual smoke, P3-5 retrospective, optional P3-6 merge, and **P3-R\*** Player aggregate APIs ([player-aggregates/](./player-aggregates/), summary in [11-phase-3-closeout.md](./11-phase-3-closeout.md)).
 
 **Last rebase:** 2026-07-18 onto `origin/master` @ `7631d0baad65b573d4d53f115c84d20af09b046e`. Future upstream rebases: [skills/rebase-and-redocument/orchestrator.prompt](./skills/rebase-and-redocument/orchestrator.prompt).
 
@@ -19,7 +19,8 @@ The completed refactor followed staged discovery, test development, validation a
 | [03-implementation-plan.md](./03-implementation-plan.md) | Map of migrated targets |
 | [05-development-steering.md](./05-development-steering.md) | Development steering rules |
 | [06-test-framework.md](./06-test-framework.md) | Test and validation conventions |
-| [11-phase-3-closeout.md](./11-phase-3-closeout.md) | Human close-out + Player API residual (P3-R) |
+| [11-phase-3-closeout.md](./11-phase-3-closeout.md) | Human close-out + Player API residual pointer (P3-R) |
+| [player-aggregates/](./player-aggregates/) | P3-R\* plan: inventory, contract, milestones, orchestrator |
 | [12-idiom-enforcement.md](./12-idiom-enforcement.md) | Completed idiom-enforcement approach |
 | [idioms-00-charter.md](./idioms-00-charter.md) | Idiom rules and reference patterns |
 
@@ -28,7 +29,7 @@ The completed refactor followed staged discovery, test development, validation a
 - **P3-4:** Walk [the manual smoke matrix](./validations/r-milestone-smoke-matrix.html) and record the human results.
 - **P3-5:** Record the close-out retrospective.
 - **P3-6 (optional):** Merge after the rebase and human close-out are accepted.
-- **P3-R\*:** Player first-class APIs for class levels, milestones, award maps, and reconcile suggestions (see [11-phase-3-closeout.md](./11-phase-3-closeout.md)). Bootstrap Lib / Dangeraudit / index Health·Event model hop is done.
+- **P3-R\*:** Player first-class APIs for class levels, milestones, award maps, and reconcile suggestions — execute from [player-aggregates/](./player-aggregates/) (P3-R0 plan done; implement P3-R1…). Bootstrap Lib / Dangeraudit / index Health·Event model hop is done.
 
 The concise [remaining-work checklist](./04-milestone-checklist.md) tracks these items. [validations/README.md](./validations/README.md) points to the retained smoke matrix and archived validation history.
 

--- a/docs/megiddo/refactor/README.md
+++ b/docs/megiddo/refactor/README.md
@@ -2,11 +2,11 @@
 
 Migrate business logic and `$DB` / `Ork3::$Lib` access out of `orkui/` into `system/lib/ork3/` and `orkservice/*`.
 
-**Status:** Implementation, automated Phase 3 audit, gate fixes, idiom enforcement, and the post-refactor rebase are complete.
-**Current tip:** `megiddo/rebase-20260717` @ `729cc577`.
-**Remaining:** P3-4 manual smoke matrix, P3-5 retrospective, and optional P3-6 merge.
+**Status:** Implementation, automated Phase 3 audit, gate fixes, idiom enforcement, and the post-refactor rebase are complete. Human Phase 3 close-out and a Player first-class API residual remain.
+**Current tip:** `megiddo/fuzzy-validator-v2` (see [PR #492](https://github.com/amtgard/ORK3/pull/492)).
+**Remaining:** P3-4 manual smoke, P3-5 retrospective, optional P3-6 merge, and **P3-R\*** Player aggregate APIs ([11-phase-3-closeout.md](./11-phase-3-closeout.md)).
 
-**Last rebase:** 2026-07-18 onto `origin/master` @ `7631d0baad65b573d4d53f115c84d20af09b046e`. The completed run used gold fuzzy bundle `20260718T030809Z-7631d0ba-fd37ea34a9523a28.zip` captured from unrebased master and validated test + mirror 40/40. A future upstream rebase starts with [skills/rebase-and-redocument/orchestrator.prompt](./skills/rebase-and-redocument/orchestrator.prompt).
+**Last rebase:** 2026-07-18 onto `origin/master` @ `7631d0baad65b573d4d53f115c84d20af09b046e`. Future upstream rebases: [skills/rebase-and-redocument/orchestrator.prompt](./skills/rebase-and-redocument/orchestrator.prompt).
 
 ## Approach
 
@@ -19,7 +19,7 @@ The completed refactor followed staged discovery, test development, validation a
 | [03-implementation-plan.md](./03-implementation-plan.md) | Map of migrated targets |
 | [05-development-steering.md](./05-development-steering.md) | Development steering rules |
 | [06-test-framework.md](./06-test-framework.md) | Test and validation conventions |
-| [11-phase-3-closeout.md](./11-phase-3-closeout.md) | Final human close-out work |
+| [11-phase-3-closeout.md](./11-phase-3-closeout.md) | Human close-out + Player API residual (P3-R) |
 | [12-idiom-enforcement.md](./12-idiom-enforcement.md) | Completed idiom-enforcement approach |
 | [idioms-00-charter.md](./idioms-00-charter.md) | Idiom rules and reference patterns |
 
@@ -28,6 +28,7 @@ The completed refactor followed staged discovery, test development, validation a
 - **P3-4:** Walk [the manual smoke matrix](./validations/r-milestone-smoke-matrix.html) and record the human results.
 - **P3-5:** Record the close-out retrospective.
 - **P3-6 (optional):** Merge after the rebase and human close-out are accepted.
+- **P3-R\*:** Player first-class APIs for class levels, milestones, award maps, and reconcile suggestions (see [11-phase-3-closeout.md](./11-phase-3-closeout.md)). Bootstrap Lib / Dangeraudit / index Health·Event model hop is done.
 
 The concise [remaining-work checklist](./04-milestone-checklist.md) tracks these items. [validations/README.md](./validations/README.md) points to the retained smoke matrix and archived validation history.
 

--- a/docs/megiddo/refactor/idioms-00-charter.md
+++ b/docs/megiddo/refactor/idioms-00-charter.md
@@ -59,7 +59,7 @@ Read these before editing any hop scope. Match **the file being edited** first; 
 
 - Auth checks: `$this->Authorization->has_authority($uid, AUTH_*, $id, $role)` after `load_model('Authorization')`.
 - Auth mutations: `$this->Authorization->add_auth([…])` / `del_auth([…])`.
-- **Dangeraudit:** when `addauth` paths in a file already call `(new Dangeraudit())->audit(…)` after `add_auth`, keep that shape; when file peers route audit through `Model_Authorization`, match peers. Do not change audit payload fields or timing.
+- **Dangeraudit:** `$this->Authorization->audit(…)` after mutations (model wraps `Dangeraudit`). Do **not** `(new Dangeraudit())` in controllers. Do not change audit payload fields or timing.
 
 ### 1.4 JSON shapes and HTTP semantics
 
@@ -76,7 +76,7 @@ Read these before editing any hop scope. Match **the file being edited** first; 
 ### 1.6 Templates and `index.php`
 
 - Template hops (I-15, I-17, I-18): idiom = precomputed auth flags and helper calls consistent with sibling templates; no markup semantic changes.
-- `index.php`: bootstrap calls match R-13/R-14 established patterns (`Health::PingDb`, request-scoped session).
+- `index.php`: bootstrap via models (`Model_Health::ping_db`, `Model_Event::get_event_summary_for_redirect`), not bare `new Health()` / `new Event()`.
 
 ---
 
@@ -89,14 +89,23 @@ Catalog from R-19* execution and agent refactors. Fix only when the **file's dom
 | `(new Model_Player())` in AJAX | `PlayerAjax` username check | `$this->load_model('Player');` → `$this->Player->…` |
 | `(new EventPlanning())` in controller | `EventAjax::remove_rsvp` | `$this->load_model('EventPlanning');` → `$this->EventPlanning->…` |
 | `(new KingdomProfile())` after `load_model` | `KingdomAjax` suspension / abbr | `$this->KingdomProfile->…` (model already loaded) |
-| `(new Dangeraudit())->audit` beside `add_auth` | `KingdomAjax`, `EventAjax`, `AdminAjax`, `ParkAjax` | Keep if all `addauth` branches in file use inline audit; else add `Model_Authorization` wrapper if peers do |
+| `(new Dangeraudit())->audit` in controller | any `*Ajax` / `Unit` | `$this->Authorization->audit(…)` |
+| `Ork3::$Lib->…` in `class.Controller` or `orkui/` | bootstrap prefs / session | `$this->load_model(…)` → snake_case wrapper |
 | `(new Heraldry())->SetEventHeraldry` in controller | `EventAjax` | `$this->load_model('EventPlanning')` or heraldry wrapper on model used elsewhere in file |
 | `(new Weather())` in `Controller_Admin` | weather stats / refresh | `$this->load_model('Weather')` or `Model_AdminDashboard` wrapper |
 | `new SearchService()` only in new model while siblings use `JSONModel` | `Model_Search` (R-11) | Match `model.Event.php` / domain wrapper style in same domain |
 | Mixed `[]` and `array()` within one method | various AJAX | Match **method's** nearest siblings, not PSR-12 |
 | Reformatting entire file for tabs/spaces | any | **Forbidden** — touch only idiom lines |
 
-**Static isolation (non-negotiable):** `rg '\$DB->' orkui/` and `rg 'Ork3::\$Lib' orkui/` must remain zero after every hop.
+**Static isolation (non-negotiable):**
+
+```bash
+rg '\$DB->' orkui/                                    # expect: no matches
+rg 'Ork3::\$Lib' orkui/                              # expect: no matches
+rg 'Ork3::\$Lib' system/lib/system/class.Controller.php   # expect: no matches
+rg '\(new Dangeraudit\(\)\)' orkui/controller/       # expect: no matches
+```
+
 
 ---
 
@@ -145,8 +154,10 @@ Run from repo root. **Exit 0** = pass for PHPUnit; **exit 1 (no matches)** = pas
 ### 4.1 Static isolation (every I-* hop)
 
 ```bash
-rg '\$DB->' orkui/                    # expect: no matches
-rg 'Ork3::\$Lib' orkui/              # expect: no matches
+rg '\$DB->' orkui/                                          # expect: no matches
+rg 'Ork3::\$Lib' orkui/                                    # expect: no matches
+rg 'Ork3::\$Lib' system/lib/system/class.Controller.php     # expect: no matches
+rg '\(new Dangeraudit\(\)\)' orkui/controller/             # expect: no matches
 ```
 
 ### 4.2 Controller idiom drift
@@ -156,7 +167,7 @@ rg 'Ork3::\$Lib' orkui/              # expect: no matches
 rg '\(new Model_' orkui/controller/
 
 # Inline domain construction in controllers (prefer load_model + model wrapper)
-rg '\(new (Player|EventPlanning|KingdomProfile|Heraldry|Weather|Dangeraudit|Report|SearchService)\(\)' orkui/controller/
+rg '\(new (Player|EventPlanning|KingdomProfile|Heraldry|Weather|Report|SearchService)\(\)' orkui/controller/
 
 # Model_* instantiated without load_model in AJAX controllers
 rg 'new Model_' orkui/controller/

--- a/docs/megiddo/refactor/player-aggregates/01-inventory.md
+++ b/docs/megiddo/refactor/player-aggregates/01-inventory.md
@@ -1,0 +1,175 @@
+# P3-R inventory — Player aggregate rule sites
+
+Line numbers are approximate as of the Megiddo tip that includes the bootstrap model hop (`Controller_Player` / revised Player templates). Re-verify if upstream drifts.
+
+**Product rule under scrutiny:** domain knowledge encoded in UI must become callable domain/model APIs.
+
+---
+
+## 1. Class-level thresholds — `Controller_Player`
+
+**File:** `orkui/controller/controller.Player.php`  
+**Method:** `profile`  
+**Lines:** ~449–468
+
+| What | Rule encoded |
+|------|----------------|
+| Inline `if ($credits >= 53) … elseif (>= 34) … (>= 21) … (>= 12) … (>= 5)` | Class level from credits+reconciled; levels 1–6 |
+| Max over classes → `$this->data['Stats']['HighestClassLevel']` | Profile chrome “highest class level” |
+
+**Canonical home already exists:** `system/lib/ork3/class.ClassLevel.php` — `THRESHOLDS = [5, 12, 21, 34, 53]` and `ClassLevel::computeClassLevel(float $credits): array{Level, ToNext}`.
+
+**Related existing API:** `Player::ComputeClassProgress(['MundaneId' => …])` returns per-class `{ClassId, ClassName, Credits, Level, ToNext}` using `GetPlayerClasses` credit semantics (same helper SignIn uses via `Model_Attendance::enrich_classes_with_progress`).
+
+**Risk:** Profile currently levels `Details['Classes']` from `fetch_player_details`. Confirm credits(+Reconciled) match `GetPlayerClasses` / `ComputeClassProgress` before switching HighestClassLevel to the progress API alone. Prefer `ClassLevel::computeClassLevel` over the same credit inputs the UI already has if semantics must stay byte-identical for fuzzy.
+
+**Target:** Domain helper (or thin `Player` wrapper) → model → controller assigns `Stats['HighestClassLevel']` only. No thresholds in controller.
+
+---
+
+## 2. Milestone timeline — `Controller_Player`
+
+**File:** `orkui/controller/controller.Player.php`  
+**Method:** `profile`  
+**Lines:** ~515–669 (plus beltline peer display dedupe ~671–691 that must run *after* milestones)
+
+| Block | Lines (approx) | Rule encoded |
+|-------|----------------|--------------|
+| First sign-in | 520–525 | `PlayerSinceDate` → `type: first_signin` |
+| Knight awards | 533–555 | AwardIds `[17,18,19,20,245]` + display names Flame/Crown/Serpent/Sword/Battle |
+| Master awards | 535, 557–561 | Master AwardIds `[1–11,240,244]` (mirrors template order→master values) |
+| Paragon awards | 563–567 | Paragon AwardIds `[37–47,49–51,241,242]` |
+| Title / officer | 569–580 | IsTitle + OfficerRole filters; suppress beltline-aliased custom titles |
+| Became / took associate | 583–606 | Beltline peers/associates + peerage label map |
+| Custom milestones | 608–620 | Already domain: `Model_Player::get_custom_milestones` → `Player::GetCustomMilestones` |
+| Cross-type dedup | 622–649 | Drop title milestones that duplicate peerage / Master X |
+| Exact dedup + sort | 651–665 | Same description+date; chronological ascending |
+
+**Inputs already available to domain:** awards list, classes (unused for level-6 milestones — those are AJAX/client), `PlayerSinceDate`, beltline peers/associates, custom milestones.
+
+**Target:** `Player::GetPlayerMilestones(…)` (name per [02-api-contract.md](./02-api-contract.md)) returning ready timeline rows. Controller: `$this->data['Milestones'] = …`. Knight/master/paragon ID catalogues become shared constants or `Award` static maps (single source with template belt icons / ladder maps).
+
+---
+
+## 3. Award maps & ladder progress — `Playernew_index.tpl`
+
+**File:** `orkui/template/revised-frontend/Playernew_index.tpl`
+
+### 3a. Class → Paragon map
+
+**Lines:** ~132–136 (preamble); consumed ~2571–2599 (Class Levels tab)
+
+```text
+$pnClassToParagon = [
+  1=>37, 2=>38, 3=>39, 4=>40, 5=>41, 6=>241, 7=>42, 8=>43,
+  9=>44, 10=>45, 11=>46, 12=>47, 14=>242, 15=>49, 16=>50, 17=>51,
+];
+```
+
+**Also:** JS payload ~3979 `classToParagon: <?= json_encode($pnClassToParagon) ?>`.
+
+**Rule:** Which Paragon award_id corresponds to each class_id for badge display.
+
+**No domain API today.** Net-new `Award::GetClassParagonMap()` (or equivalent on `Player`).
+
+### 3b. Order → Master map (duplicate of domain)
+
+**Lines:** ~2134–2165 (`$pnOrderToMaster`, `$pnOrderNames`); ladder tile build ~2166–2232
+
+**Canonical home already exists:** `Award::GetLadderMasterMap()` in `system/lib/ork3/class.Award.php` — same order/master pairs, names, and `MaxRank` (Zodiac 12). Comment in Award.php already says keep in sync with this template.
+
+**Irony:** Template **already** calls `Award::GetLadderMasterMap()` at ~3915 for JS recommendation logic while the Awards tab still hardcodes `$pnOrderToMaster`.
+
+**Target:** Delete template maps; consume `GetLadderMasterMap()` via controller/model-assigned DTO. Prefer building **ladder progress tiles** in domain (`Player::GetLadderProgress`) so Approx/max-rank/master-fill logic is not template-owned.
+
+### 3c. Ladder progress algorithm (template-owned)
+
+**Lines:** ~2132–2232
+
+| Step | Rule |
+|------|------|
+| Filter ladder awards; skip Walker (31) | Which awards count toward tiles |
+| Aggregate Rank / RankSet / UnrankedCount | Dedup by rank; count unranked historical |
+| HasMaster via order→master map | Master badge |
+| Approx when effective count > Rank and no Master | Historical approximation `~` |
+| Cap Rank at MaxRank (10 / Zodiac 12) | Max rank per order |
+| Synthetic tile when Master held but no ladder rows | Complete masterhood display |
+
+**Target:** Domain DTO list of tiles `{AwardId, Name, Short, Rank, MaxRank, HasMaster, Approx}`; template only renders.
+
+### 3d. Knight belt catalogue (related, same AwardId set)
+
+**Lines:** ~31–65
+
+| What | Rule |
+|------|------|
+| `$knightAwardIds` | Same IDs as controller milestone knights |
+| `$beltImageMap` | Asset paths per knighthood |
+| AliasAwardId promotion | Custom Title aliased to Knight-of-X counts as that belt |
+
+**Recommendation:** Include knight AwardId/name catalogue in the shared Award/Player maps under P3-R2 so controller milestones and template belts cannot drift. Belt **image URLs** may remain presentation (host/path) if the API returns AwardIds + labels only — document choice in the R2 commit.
+
+### 3e. Historical presence flags
+
+**Lines:** ~90–114 (`$hasHistorical`, `$hasHistoricalTip`)
+
+**Rule:** Ladder award with `GivenById === 0 && EnteredById === 0` (and OfficerRole/IsTitle filters). Admin CTA vs public tip.
+
+**Target:** Prefer deriving from reconcile page DTO / `Player::HasHistoricalLadderAwards` (or flags on reconcile/ladder APIs) so the filter is not copied a third time in the template. Can land with P3-R3 if R2 stays map-focused.
+
+---
+
+## 4. Reconcile smart rank — `Playernew_reconcile.tpl`
+
+**File:** `orkui/template/revised-frontend/Playernew_reconcile.tpl`  
+**Lines:** ~13–73 (logic); remainder is display/JS POST to `PlayerAjax/.../reconcileaward`
+
+| Block | Rule encoded |
+|-------|----------------|
+| Partition awards | Historical = GivenById 0 AND EnteredById 0; else collect real ranks by AwardId |
+| Ladder-only filter | `IsLadder === 1` for reconcilable rows |
+| Sort | AwardId ASC, date ASC (missing dates last) |
+| Smart rank | Prefer existing Rank if unused by real+suggested; else smallest free positive integer per AwardId group |
+
+**Already domain:** `Player::GetReconcileAwardMap($kingdomId)` / `Model_Player::get_reconcile_award_map` — award_id → kingdomaward_id for dropdowns (controller ~780). Keep; extend with suggestions aggregate.
+
+**Target:** `Player::GetReconcileSuggestions` (or `GetReconcilePageData`) returning historical rows + `SuggestedRank` + summary counts. Template display-only; auth gate can stay controller or thin template check using controller-provided flags.
+
+---
+
+## 5. Existing domain / model inventory (do not reinvent)
+
+| API | Layer | Role |
+|-----|-------|------|
+| `ClassLevel::computeClassLevel` / `THRESHOLDS` | Domain static | Level + ToNext |
+| `Player::ComputeClassProgress` | Domain | Per-class progress via GetPlayerClasses |
+| `Model_Attendance::enrich_classes_with_progress` | Model | SignIn enrichment pattern to mirror |
+| `Award::GetLadderMasterMap` | Domain static | Order → MasterAwardIds, names, MaxRank |
+| `Player::GetReconcileAwardMap` | Domain | Kingdom award map for reconcile UI |
+| `Player::GetCustomMilestones` (+ CRUD siblings) | Domain | Custom timeline rows |
+| `Model_Player::get_custom_milestones` / `get_beltline_for_player` / `get_reconcile_award_map` | Model | Existing snake_case wrappers |
+| `tests/Unit/ClassLevelTest.php` | Test | Threshold characterization |
+| `tests/Integration/AttendanceSignInTest.php` | Test | ComputeClassProgress integration |
+| `tests/Integration/LadderGridTest.php` | Test | GetLadderMasterMap consumers |
+
+---
+
+## 6. Explicit non-goals (this residual)
+
+- Moving feast prefs, dues, voting eligibility, or qual-test chrome (already mostly model-backed).
+- Changing Amtgard ladder / paragon / knight product rules.
+- Re-recording fuzzy baselines without intentional UI change (P3-R4 should be behavior-preserving).
+- Mandatory orkservice SOAP/JSON registration (optional stretch on P3-R4).
+
+---
+
+## 7. Drift checklist for implementers
+
+Before deleting a template/controller block, grep for the same AwardId list elsewhere:
+
+```bash
+rg -n 'pnOrderToMaster|pnClassToParagon|GetLadderMasterMap|__knightIds|__paragonIds|>= 53' \
+  orkui/ system/lib/ork3/ docs/megiddo/refactor/player-aggregates/
+```
+
+Single source of truth after P3-R2/R3: domain `Award` / `Player` / `ClassLevel` only.

--- a/docs/megiddo/refactor/player-aggregates/02-api-contract.md
+++ b/docs/megiddo/refactor/player-aggregates/02-api-contract.md
@@ -1,0 +1,276 @@
+# P3-R API contract — Player aggregates
+
+Naming: **PascalCase** on domain (`system/lib/ork3/`), **snake_case** on `Model_Player` wrappers. Prefer extending `Player`, `ClassLevel`, and `Award`. Controllers call models only (idiom charter §1.3 / bootstrap hop).
+
+Status codes follow existing Ork3 `Success` / `InvalidParameter` envelopes where methods take `$request` arrays.
+
+---
+
+## A. Already shipped (consume, do not fork)
+
+### `ClassLevel` (`system/lib/ork3/class.ClassLevel.php`)
+
+```php
+ClassLevel::THRESHOLDS; // [5, 12, 21, 34, 53]
+ClassLevel::computeClassLevel(float $credits): array{Level: int, ToNext: ?float}
+```
+
+### `Player::ComputeClassProgress`
+
+```php
+Player::ComputeClassProgress(['MundaneId' => int]): Status|Success(list<{
+  ClassId, ClassName, Credits, Level, ToNext
+}>)
+```
+
+Model pattern (SignIn): `Model_Attendance::enrich_classes_with_progress`.
+
+### `Award::GetLadderMasterMap`
+
+```php
+Award::GetLadderMasterMap(): array<int, array{
+  MasterAwardIds: list<int>,
+  LadderName: string,
+  MasterName: string,
+  MaxRank: int
+}>
+// Keys = order/ladder AwardId (21, 22, … 243)
+```
+
+### `Player::GetReconcileAwardMap`
+
+```php
+Player::GetReconcileAwardMap(int $kingdomId): array<int, int> // award_id => kingdomaward_id
+```
+
+Model: `get_reconcile_award_map($kingdom_id)`.
+
+### Custom milestones
+
+`Player::GetCustomMilestones($mundane_id)` (+ existing add/update/delete). Model: `get_custom_milestones`.
+
+---
+
+## B. Proposed net-new / extended APIs
+
+Names are proposals; implementers may rename for consistency with neighboring `Player` methods but must keep one clear domain entry point per concern.
+
+### B1. Class stats for profile chrome — **P3-R1**
+
+**Problem:** Controller duplicates thresholds to compute `HighestClassLevel`.
+
+**Option A (preferred if credit semantics match):**
+
+```php
+// Domain
+Player::GetHighestClassLevel(int $mundaneId): int
+// Implementation: max Level from ComputeClassProgress Detail; 0 if none
+
+// Model
+Model_Player::get_highest_class_level(int $mundane_id): int
+```
+
+**Option B (byte-identical to today’s profile loop):**
+
+```php
+// Domain — pure function over already-fetched class rows
+Player::HighestClassLevelFromClasses(array $classes): int
+// Each row: Credits + Reconciled (or Credits already combined); uses ClassLevel::computeClassLevel
+
+// Model
+Model_Player::highest_class_level_from_classes(array $classes): int
+```
+
+Controller assigns `$this->data['Stats']['HighestClassLevel']` from the model. No threshold literals in `orkui/`.
+
+**Characterization:** Extend `ClassLevelTest` and/or add a small `Player` unit/integration case for HighestClassLevel vs known credit fixtures. Assert controller no longer contains `>= 53` / `>= 34` / etc.
+
+---
+
+### B2. Shared award catalogues — **P3-R2**
+
+Centralize ID lists currently triple-encoded (controller milestones, template belts, template paragon).
+
+```php
+// Domain (Award static helpers — keep next to GetLadderMasterMap)
+
+Award::GetClassParagonMap(): array<int, int>
+// class_id => paragon award_id
+// Source of truth for $pnClassToParagon
+
+Award::GetKnightAwardMap(): array<int, string>
+// award_id => short name (Flame, Crown, …)
+// IDs: 17,18,19,20,245 — shared by milestones + belt detection
+
+Award::GetMasterAwardIds(): list<int>
+// Flatten MasterAwardIds from GetLadderMasterMap() — replaces $__masterIds
+
+Award::GetParagonAwardIds(): list<int>
+// Values of GetClassParagonMap() (or explicit list matching controller today)
+```
+
+Model wrappers only if templates/controllers need them without importing `Award` (prefer controller passes maps into `$this->data`):
+
+```php
+Model_Player::get_class_paragon_map(): array
+Model_Player::get_ladder_master_map(): array  // thin → Award::GetLadderMasterMap()
+```
+
+**Note:** Templates must not call `new Award()` / static domain if idiom prefers model-only. Assign from controller: `$this->data['ClassParagonMap']`, `$this->data['LadderMasterMap']`.
+
+---
+
+### B3. Milestone timeline — **P3-R2**
+
+```php
+// Domain
+Player::GetPlayerMilestones(array $request): Status|Success(list<MilestoneRow>)
+
+// Request (flexible — prefer passing already-loaded aggregates to avoid N+1):
+[
+  'MundaneId' => int,                 // required if loading internally
+  'PlayerSinceDate' => ?string,       // optional override
+  'Awards' => ?list,                  // optional; else load via existing detail APIs
+  'BeltlinePeers' => ?list,
+  'BeltlineAssociates' => ?list,
+  'IncludeCustom' => bool,            // default true
+]
+
+// MilestoneRow
+[
+  'type' => string,           // first_signin|knight|master|paragon|title|officer|
+                              // became_associate|took_associate|custom
+  'date' => string,           // Y-m-d
+  'icon' => string,           // fa-* class suffix currently used by UI
+  'description' => string,
+  'milestoneId' => ?int,      // custom only
+]
+```
+
+```php
+// Model
+Model_Player::get_player_milestones(array $request): array  // Success envelope or list — match sibling style
+```
+
+**Controller after wire:** build/fetch beltline as today → call model → `$this->data['Milestones']`; keep peer display dedupe after milestones (or move both into domain with a documented order).
+
+**Characterization:** Fixture player with known awards/peers; assert types, dedup of Master title vs master award, chronological order. Freeze knight/paragon ID sets in unit tests against `Award::*` maps.
+
+---
+
+### B4. Ladder progress tiles — **P3-R2**
+
+```php
+// Domain
+Player::GetLadderProgress(array $request): Status|Success(list<LadderTile>)
+
+// Request
+[
+  'MundaneId' => int,
+  'Awards' => ?list,   // optional preloaded Details['Awards']
+]
+
+// LadderTile (sorted by Name for stable UI)
+[
+  'AwardId' => int,       // order/ladder award_id
+  'Name' => string,
+  'Short' => string,
+  'Rank' => int,          // capped display rank
+  'MaxRank' => int,       // from GetLadderMasterMap
+  'HasMaster' => bool,
+  'Approx' => bool,
+]
+```
+
+Uses `Award::GetLadderMasterMap()` only — delete `$pnOrderToMaster` / `$pnOrderNames`.
+
+```php
+// Model
+Model_Player::get_ladder_progress(array $request): array
+```
+
+---
+
+### B5. Reconcile suggestions — **P3-R3**
+
+```php
+// Domain
+Player::GetReconcilePageData(array $request): Status|Success(ReconcilePageDto)
+
+// Request
+[
+  'MundaneId' => int,
+  'KingdomId' => int,     // for AwardId→KingdomAwardId map
+  'Awards' => ?list,      // optional Details['Awards']
+]
+
+// ReconcilePageDto
+[
+  'HistoricalAwards' => list<array>,  // ladder historical rows, sorted
+  'RankSuggestions' => array<int, int>, // AwardsId => suggested Rank
+  'RealRanksByAwardId' => array<int, list<int>>,
+  'AwardIdToKingdomAwardId' => array<int, int>,
+  'Summary' => [
+    'AwardTypeCount' => int,
+    'TotalCount' => int,
+  ],
+  'HasHistoricalLadder' => bool,      // for profile CTA / tip
+]
+```
+
+Smart-rank algorithm must match current template behavior (see [01-inventory.md](./01-inventory.md) §4) — characterization tests before deleting template PHP.
+
+```php
+// Model
+Model_Player::get_reconcile_page_data(array $request): array
+```
+
+**Optional split:** `GetReconcileSuggestions($awards)` pure function + map fetch, if that eases unit testing without DB.
+
+---
+
+## C. Controller / template data contracts after wire (P3-R4)
+
+### `Controller_Player::profile`
+
+Assign (names illustrative):
+
+| `$this->data[…]` | Source |
+|------------------|--------|
+| `Stats['HighestClassLevel']` | B1 |
+| `Milestones` / `CustomMilestones` | B3 + existing custom fetch |
+| `LadderProgress` | B4 |
+| `ClassParagonMap` | B2 |
+| `LadderMasterMap` | B2 / existing Award map |
+| `HasHistorical` / `HasHistoricalTip` | B5 flags or light helper |
+| `AwardIdToKingdomAwardId` | existing (reconcile only) |
+
+Templates: remove `$pnOrderToMaster`, `$pnClassToParagon`, inline smart-rank, inline class thresholds. Iterate DTOs / maps from `$this->data`.
+
+### `Controller_Player::reconcile`
+
+Assign full `ReconcilePageDto` fields; template drops partition/suggestion PHP.
+
+---
+
+## D. Optional orkservice exposure — **P3-R4 stretch**
+
+Not required for UI thinness. If external clients need the same DTOs:
+
+| Domain | Suggested JSON registration |
+|--------|------------------------------|
+| `GetPlayerMilestones` | `PlayerService.GetPlayerMilestones` |
+| `GetLadderProgress` | `PlayerService.GetLadderProgress` |
+| `GetReconcilePageData` | `PlayerService.GetReconcilePageData` |
+| `GetHighestClassLevel` / progress | may already be reachable via class APIs — register only if gap |
+
+Follow existing `PlayerService` registration patterns (`*.registration.php`, `*.function.php`, definitions). SOAP only if the service still maintains dual surface for that method family.
+
+---
+
+## E. Anti-patterns
+
+- Do not add a second `THRESHOLDS` array anywhere.
+- Do not leave `$pnOrderToMaster` “for convenience” once `GetLadderMasterMap` is wired.
+- Do not call `Ork3::$Lib` or `$DB` from `orkui/` while implementing these APIs.
+- Do not put smart-rank or AwardId lists into JavaScript as the source of truth; JS may receive JSON copies of domain maps for client UX only.

--- a/docs/megiddo/refactor/player-aggregates/03-milestones.md
+++ b/docs/megiddo/refactor/player-aggregates/03-milestones.md
@@ -1,0 +1,135 @@
+# P3-R milestones — Player aggregate APIs
+
+Executable checklist for implementers / orchestrator. IDs reuse **P3-R0…P3-R4** from [11-phase-3-closeout.md](../11-phase-3-closeout.md). Branch one milestone at a time per [05-development-steering.md](../05-development-steering.md) (e.g. `megiddo/p3-r1-class-level-api`).
+
+**Steering:** Full PHPUnit suite before sign-off (DS-4/5). One commit per milestone unless the active branch already holds related docs. Do not push/PR unless asked.
+
+---
+
+## Gates (every implementing milestone)
+
+| Gate | Command / check |
+|------|-----------------|
+| PHPUnit | Full suite per [06-test-framework.md](../06-test-framework.md) |
+| Static `orkui/` | Zero `$DB` access and zero `Ork3::$Lib` (existing Phase 3 greps) |
+| Idiom | Controllers use `Model_*` only for new hops; no `(new Player())` / Lib in `orkui/controller` |
+| Fuzzy (P3-R4) | `player-profile` (+ sandbox if used) **test + mirror** validate; re-record only with intentional drift approval |
+
+---
+
+## P3-R0 — Inventory + contract
+
+**Status:** Complete when this `player-aggregates/` package is committed.
+
+- [x] Inventory file:line sites ([01-inventory.md](./01-inventory.md))
+- [x] API contract ([02-api-contract.md](./02-api-contract.md))
+- [x] Cross-links from Phase 3 close-out / remaining checklist / refactor README
+- [x] Orchestrator / agent prompts for follow-on implementation
+
+**Acceptance:** Docs only; no production PHP changes required.
+
+---
+
+## P3-R1 — Class level / progress API
+
+**Goal:** Remove threshold block from `Controller_Player::profile`; use `ClassLevel` / `Player` (mirror SignIn).
+
+### Work
+
+- [ ] Choose Option A or B from [02-api-contract.md](./02-api-contract.md) §B1 after comparing `Details['Classes']` credits vs `ComputeClassProgress`
+- [ ] Implement domain + `Model_Player` wrapper
+- [ ] Wire controller: assign `Stats['HighestClassLevel']` from model; delete inline `>= 53`… chain
+- [ ] PHPUnit characterization (extend `ClassLevelTest` and/or Player/integration)
+
+### Acceptance
+
+- [ ] No class-level threshold literals in `orkui/controller/controller.Player.php`
+- [ ] Full PHPUnit green
+- [ ] Static `orkui/` Lib/$DB clean
+- [ ] Behavior: HighestClassLevel matches pre-change for fixture players (test assertion)
+
+**Fuzzy:** Not required if chrome number is unchanged; optional spot-check.
+
+---
+
+## P3-R2 — Milestones + award maps + ladder progress
+
+**Goal:** AwardId catalogues and timeline/ladder algorithms leave controller/templates.
+
+### Work
+
+- [ ] Add `Award::GetClassParagonMap` (+ knight/master/paragon helpers as needed); ensure `GetLadderMasterMap` is the only order→master source
+- [ ] Implement `Player::GetPlayerMilestones` + model wrapper; port controller block ~515–669 including dedup/sort
+- [ ] Implement `Player::GetLadderProgress` + model wrapper; port template ladder tile algorithm
+- [ ] Thin `Controller_Player::profile`: assign `Milestones`, `LadderProgress`, maps
+- [ ] Thin `Playernew_index.tpl`: remove `$pnOrderToMaster`, `$pnOrderNames`, `$pnClassToParagon`; iterate DTOs; knight belt detection may consume shared knight map
+- [ ] PHPUnit: map equality vs former literals; milestone fixture cases; ladder Approx/Master edge cases
+
+### Acceptance
+
+- [ ] `rg 'pnOrderToMaster|pnClassToParagon|__knightIds|__paragonIds'` clean under `orkui/` (except comments pointing to domain if any)
+- [ ] Template does not define order→master or class→paragon maps
+- [ ] Full PHPUnit green; static gates clean
+- [ ] Visual/DOM behavior preserved for Awards / Class Levels / Milestones tabs (manual or fuzzy later)
+
+**Note:** Belt image URL assembly may remain in template if AwardIds come from domain.
+
+---
+
+## P3-R3 — Reconcile suggestions API
+
+**Goal:** Smart-rank and historical partition leave `Playernew_reconcile.tpl`.
+
+### Work
+
+- [ ] Implement `Player::GetReconcilePageData` (or split pure suggestion helper) + model wrapper
+- [ ] Characterization tests locking smart-rank outcomes for mixed historical/real rank sets
+- [ ] Wire `Controller_Player::reconcile`; template display-only
+- [ ] Optional: profile `HasHistorical` / `HasHistoricalTip` from same helper (remove duplicate filter in index tpl)
+
+### Acceptance
+
+- [ ] No smart-rank / historical partition algorithm in `Playernew_reconcile.tpl`
+- [ ] `GetReconcileAwardMap` still used (via page DTO or existing assign)
+- [ ] Full PHPUnit green; static gates clean
+
+---
+
+## P3-R4 — Wire + gate (+ optional orkservice)
+
+**Goal:** End-to-end thin UI; prove with fuzzy; optionally expose JSON.
+
+### Work
+
+- [ ] Confirm all P3-R1–R3 call sites wired; grep inventory §7 clean
+- [ ] Fuzzy validate `player-profile` (and `player-profile-sandbox` if in active setpoint) on **test** and **mirror**
+- [ ] Re-record baselines only if intentional drift approved; otherwise fix regressions
+- [ ] Update [04-milestone-checklist.md](../04-milestone-checklist.md) / close-out notes: check off P3-R*
+- [ ] **Optional stretch:** register thin `PlayerService` methods for milestones / ladder / reconcile DTOs ([02-api-contract.md](./02-api-contract.md) §D) — does not block UI sign-off
+
+### Acceptance
+
+- [ ] Controllers/templates contain no ladder rule literals (thresholds, AwardId catalogues, smart-rank)
+- [ ] Full PHPUnit green
+- [ ] Static `orkui/` Lib/$DB clean
+- [ ] Fuzzy player-profile test+mirror pass
+- [ ] Checklist boxes for P3-R0…R4 marked done; human P3-4/5/6 untouched
+
+---
+
+## Suggested agent order
+
+```text
+P3-R0 (docs) → P3-R1 → P3-R2 → P3-R3 → P3-R4
+```
+
+Do not parallelize R1–R4 on overlapping `Controller_Player` / template files. Use [orchestrator.prompt](./orchestrator.prompt) to serialize workers from [agent-prompt.md](./agent-prompt.md).
+
+---
+
+## Open questions (resolve during R1–R3, document in commit)
+
+1. **Credit semantics:** Does `fetch_player_details` Classes credits match `GetPlayerClasses`? Chooses B1 Option A vs B.
+2. **Belt assets:** Domain returns AwardIds only vs include relative image keys.
+3. **Milestone icons:** Keep Font Awesome class strings in domain DTO (current) vs map type→icon in template.
+4. **orkservice:** Defer forever vs register in R4 for one client — product call, not a gate.

--- a/docs/megiddo/refactor/player-aggregates/03-milestones.md
+++ b/docs/megiddo/refactor/player-aggregates/03-milestones.md
@@ -89,16 +89,18 @@ Executable checklist for implementers / orchestrator. IDs reuse **P3-R0…P3-R4*
 
 ### Work
 
-- [ ] Implement `Player::GetReconcilePageData` (or split pure suggestion helper) + model wrapper
-- [ ] Characterization tests locking smart-rank outcomes for mixed historical/real rank sets
-- [ ] Wire `Controller_Player::reconcile`; template display-only
-- [ ] Optional: profile `HasHistorical` / `HasHistoricalTip` from same helper (remove duplicate filter in index tpl)
+- [x] Implement `Player::GetReconcilePageData` (or split pure suggestion helper) + model wrapper
+- [x] Characterization tests locking smart-rank outcomes for mixed historical/real rank sets
+- [x] Wire `Controller_Player::reconcile`; template display-only
+- [x] Optional: profile `HasHistorical` / `HasHistoricalTip` from same helper (remove duplicate filter in index tpl)
 
 ### Acceptance
 
-- [ ] No smart-rank / historical partition algorithm in `Playernew_reconcile.tpl`
-- [ ] `GetReconcileAwardMap` still used (via page DTO or existing assign)
-- [ ] Full PHPUnit green; static gates clean
+- [x] No smart-rank / historical partition algorithm in `Playernew_reconcile.tpl`
+- [x] `GetReconcileAwardMap` still used (via page DTO or existing assign)
+- [x] Full PHPUnit green; static gates clean
+
+**Notes:** Pure `GetReconcileSuggestions` + page DTO `GetReconcilePageData` (includes award map). Profile flags use suggestions helper only (no map DB hit).
 
 ---
 

--- a/docs/megiddo/refactor/player-aggregates/03-milestones.md
+++ b/docs/megiddo/refactor/player-aggregates/03-milestones.md
@@ -34,19 +34,21 @@ Executable checklist for implementers / orchestrator. IDs reuse **P3-R0…P3-R4*
 
 **Goal:** Remove threshold block from `Controller_Player::profile`; use `ClassLevel` / `Player` (mirror SignIn).
 
+**Choice (credit semantics):** **Option A** — `Player::GetHighestClassLevel` via `ComputeClassProgress`. Evidence: `GetPlayerProfileDetails` already loads `Classes` from `GetPlayerClasses`, the same source `ComputeClassProgress` uses (Credits + Reconciled). `HighestClassLevelFromClasses` remains as a pure characterization helper (Option B path) and matches Option A on those rows.
+
 ### Work
 
-- [ ] Choose Option A or B from [02-api-contract.md](./02-api-contract.md) §B1 after comparing `Details['Classes']` credits vs `ComputeClassProgress`
-- [ ] Implement domain + `Model_Player` wrapper
-- [ ] Wire controller: assign `Stats['HighestClassLevel']` from model; delete inline `>= 53`… chain
-- [ ] PHPUnit characterization (extend `ClassLevelTest` and/or Player/integration)
+- [x] Choose Option A or B from [02-api-contract.md](./02-api-contract.md) §B1 after comparing `Details['Classes']` credits vs `ComputeClassProgress`
+- [x] Implement domain + `Model_Player` wrapper
+- [x] Wire controller: assign `Stats['HighestClassLevel']` from model; delete inline `>= 53`… chain
+- [x] PHPUnit characterization (extend `ClassLevelTest` and/or Player/integration)
 
 ### Acceptance
 
-- [ ] No class-level threshold literals in `orkui/controller/controller.Player.php`
-- [ ] Full PHPUnit green
-- [ ] Static `orkui/` Lib/$DB clean
-- [ ] Behavior: HighestClassLevel matches pre-change for fixture players (test assertion)
+- [x] No class-level threshold literals in `orkui/controller/controller.Player.php`
+- [x] Full PHPUnit green
+- [x] Static `orkui/` Lib/$DB clean
+- [x] Behavior: HighestClassLevel matches pre-change for fixture players (test assertion)
 
 **Fuzzy:** Not required if chrome number is unchanged; optional spot-check.
 
@@ -129,7 +131,7 @@ Do not parallelize R1–R4 on overlapping `Controller_Player` / template files. 
 
 ## Open questions (resolve during R1–R3, document in commit)
 
-1. **Credit semantics:** Does `fetch_player_details` Classes credits match `GetPlayerClasses`? Chooses B1 Option A vs B.
+1. **Credit semantics:** **Resolved (P3-R1):** `fetch_player_details` / `GetPlayerProfileDetails` Classes come from `GetPlayerClasses` — same as `ComputeClassProgress`. Chose **Option A** (`GetHighestClassLevel`). Option B helper `HighestClassLevelFromClasses` kept for characterization.
 2. **Belt assets:** Domain returns AwardIds only vs include relative image keys.
 3. **Milestone icons:** Keep Font Awesome class strings in domain DTO (current) vs map type→icon in template.
 4. **orkservice:** Defer forever vs register in R4 for one client — product call, not a gate.

--- a/docs/megiddo/refactor/player-aggregates/03-milestones.md
+++ b/docs/megiddo/refactor/player-aggregates/03-milestones.md
@@ -58,20 +58,25 @@ Executable checklist for implementers / orchestrator. IDs reuse **P3-R0…P3-R4*
 
 **Goal:** AwardId catalogues and timeline/ladder algorithms leave controller/templates.
 
+**Open-question decisions (this milestone):**
+- **Belt assets:** Domain returns AwardIds + short names (`GetKnightAwardMap`); belt **IMAGE URLs** remain in the template (host/path presentation).
+- **Milestone icons:** Font Awesome class strings stay in the domain DTO (`icon` field) — template renders as-is (matches pre-R2 controller behavior).
+- **Master catalogue:** `GetMasterAwardIds` flattens `GetLadderMasterMap` and **includes Warlord (12)** — former controller list omitted 12; unified on the ladder map as sole source.
+
 ### Work
 
-- [ ] Add `Award::GetClassParagonMap` (+ knight/master/paragon helpers as needed); ensure `GetLadderMasterMap` is the only order→master source
-- [ ] Implement `Player::GetPlayerMilestones` + model wrapper; port controller block ~515–669 including dedup/sort
-- [ ] Implement `Player::GetLadderProgress` + model wrapper; port template ladder tile algorithm
-- [ ] Thin `Controller_Player::profile`: assign `Milestones`, `LadderProgress`, maps
-- [ ] Thin `Playernew_index.tpl`: remove `$pnOrderToMaster`, `$pnOrderNames`, `$pnClassToParagon`; iterate DTOs; knight belt detection may consume shared knight map
-- [ ] PHPUnit: map equality vs former literals; milestone fixture cases; ladder Approx/Master edge cases
+- [x] Add `Award::GetClassParagonMap` (+ knight/master/paragon helpers as needed); ensure `GetLadderMasterMap` is the only order→master source
+- [x] Implement `Player::GetPlayerMilestones` + model wrapper; port controller block ~515–669 including dedup/sort
+- [x] Implement `Player::GetLadderProgress` + model wrapper; port template ladder tile algorithm
+- [x] Thin `Controller_Player::profile`: assign `Milestones`, `LadderProgress`, maps
+- [x] Thin `Playernew_index.tpl`: remove `$pnOrderToMaster`, `$pnOrderNames`, `$pnClassToParagon`; iterate DTOs; knight belt detection may consume shared knight map
+- [x] PHPUnit: map equality vs former literals; milestone fixture cases; ladder Approx/Master edge cases
 
 ### Acceptance
 
-- [ ] `rg 'pnOrderToMaster|pnClassToParagon|__knightIds|__paragonIds'` clean under `orkui/` (except comments pointing to domain if any)
-- [ ] Template does not define order→master or class→paragon maps
-- [ ] Full PHPUnit green; static gates clean
+- [x] `rg 'pnOrderToMaster|pnClassToParagon|__knightIds|__paragonIds'` clean under `orkui/` (except comments pointing to domain if any)
+- [x] Template does not define order→master or class→paragon maps
+- [x] Full PHPUnit green; static gates clean
 - [ ] Visual/DOM behavior preserved for Awards / Class Levels / Milestones tabs (manual or fuzzy later)
 
 **Note:** Belt image URL assembly may remain in template if AwardIds come from domain.
@@ -132,6 +137,6 @@ Do not parallelize R1–R4 on overlapping `Controller_Player` / template files. 
 ## Open questions (resolve during R1–R3, document in commit)
 
 1. **Credit semantics:** **Resolved (P3-R1):** `fetch_player_details` / `GetPlayerProfileDetails` Classes come from `GetPlayerClasses` — same as `ComputeClassProgress`. Chose **Option A** (`GetHighestClassLevel`). Option B helper `HighestClassLevelFromClasses` kept for characterization.
-2. **Belt assets:** Domain returns AwardIds only vs include relative image keys.
-3. **Milestone icons:** Keep Font Awesome class strings in domain DTO (current) vs map type→icon in template.
+2. **Belt assets:** **Resolved (P3-R2):** Domain returns AwardIds + short names only; belt image URLs remain in the template.
+3. **Milestone icons:** **Resolved (P3-R2):** Keep Font Awesome class strings in the domain DTO (`icon`); template does not remap type→icon.
 4. **orkservice:** Defer forever vs register in R4 for one client — product call, not a gate.

--- a/docs/megiddo/refactor/player-aggregates/03-milestones.md
+++ b/docs/megiddo/refactor/player-aggregates/03-milestones.md
@@ -77,7 +77,7 @@ Executable checklist for implementers / orchestrator. IDs reuse **P3-R0…P3-R4*
 - [x] `rg 'pnOrderToMaster|pnClassToParagon|__knightIds|__paragonIds'` clean under `orkui/` (except comments pointing to domain if any)
 - [x] Template does not define order→master or class→paragon maps
 - [x] Full PHPUnit green; static gates clean
-- [ ] Visual/DOM behavior preserved for Awards / Class Levels / Milestones tabs (manual or fuzzy later)
+- [x] Visual/DOM behavior preserved for Awards / Class Levels / Milestones tabs (manual or fuzzy later) — confirmed via P3-R4 fuzzy `player-profile` test+mirror
 
 **Note:** Belt image URL assembly may remain in template if AwardIds come from domain.
 
@@ -108,21 +108,30 @@ Executable checklist for implementers / orchestrator. IDs reuse **P3-R0…P3-R4*
 
 **Goal:** End-to-end thin UI; prove with fuzzy; optionally expose JSON.
 
+**Status:** Complete (UI gate). orkservice stretch skipped (not a UI blocker).
+
 ### Work
 
-- [ ] Confirm all P3-R1–R3 call sites wired; grep inventory §7 clean
-- [ ] Fuzzy validate `player-profile` (and `player-profile-sandbox` if in active setpoint) on **test** and **mirror**
-- [ ] Re-record baselines only if intentional drift approved; otherwise fix regressions
-- [ ] Update [04-milestone-checklist.md](../04-milestone-checklist.md) / close-out notes: check off P3-R*
-- [ ] **Optional stretch:** register thin `PlayerService` methods for milestones / ladder / reconcile DTOs ([02-api-contract.md](./02-api-contract.md) §D) — does not block UI sign-off
+- [x] Confirm all P3-R1–R3 call sites wired; grep inventory §7 clean
+- [x] Fuzzy validate `player-profile` on **test** and **mirror** (`player-profile-sandbox` not required for this gate)
+- [x] Re-record baselines only if intentional drift approved; otherwise fix regressions — **no re-record** (scores 1.00)
+- [x] Update [04-milestone-checklist.md](../04-milestone-checklist.md) / close-out notes: check off P3-R*
+- [ ] **Optional stretch (skipped):** register thin `PlayerService` methods for milestones / ladder / reconcile DTOs ([02-api-contract.md](./02-api-contract.md) §D) — does not block UI sign-off
+
+### Wire leftovers fixed in R4
+
+- Removed dead `_ma_level` / `_ma_progress` threshold helpers from `Playernew_index.tpl`
+- Exposed `ClassLevel::THRESHOLDS` via `Model_Player::get_class_level_thresholds` → controller `ClassLevelThresholds` → `PnConfig.classLevelThresholds`
+- Classes-table / My Amtgard / level-6 milestone JS consume PnConfig only (no hard-coded `>= 53` / `[5,12,21,34,53]` in revised-frontend)
+- Legacy `orkui/template/default/Player_index.tpl` + `Admin_player.tpl` still have threshold JS but are **not** on the active Player profile route (`Playernew_index.tpl`)
 
 ### Acceptance
 
-- [ ] Controllers/templates contain no ladder rule literals (thresholds, AwardId catalogues, smart-rank)
-- [ ] Full PHPUnit green
-- [ ] Static `orkui/` Lib/$DB clean
-- [ ] Fuzzy player-profile test+mirror pass
-- [ ] Checklist boxes for P3-R0…R4 marked done; human P3-4/5/6 untouched
+- [x] Controllers / revised Player templates contain no ladder rule literals (thresholds, AwardId catalogues, smart-rank)
+- [x] Full PHPUnit green (292 tests)
+- [x] Static `orkui/` Lib/$DB clean
+- [x] Fuzzy `player-profile` test+mirror PASS — assets=1.00 dom=1.00 visual=1.000 (run `p3-r4-player-profile`)
+- [x] Checklist boxes for P3-R0…R4 marked done; human P3-4/5/6 untouched
 
 ---
 

--- a/docs/megiddo/refactor/player-aggregates/README.md
+++ b/docs/megiddo/refactor/player-aggregates/README.md
@@ -1,0 +1,78 @@
+# Player first-class aggregate APIs (play-aggregates)
+
+**Nickname:** play-aggregates  
+**Parent residual:** [P3-R\*](../11-phase-3-closeout.md) from Phase 3 close-out  
+**Status:** Planning complete (this package). Implementation starts at **P3-R1**.  
+**Branch context:** Stack on the current Megiddo tip (`megiddo/p3-bootstrap-model-hop` or successor).
+
+---
+
+## Why
+
+Phase 3 eliminated `$DB` / `Ork3::$Lib` from `orkui/`, but **award ladders, class-level thresholds, milestone timelines, and reconcile “smart rank” rules** still live in `Controller_Player` and revised Player templates. That violates the product goal:
+
+> Anything the frontend needs must be accessible via API as a first-class citizen. Controllers/templates only orchestrate and render.
+
+Those rules are real domain knowledge. Future orkservice / mobile / embed clients cannot reuse them while they remain PHP in templates.
+
+Sign-in already consumes class progress through the Attendance model (`enrich_classes_with_progress` → `Player::ComputeClassProgress` → `ClassLevel::computeClassLevel`). Player profile must match that pattern for the remaining aggregates.
+
+---
+
+## Scope
+
+| In scope | Out of scope |
+|----------|--------------|
+| Class-level / highest-level stats on profile | Reopening unrelated R-* controllers |
+| Milestone timeline construction + award ID catalogues | Bootstrap Lib / Dangeraudit hop (done) |
+| Order→Master and Class→Paragon maps; ladder progress tiles | Human P3-4 / P3-5 / P3-6 close-out |
+| Historical award partition + smart-rank suggestions | Product changes to ladder/paragon rules |
+| Thin `Controller_Player` + revised templates | Optional orkservice JSON exposure (later gate only) |
+
+Prefer **extending** `Player`, `ClassLevel`, and `Award` over inventing parallel services.
+
+---
+
+## Package map
+
+| Doc | Purpose |
+|-----|---------|
+| [01-inventory.md](./01-inventory.md) | File:line rule sites and what each encodes |
+| [02-api-contract.md](./02-api-contract.md) | Domain / model method shapes and DTOs |
+| [03-milestones.md](./03-milestones.md) | Executable P3-R0…R4 checklist + acceptance gates |
+| [agent-prompt.md](./agent-prompt.md) | Worker prompts for implementer agents |
+| [orchestrator.prompt](./orchestrator.prompt) | Serialized orchestrator driver |
+
+---
+
+## Success criteria
+
+1. **No ladder rules in `orkui/`.** Thresholds, AwardId catalogues, order/class→award maps, peerage/milestone dedup, and smart-rank suggestion logic live in `system/lib/ork3/` (and thin `Model_Player` wrappers). Templates iterate DTOs only.
+2. **Controller is thin.** `Controller_Player::profile` / `reconcile` assign domain results into `$this->data`; they do not encode thresholds or AwardId lists.
+3. **Reuse first.** `ClassLevel::computeClassLevel`, `Player::ComputeClassProgress`, `Award::GetLadderMasterMap`, `Player::GetReconcileAwardMap`, and custom-milestone APIs are the base — extend or wrap, do not fork.
+4. **Characterization then wire.** PHPUnit covers new/changed domain methods before template/controller deletion of duplicated logic.
+5. **Gates.** Full PHPUnit suite green; static `orkui/` still zero `$DB` / `Ork3::$Lib`; fuzzy `player-profile` (test + mirror) pass after P3-R4 wire (re-record only if intentional DOM drift is approved).
+6. **orkservice optional.** External JSON exposure is a P3-R4 stretch, not a blocker for UI thinness.
+
+---
+
+## Milestone order (summary)
+
+| ID | Deliverable |
+|----|-------------|
+| **P3-R0** | This inventory + contract package (done when committed) |
+| **P3-R1** | Class level / progress via `ClassLevel` / `Player` |
+| **P3-R2** | Milestones + award maps + ladder progress API |
+| **P3-R3** | Reconcile suggestions API |
+| **P3-R4** | Wire controller/templates; fuzzy canaries; optional orkservice |
+
+Details and acceptance gates: [03-milestones.md](./03-milestones.md).
+
+---
+
+## Related
+
+- [11-phase-3-closeout.md](../11-phase-3-closeout.md) — Phase 3 human gates + P3-R residual pointer  
+- [04-milestone-checklist.md](../04-milestone-checklist.md) — remaining-work checkboxes  
+- [idioms-00-charter.md](../idioms-00-charter.md) — frontend must not reintroduce Lib/domain call-site coupling  
+- [05-development-steering.md](../05-development-steering.md) — DS-* commit / branch / test rules  

--- a/docs/megiddo/refactor/player-aggregates/agent-prompt.md
+++ b/docs/megiddo/refactor/player-aggregates/agent-prompt.md
@@ -1,0 +1,107 @@
+# Player aggregates — agent prompts (P3-R*)
+
+Worker bodies for Task/sub-agents. Paste the full section for the active milestone. Sub-agents have no parent chat history.
+
+Shared preamble for every worker:
+
+```text
+You are implementing Megiddo P3-R Player first-class aggregate APIs.
+Repo root: ORK3 working tree on the active megiddo/* branch.
+Plan package: docs/megiddo/refactor/player-aggregates/ (README, 01-inventory, 02-api-contract, 03-milestones).
+Rules: Prefer extending Player / ClassLevel / Award. Controllers use Model_* only. No $DB / Ork3::$Lib in orkui/. Plan-only docs are done (P3-R0); do not expand scope to P3-4/5/6 human close-out. Do not push/PR unless asked. One commit for this milestone when complete. Return: status (ok|blocked|failed), files touched, commit SHA, PHPUnit result, open questions.
+```
+
+---
+
+## P3-R1 worker
+
+```text
+Milestone: P3-R1 — Class level / progress API.
+
+Read:
+- docs/megiddo/refactor/player-aggregates/01-inventory.md §1
+- docs/megiddo/refactor/player-aggregates/02-api-contract.md §B1
+- docs/megiddo/refactor/player-aggregates/03-milestones.md §P3-R1
+- system/lib/ork3/class.ClassLevel.php
+- Player::ComputeClassProgress and Model_Attendance::enrich_classes_with_progress
+- orkui/controller/controller.Player.php HighestClassLevel block (~449–468)
+
+Tasks:
+1. Compare Details['Classes'] credit semantics vs ComputeClassProgress; pick Option A or B; note choice in commit message.
+2. Implement domain + Model_Player wrapper; wire Controller_Player::profile; delete threshold chain from controller.
+3. Add/extend PHPUnit characterization.
+4. Run full PHPUnit suite; confirm orkui/ has no new Lib/$DB and no threshold literals in controller.
+5. Commit on branch megiddo/p3-r1-class-level-api (or stacked name from parent). Check off P3-R1 in docs/megiddo/refactor/04-milestone-checklist.md and 03-milestones.md.
+
+Do not implement milestones, award maps, or reconcile in this hop.
+```
+
+---
+
+## P3-R2 worker
+
+```text
+Milestone: P3-R2 — Milestones + award maps + ladder progress.
+
+Read:
+- docs/megiddo/refactor/player-aggregates/01-inventory.md §2–3
+- docs/megiddo/refactor/player-aggregates/02-api-contract.md §B2–B4
+- docs/megiddo/refactor/player-aggregates/03-milestones.md §P3-R2
+- Award::GetLadderMasterMap
+- Controller_Player profile milestones block (~515–669)
+- Playernew_index.tpl $pnClassToParagon, $pnOrderToMaster, ladder tile build
+
+Tasks:
+1. Add Award catalogue helpers (ClassParagon, Knight, etc.); single-source ladder via GetLadderMasterMap.
+2. Implement Player::GetPlayerMilestones + GetLadderProgress + Model_Player wrappers.
+3. Thin controller assigns DTOs/maps; thin template — remove hardcoded maps and ladder algorithm.
+4. PHPUnit for maps, milestone dedup, ladder Approx/Master cases.
+5. Full suite + static gates; commit; check off P3-R2 in checklists.
+
+Do not implement reconcile smart-rank (P3-R3) or fuzzy re-record (P3-R4) unless parent explicitly expands scope.
+```
+
+---
+
+## P3-R3 worker
+
+```text
+Milestone: P3-R3 — Reconcile suggestions API.
+
+Read:
+- docs/megiddo/refactor/player-aggregates/01-inventory.md §4
+- docs/megiddo/refactor/player-aggregates/02-api-contract.md §B5
+- docs/megiddo/refactor/player-aggregates/03-milestones.md §P3-R3
+- Playernew_reconcile.tpl lines ~13–73
+- Player::GetReconcileAwardMap / Model_Player::get_reconcile_award_map
+
+Tasks:
+1. Port historical partition + smart-rank into Player::GetReconcilePageData (or pure helper + page DTO).
+2. Characterization tests locking suggestion outcomes.
+3. Wire Controller_Player::reconcile; template display-only. Optionally drive HasHistorical flags from same API.
+4. Full suite + static gates; commit; check off P3-R3.
+
+Do not register orkservice or run fuzzy capture unless asked.
+```
+
+---
+
+## P3-R4 worker
+
+```text
+Milestone: P3-R4 — Wire + gate (+ optional orkservice).
+
+Read:
+- docs/megiddo/refactor/player-aggregates/03-milestones.md §P3-R4
+- docs/megiddo/refactor/06-test-framework.md (fuzzy / e2e preflight)
+- Confirm R1–R3 landed; grep inventory §7
+
+Tasks:
+1. Grep orkui/ for residual ladder rule literals; fix any leftovers.
+2. Full PHPUnit; static Lib/$DB greps.
+3. Fuzzy validate player-profile (test + mirror). Re-record only with intentional drift approval from human/parent.
+4. Optional stretch: PlayerService registration for new DTOs — only if parent requests; not a UI blocker.
+5. Check off P3-R4 in 04-milestone-checklist.md and 03-milestones.md; note remaining human P3-4/5/6 unchanged. Commit.
+
+Return fuzzy scores and whether orkservice was touched.
+```

--- a/docs/megiddo/refactor/player-aggregates/orchestrator.prompt
+++ b/docs/megiddo/refactor/player-aggregates/orchestrator.prompt
@@ -1,0 +1,51 @@
+You are the Megiddo **Player aggregate APIs (P3-R\*)** ORCHESTRATOR. You do not implement domain/model/controller/template changes yourself. You drive the pipeline by launching one serialized sub-agent per P3-R* milestone, waiting for each to finish, then starting the next.
+
+## Read first
+
+- docs/megiddo/refactor/player-aggregates/README.md
+- docs/megiddo/refactor/player-aggregates/03-milestones.md
+- docs/megiddo/refactor/player-aggregates/agent-prompt.md
+- docs/megiddo/refactor/04-milestone-checklist.md
+- docs/megiddo/refactor/11-phase-3-closeout.md (§ P3-R)
+- docs/megiddo/refactor/05-development-steering.md
+
+## Hard rules
+
+1. Serialize: never launch two Task/sub-agents in parallel for this pipeline. One completes → verify checklist → then launch the next.
+2. Worker scope: each sub-agent gets ONLY its milestone worker prompt from agent-prompt.md (plus the shared preamble). Paste the full worker prompt text into the Task prompt (sub-agents have no parent chat history).
+3. Task tool: subagent_type generalPurpose. Set description to the P3-R* id. Do not set run_in_background true — wait for the result.
+4. Checklist is source of truth: after each worker, re-read docs/megiddo/refactor/player-aggregates/03-milestones.md and 04-milestone-checklist.md. If the worker failed to check boxes or commit when required, resume that same P3-R* once with a fix-up prompt, or STOP and report to the user.
+5. Stop and ask the user if a worker reports: credit-semantics conflict that would change displayed levels, product disagreement on ladder/paragon IDs, fuzzy regression requiring product decision, or scope explosion into unrelated controllers.
+6. Spirit: workers must not reintroduce $DB or Ork3::$Lib into orkui/. Prefer extending Player / ClassLevel / Award. No push/PR unless the user already asked.
+7. P3-R0 is docs-only and should already be checked off. Do not wipe human P3-4 / P3-5 / P3-6.
+8. Resume: start at the first unchecked P3-R* on 03-milestones.md (usually P3-R1). If the user says to resume from a specific id, skip milestones already checked before that id.
+9. Optional orkservice exposure is P3-R4 stretch only — not a blocker for UI thinness.
+
+## Pipeline order
+
+P3-R1 → P3-R2 → P3-R3 → P3-R4
+
+## Per-hop procedure
+
+For each next milestone ID:
+
+1. Write a one-line status to the user: Starting {ID}…
+2. Launch Task with the full matching worker prompt from agent-prompt.md, plus this preamble:
+
+Orchestrator context:
+- Working branch: (current megiddo tip / stacked branch name)
+- Base SHA: (git rev-parse HEAD before worker)
+- Previous milestone result summary: (paste worker report)
+- You must update docs/megiddo/refactor/player-aggregates/03-milestones.md and docs/megiddo/refactor/04-milestone-checklist.md
+- Return a structured report: status (ok|blocked|failed), checklist boxes updated, commit hash if any, next recommended ID, blockers
+
+3. Wait for the Task result.
+4. Verify checklist progress for that ID.
+5. If blocked/failed → stop queue, summarize for the user, do not start the next ID.
+6. If ok → proceed to the next ID.
+
+## Final response (after P3-R4 or stop)
+
+Report a table with: Branch, Commits (per P3-R*), PHPUnit, Static gates, Fuzzy (if R4), orkservice touched?, Next (human P3-4 or resume point), Open questions for the product owner.
+
+Begin now: read the checklist, determine the first unchecked milestone (skip P3-R0 if complete), launch that sub-agent.

--- a/orkui/controller/controller.AdminAjax.php
+++ b/orkui/controller/controller.AdminAjax.php
@@ -60,7 +60,7 @@ class Controller_AdminAjax extends Controller
             $authId = (int)($r['Detail'] ?? 0);
             $this->load_model('Player');
             $persona = $this->Player->get_persona($mid);
-            (new Dangeraudit())->audit('Authorization::AddAuthorization', ['MundaneId' => $mid, 'Type' => AUTH_ADMIN, 'Id' => 0, 'Role' => AUTH_ADMIN], 'Player', $mid, null, [
+            $this->Authorization->audit('Authorization::AddAuthorization', ['MundaneId' => $mid, 'Type' => AUTH_ADMIN, 'Id' => 0, 'Role' => AUTH_ADMIN], 'Player', $mid, null, [
                 'authorization_id' => $authId,
                 'mundane_id'       => $mid,
                 'park_id'          => 0,

--- a/orkui/controller/controller.EventAjax.php
+++ b/orkui/controller/controller.EventAjax.php
@@ -325,7 +325,7 @@ class Controller_EventAjax extends Controller
             $authId = (int)($r['Detail'] ?? 0);
             $this->load_model('Player');
             $persona = $this->Player->get_persona($mid);
-            (new Dangeraudit())->audit('Authorization::AddAuthorization', ['MundaneId' => $mid, 'Type' => AUTH_EVENT, 'Id' => $event_id, 'Role' => $role], 'Player', $mid, null, [
+            $this->Authorization->audit('Authorization::AddAuthorization', ['MundaneId' => $mid, 'Type' => AUTH_EVENT, 'Id' => $event_id, 'Role' => $role], 'Player', $mid, null, [
                 'authorization_id' => $authId,
                 'mundane_id'       => $mid,
                 'park_id'          => 0,
@@ -414,7 +414,7 @@ class Controller_EventAjax extends Controller
 
         $priorState = $r['PriorState'] ?? null;
         $staff = $r['Staff'] ?? [];
-        (new Dangeraudit())->audit(
+        $this->Authorization->audit(
             $priorState ? 'EventStaff::Update' : 'EventStaff::Add',
             [
                 'EventId'       => $event_id,
@@ -476,7 +476,7 @@ class Controller_EventAjax extends Controller
 
         $priorState = $r['PriorState'] ?? null;
         if ($priorState) {
-            (new Dangeraudit())->audit(
+            $this->Authorization->audit(
                 'EventStaff::Remove',
                 ['EventId' => $event_id, 'DetailId' => $detail_id, 'StaffId' => $staff_id],
                 'Event',

--- a/orkui/controller/controller.KingdomAjax.php
+++ b/orkui/controller/controller.KingdomAjax.php
@@ -593,7 +593,7 @@ class Controller_KingdomAjax extends Controller
             $authId = (int)($r['Detail'] ?? 0);
             $this->load_model('Player');
             $persona = $this->Player->get_persona($mid);
-            (new Dangeraudit())->audit('Authorization::AddAuthorization', ['MundaneId' => $mid, 'Type' => AUTH_KINGDOM, 'Id' => $kingdom_id, 'Role' => $role], 'Player', $mid, null, [
+            $this->Authorization->audit('Authorization::AddAuthorization', ['MundaneId' => $mid, 'Type' => AUTH_KINGDOM, 'Id' => $kingdom_id, 'Role' => $role], 'Player', $mid, null, [
                 'authorization_id' => $authId,
                 'mundane_id'       => $mid,
                 'park_id'          => 0,

--- a/orkui/controller/controller.ParkAjax.php
+++ b/orkui/controller/controller.ParkAjax.php
@@ -378,7 +378,7 @@ class Controller_ParkAjax extends Controller
             $authId = (int)($r['Detail'] ?? 0);
             $this->load_model('Player');
             $persona = $this->Player->get_persona($mid);
-            (new Dangeraudit())->audit('Authorization::AddAuthorization', ['MundaneId' => $mid, 'Type' => AUTH_PARK, 'Id' => $park_id, 'Role' => $role], 'Player', $mid, null, [
+            $this->Authorization->audit('Authorization::AddAuthorization', ['MundaneId' => $mid, 'Type' => AUTH_PARK, 'Id' => $park_id, 'Role' => $role], 'Player', $mid, null, [
                 'authorization_id' => $authId,
                 'mundane_id'       => $mid,
                 'park_id'          => (int)$park_id,

--- a/orkui/controller/controller.Player.php
+++ b/orkui/controller/controller.Player.php
@@ -434,7 +434,7 @@ class Controller_Player extends Controller
             'TotalAttendance'   => 0,
             'TotalAwards'       => 0,
             'TotalTitles'       => 0,
-            'HighestClassLevel' => 0,
+            'HighestClassLevel' => $this->Player->get_highest_class_level($id),
             'LastPlayedClass'   => '',
         ];
         if (is_array($this->data['Details']['Awards'])) {
@@ -443,27 +443,6 @@ class Controller_Player extends Controller
                     $this->data['Stats']['TotalAwards']++;
                 } else {
                     $this->data['Stats']['TotalTitles']++;
-                }
-            }
-        }
-        if (is_array($this->data['Details']['Classes'])) {
-            foreach ($this->data['Details']['Classes'] as $c) {
-                $credits = $c['Credits'] + $c['Reconciled'];
-                if ($credits >= 53) {
-                    $lvl = 6;
-                } elseif ($credits >= 34) {
-                    $lvl = 5;
-                } elseif ($credits >= 21) {
-                    $lvl = 4;
-                } elseif ($credits >= 12) {
-                    $lvl = 3;
-                } elseif ($credits >= 5) {
-                    $lvl = 2;
-                } else {
-                    $lvl = 1;
-                }
-                if ($lvl > $this->data['Stats']['HighestClassLevel']) {
-                    $this->data['Stats']['HighestClassLevel'] = $lvl;
                 }
             }
         }

--- a/orkui/controller/controller.Player.php
+++ b/orkui/controller/controller.Player.php
@@ -509,6 +509,7 @@ class Controller_Player extends Controller
             'Awards' => $__awards,
         ]);
         $this->data['ClassParagonMap'] = $this->Player->get_class_paragon_map();
+        $this->data['ClassLevelThresholds'] = $this->Player->get_class_level_thresholds();
         $this->data['LadderMasterMap'] = $this->Player->get_ladder_master_map();
         $this->data['KnightAwardMap'] = $this->Player->get_knight_award_map();
 

--- a/orkui/controller/controller.Player.php
+++ b/orkui/controller/controller.Player.php
@@ -492,160 +492,25 @@ class Controller_Player extends Controller
         $this->data['PlayerTitles'] = $beltline['Titles'];
 
         // ===== Milestones Timeline Data =====
-        $__milestones = [];
         $__awards = is_array($this->data['Details']['Awards']) ? $this->data['Details']['Awards'] : [];
-        $__classes = is_array($this->data['Details']['Classes']) ? $this->data['Details']['Classes'] : [];
-
-        // 1. First Sign-In — use PlayerSinceDate (already computed via MIN(date)
-        // query at controller line ~358); no full-attendance scan needed.
-        $__earliestDate = $this->data['Player']['PlayerSinceDate'] ?? null;
-        if ($__earliestDate && $__earliestDate !== '0000-00-00' && $__earliestDate !== '1970-01-01') {
-            $__milestones[] = ['type' => 'first_signin', 'date' => $__earliestDate, 'icon' => 'fa-door-open', 'description' => 'First sign-in at Amtgard'];
-        }
-
-        // 2. Reached Level 6 in Class — computed client-side once attendance loads
-        // (see PlayerAjax/attendance handler in Playernew_index.tpl). Server-side
-        // generation removed so we don't have to fetch full attendance during
-        // page render.
-
-        // 3-6: Awards-based milestones
-        $__knightIds  = [17, 18, 19, 20, 245];
-        $__knightNames = [17 => 'Flame', 18 => 'Crown', 19 => 'Serpent', 20 => 'Sword', 245 => 'Battle'];
-        $__masterIds  = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 240, 244]; // mirrors $pnOrderToMaster values in Playernew_index.tpl
-        foreach ($__awards as $__aw) {
-            $__aid = (int)($__aw['AwardId'] ?? 0);
-            $__awDate = $__aw['Date'] ?? '';
-            // Prefer the player-specific custom_name when present (Custom Title /
-            // Custom Award rows). Otherwise fall back to the kingdomaward name,
-            // then the underlying award name.
-            $__awName = !empty($__aw['CustomAwardName']) ? $__aw['CustomAwardName'] : (!empty($__aw['KingdomAwardName']) ? $__aw['KingdomAwardName'] : ($__aw['Name'] ?? ''));
-            $__officerRole = $__aw['OfficerRole'] ?? 'none';
-            $__isTitle = (int)($__aw['IsTitle'] ?? 0);
-            $__aliasPeerage = $__aw['AliasPeerage'] ?? '';
-
-            if (empty($__awDate) || $__awDate === '0000-00-00') {
-                continue;
-            }
-
-            // Knight
-            if (in_array($__aid, $__knightIds)) {
-                $__knLabel = isset($__knightNames[$__aid]) ? 'Knight of the ' . $__knightNames[$__aid] : 'Knighted';
-                $__milestones[] = ['type' => 'knight', 'date' => $__awDate, 'icon' => 'fa-shield-alt', 'description' => 'Earned ' . $__knLabel];
-            }
-
-            // Master title — only when the player actually holds the formal Master award,
-            // not merely because they reached rank 10 of the corresponding Order.
-            if (in_array($__aid, $__masterIds)) {
-                $__milestones[] = ['type' => 'master', 'date' => $__awDate, 'icon' => 'fa-star', 'description' => 'Earned ' . $__awName];
-            }
-
-            // Paragon (class-specific paragon awards)
-            $__paragonIds = [37,38,39,40,41,241,42,43,44,45,46,47,242,49,50,51];
-            if (in_array($__aid, $__paragonIds)) {
-                $__milestones[] = ['type' => 'paragon', 'date' => $__awDate, 'icon' => 'fa-gem', 'description' => 'Earned ' . $__awName];
-            }
-
-            // Title (IsTitle=1 and OfficerRole is none, exclude paragons/knights already handled above).
-            // For Custom Titles aliased to a beltline peerage (Page/Squire/etc.),
-            // suppress this — the 'became_associate' milestone already covers it.
-            if ($__isTitle === 1 && in_array($__officerRole, ['none', null]) && !in_array($__aid, $__paragonIds) && !in_array($__aid, $__knightIds)
-                && !in_array($__aliasPeerage, ['Page', 'Lords-Page', 'Squire', 'Man-At-Arms'])) {
-                $__milestones[] = ['type' => 'title', 'date' => $__awDate, 'icon' => 'fa-crown', 'description' => 'Earned the title ' . $__awName];
-            }
-
-            // Served as Officer (OfficerRole is not none)
-            if (!in_array($__officerRole, ['none', null, ''])) {
-                $__milestones[] = ['type' => 'officer', 'date' => $__awDate, 'icon' => 'fa-landmark', 'description' => 'Served as ' . $__awName];
-            }
-        }
-
-        // 7. Became Associate (peerage awards given TO this player - from BeltlinePeers data)
-        $__blPeerLabels = ['Squire' => 'Squire', 'Man-At-Arms' => 'Person-at-Arms', 'Lords-Page' => "Lord's Page", 'Page' => 'Page'];
-        if (!empty($this->data['BeltlinePeers'])) {
-            foreach ($this->data['BeltlinePeers'] as $__bp) {
-                $__peerDate = $__bp['Date'] ?? '';
-                if (empty($__peerDate) || $__peerDate === '0000-00-00') {
-                    continue;
-                }
-                $__peerLabel = $__blPeerLabels[$__bp['Peerage']] ?? $__bp['Peerage'];
-                $__milestones[] = ['type' => 'became_associate', 'date' => $__peerDate, 'icon' => 'fa-handshake', 'description' => 'Became ' . $__peerLabel . ' to ' . $__bp['Persona']];
-            }
-        }
-
-        // 8. Took Associate (peerage awards given BY this player - from BeltlineAssociates data)
-        if (!empty($this->data['BeltlineAssociates'])) {
-            foreach ($this->data['BeltlineAssociates'] as $__ba) {
-                $__assocDate = $__ba['Date'] ?? '';
-                if (empty($__assocDate) || $__assocDate === '0000-00-00') {
-                    continue;
-                }
-                $__assocLabel = $__blPeerLabels[$__ba['Peerage']] ?? $__ba['Peerage'];
-                $__milestones[] = ['type' => 'took_associate', 'date' => $__assocDate, 'icon' => 'fa-hand-holding-heart', 'description' => 'Took ' . $__ba['Persona'] . ' as ' . $__assocLabel];
-            }
-        }
-
-        // 9. Custom milestones from DB
         $__customMs = $this->Player->get_custom_milestones((int)$id);
-        if (is_array($__customMs)) {
-            foreach ($__customMs as $__cm) {
-                $__milestones[] = [
-                    'type' => 'custom',
-                    'date' => $__cm['MilestoneDate'],
-                    'icon' => $__cm['Icon'],
-                    'description' => $__cm['Description'],
-                    'milestoneId' => (int)$__cm['MilestoneId'],
-                ];
-            }
-        }
-
-        // Cross-type dedup:
-        // 1. Remove 'title' milestones for peerage terms (already covered by 'became_associate')
-        // 2. Remove 'title' milestones for "Master X" that duplicate an existing 'master' milestone
-        $__masterMsNames = [];
-        foreach ($__milestones as $__m) {
-            if ($__m['type'] === 'master') {
-                $__masterMsNames[] = strtolower(preg_replace('/^Earned (?:Master )?/', '', $__m['description']));
-            }
-        }
-        $__peerageTerms = ['squire', 'man-at-arms', 'person-at-arms', "lord's page", 'page'];
-        $__milestones = array_values(array_filter($__milestones, function ($m) use ($__masterMsNames, $__peerageTerms) {
-            if ($m['type'] !== 'title') {
-                return true;
-            }
-            $__tn = strtolower(preg_replace('/^Earned the title /', '', $m['description']));
-            if (in_array($__tn, $__peerageTerms)) {
-                return false;
-            }
-            if (substr($__tn, 0, 7) === 'master ') {
-                $__kw = substr($__tn, 7);
-                foreach ($__masterMsNames as $__mn) {
-                    if (strpos($__mn, $__kw) !== false) {
-                        return false;
-                    }
-                }
-            }
-            return true;
-        }));
-
-        // Deduplicate milestones with same description + date
-        $__seen = [];
-        $__milestones = array_filter($__milestones, function ($m) use (&$__seen) {
-            $key = $m['date'] . '|' . $m['description'];
-            if (isset($__seen[$key])) {
-                return false;
-            }
-            $__seen[$key] = true;
-            return true;
-        });
-
-        // Sort chronologically ascending
-        usort($__milestones, function ($a, $b) {
-            return strtotime($a['date']) - strtotime($b['date']);
-        });
-
-        $this->data['Milestones'] = $__milestones;
+        $this->data['Milestones'] = $this->Player->get_player_milestones([
+            'MundaneId' => (int)$id,
+            'PlayerSinceDate' => $this->data['Player']['PlayerSinceDate'] ?? null,
+            'Awards' => $__awards,
+            'BeltlinePeers' => $this->data['BeltlinePeers'] ?? [],
+            'BeltlineAssociates' => $this->data['BeltlineAssociates'] ?? [],
+            'IncludeCustom' => true,
+        ]);
         $this->data['CustomMilestones'] = is_array($__customMs) ? $__customMs : [];
         $this->data['MilestoneConfig'] = $this->data['Player']['MilestoneConfig'] ?? '';
+        $this->data['LadderProgress'] = $this->Player->get_ladder_progress([
+            'MundaneId' => (int)$id,
+            'Awards' => $__awards,
+        ]);
+        $this->data['ClassParagonMap'] = $this->Player->get_class_paragon_map();
+        $this->data['LadderMasterMap'] = $this->Player->get_ladder_master_map();
+        $this->data['KnightAwardMap'] = $this->Player->get_knight_award_map();
 
         // Collapse the Peers/Associates *display* lists to one row per
         // counterparty, keeping the highest-precedence peerage (the SQL

--- a/orkui/controller/controller.Player.php
+++ b/orkui/controller/controller.Player.php
@@ -512,6 +512,11 @@ class Controller_Player extends Controller
         $this->data['LadderMasterMap'] = $this->Player->get_ladder_master_map();
         $this->data['KnightAwardMap'] = $this->Player->get_knight_award_map();
 
+        $__reconcileHints = $this->Player->get_reconcile_suggestions($__awards);
+        $this->data['HasHistoricalLadder'] = !empty($__reconcileHints['HasHistoricalLadder']);
+        $this->data['HasHistorical'] = !empty($this->data['canManageAwards']) && $this->data['HasHistoricalLadder'];
+        $this->data['HasHistoricalTip'] = $this->data['HasHistoricalLadder'];
+
         // Collapse the Peers/Associates *display* lists to one row per
         // counterparty, keeping the highest-precedence peerage (the SQL
         // already orders Squire→Page so the first row wins). Run this AFTER
@@ -621,8 +626,19 @@ class Controller_Player extends Controller
         }
         $this->data['PreloadOfficers'] = $preloadOfficers;
 
-        // AwardId → KingdomAwardId map for current kingdom (pre-match historical award dropdowns)
-        $this->data['AwardIdToKingdomAwardId'] = $this->Player->get_reconcile_award_map((int)$this->session->kingdom_id);
+        $awards = is_array($this->data['Details']['Awards'] ?? null) ? $this->data['Details']['Awards'] : [];
+        $reconcilePage = $this->Player->get_reconcile_page_data([
+            'MundaneId' => $id,
+            'KingdomId' => (int)$this->session->kingdom_id,
+            'Awards' => $awards,
+        ]);
+        $this->data['HistoricalAwards'] = $reconcilePage['HistoricalAwards'];
+        $this->data['RankSuggestions'] = $reconcilePage['RankSuggestions'];
+        $this->data['RealRanksByAwardId'] = $reconcilePage['RealRanksByAwardId'];
+        $this->data['AwardIdToKingdomAwardId'] = $reconcilePage['AwardIdToKingdomAwardId'];
+        $this->data['AwardTypeCount'] = (int)($reconcilePage['Summary']['AwardTypeCount'] ?? 0);
+        $this->data['TotalCount'] = (int)($reconcilePage['Summary']['TotalCount'] ?? 0);
+        $this->data['HasHistoricalLadder'] = !empty($reconcilePage['HasHistoricalLadder']);
     }
 
     private function award_rec_can_delete(int $uid, string $role): bool

--- a/orkui/controller/controller.Unit.php
+++ b/orkui/controller/controller.Unit.php
@@ -150,7 +150,7 @@ class Controller_Unit extends Controller
                         // so the audit call lives here to mirror the pattern used by
                         // the raw-INSERT paths. Anchored to the grantee so the entry
                         // shows on the affected player's audit history.
-                        (new Dangeraudit())->audit(
+                        $this->Authorization->audit(
                             'Authorization::AddAuthorization',
                             ['MundaneId' => $_grantee_mid, 'Type' => AUTH_UNIT, 'Id' => $unit_id_int, 'Role' => AUTH_CREATE],
                             'Player',

--- a/orkui/index.php
+++ b/orkui/index.php
@@ -6,7 +6,8 @@ define('UIR', HTTP_UI_REMOTE . 'index.php?Route=');
 ini_set("error_reporting", E_ALL & ~E_DEPRECATED & ~E_NOTICE & ~E_WARNING);
 
 if (isset($_REQUEST['Route']) && $_REQUEST['Route'] === 'Health') {
-    $ok = (new Health())->PingDb();
+    require_once DIR_MODEL . 'model.Health.php';
+    $ok = (new Model_Health())->ping_db();
     http_response_code($ok ? 200 : 503);
     if ($_SERVER['REQUEST_METHOD'] !== 'HEAD') {
         header('Content-Type: text/plain');
@@ -62,7 +63,8 @@ foreach ($_legacyRedirects as $_old => $_new) {
 // Redirect Event/index/{id} to the kingdom event attendance report with the event name as filter
 if (preg_match('#^Event/index/(\d+)#i', $_REQUEST['Route'], $_m)) {
     $_event_id = (int)$_m[1];
-    $_summary = (new Event())->GetEventSummaryForRedirect($_event_id);
+    require_once DIR_MODEL . 'model.Event.php';
+    $_summary = (new Model_Event())->get_event_summary_for_redirect($_event_id);
     if ($_summary['KingdomId'] > 0 && $_summary['Name'] !== '') {
         header('Location: ' . UIR . 'Reports/event_attendance/Kingdom/' . $_summary['KingdomId'] . '&filter=' . rawurlencode($_summary['Name']), true, 302);
         exit;

--- a/orkui/model/model.Authorization.php
+++ b/orkui/model/model.Authorization.php
@@ -4,7 +4,7 @@ class Model_Authorization extends Model
 {
     public function __construct()
     {
-        parent::__construct($call, $method);
+        parent::__construct();
         $this->Authorization = new APIModel('Authorization');
     }
 
@@ -28,8 +28,30 @@ class Model_Authorization extends Model
         return $this->_authorization_gate()->check($uid, $type, $id, $role);
     }
 
+    /**
+     * First-class audit write for auth / staff mutations (replaces inline new Dangeraudit()).
+     */
+    public function audit($call, $parameters, $entity, $entity_id, $prior_state = null, $post_state = null)
+    {
+        return $this->_dangeraudit()->audit($call, $parameters, $entity, $entity_id, $prior_state, $post_state);
+    }
+
+    /**
+     * HasAuthority / auth ORM shares the global DB connection — clear after nav auth
+     * checks so subclass actions start clean.
+     */
+    public function clear_db_after_auth_checks(): void
+    {
+        $this->_authorization_gate()->clearSharedDb();
+    }
+
     private function _authorization_gate(): AuthorizationGate
     {
         return new AuthorizationGate();
+    }
+
+    private function _dangeraudit(): Dangeraudit
+    {
+        return new Dangeraudit();
     }
 }

--- a/orkui/model/model.Event.php
+++ b/orkui/model/model.Event.php
@@ -467,4 +467,15 @@ class Model_Event extends Model
         return $this->Event->GetEventTemplatesForKingdom((int) $kingdom_id);
     }
 
+    /** @return array{KingdomId: int, Name: string} */
+    public function get_event_summary_for_redirect(int $event_id): array
+    {
+        return $this->_event_domain()->GetEventSummaryForRedirect($event_id);
+    }
+
+    private function _event_domain(): Event
+    {
+        return new Event();
+    }
+
 }

--- a/orkui/model/model.Health.php
+++ b/orkui/model/model.Health.php
@@ -1,0 +1,14 @@
+<?php
+
+class Model_Health extends Model
+{
+    public function ping_db(): bool
+    {
+        return $this->_health()->PingDb();
+    }
+
+    private function _health(): Health
+    {
+        return new Health();
+    }
+}

--- a/orkui/model/model.Player.php
+++ b/orkui/model/model.Player.php
@@ -322,6 +322,53 @@ class Model_Player extends Model
         return $this->_player()->GetReconcileAwardMap($kingdom_id);
     }
 
+    /**
+     * Pure historical partition + smart-rank (no kingdom map / no DB).
+     *
+     * @param list<array<string, mixed>> $awards
+     * @return array{
+     *   HistoricalAwards: list<array<string, mixed>>,
+     *   RankSuggestions: array<int, int>,
+     *   RealRanksByAwardId: array<int, list<int>>,
+     *   Summary: array{AwardTypeCount: int, TotalCount: int},
+     *   HasHistoricalLadder: bool
+     * }
+     */
+    public function get_reconcile_suggestions(array $awards): array
+    {
+        return $this->_player()->GetReconcileSuggestions($awards);
+    }
+
+    /**
+     * @param array<string, mixed> $request
+     * @return array{
+     *   HistoricalAwards: list<array<string, mixed>>,
+     *   RankSuggestions: array<int, int>,
+     *   RealRanksByAwardId: array<int, list<int>>,
+     *   AwardIdToKingdomAwardId: array<int, int>,
+     *   Summary: array{AwardTypeCount: int, TotalCount: int},
+     *   HasHistoricalLadder: bool
+     * }
+     */
+    public function get_reconcile_page_data(array $request): array
+    {
+        $empty = [
+            'HistoricalAwards' => [],
+            'RankSuggestions' => [],
+            'RealRanksByAwardId' => [],
+            'AwardIdToKingdomAwardId' => [],
+            'Summary' => ['AwardTypeCount' => 0, 'TotalCount' => 0],
+            'HasHistoricalLadder' => false,
+        ];
+        $response = $this->_player()->GetReconcilePageData($request);
+        if (($response['Status'] ?? 1) != 0) {
+            return $empty;
+        }
+        $detail = $response['Detail'] ?? null;
+
+        return is_array($detail) ? array_merge($empty, $detail) : $empty;
+    }
+
     public function get_highest_class_level(int $mundane_id): int
     {
         return $this->_player()->GetHighestClassLevel($mundane_id);

--- a/orkui/model/model.Player.php
+++ b/orkui/model/model.Player.php
@@ -322,6 +322,11 @@ class Model_Player extends Model
         return $this->_player()->GetReconcileAwardMap($kingdom_id);
     }
 
+    public function get_highest_class_level(int $mundane_id): int
+    {
+        return $this->_player()->GetHighestClassLevel($mundane_id);
+    }
+
     public function dismiss_whats_new($mundane_id, $version)
     {
         return $this->_player()->DismissWhatsNew((int)$mundane_id, (string)$version);

--- a/orkui/model/model.Player.php
+++ b/orkui/model/model.Player.php
@@ -327,6 +327,23 @@ class Model_Player extends Model
         return $this->_player()->DismissWhatsNew((int)$mundane_id, (string)$version);
     }
 
+    /** @return array{BasicFonts: int, DyslexiaFonts: int} */
+    public function get_viewer_preferences(int $mundane_id): array
+    {
+        return $this->_player()->GetViewerPreferences($mundane_id);
+    }
+
+    public function get_whats_new_seen(int $mundane_id, string $version): bool
+    {
+        return $this->_player()->GetWhatsNewSeen($mundane_id, $version);
+    }
+
+    /** @return array{KingdomId: int, ParentKingdomId: int} */
+    public function get_home_kingdom(int $mundane_id): array
+    {
+        return $this->_player()->GetHomeKingdom($mundane_id);
+    }
+
     public function check_username_available($username, $exclude_mundane_id = 0)
     {
         return $this->_player()->CheckUsernameAvailable($username, $exclude_mundane_id);

--- a/orkui/model/model.Player.php
+++ b/orkui/model/model.Player.php
@@ -374,6 +374,24 @@ class Model_Player extends Model
         return $this->_player()->GetHighestClassLevel($mundane_id);
     }
 
+    /**
+     * ClassLevel::THRESHOLDS for client UX (PnConfig) — single source, no UI copy.
+     *
+     * @return list<float|int>
+     */
+    public function get_class_level_thresholds(): array
+    {
+        return ClassLevel::THRESHOLDS;
+    }
+
+    /**
+     * @return array{Level: int, ToNext: ?float}
+     */
+    public function compute_class_level(float $credits): array
+    {
+        return ClassLevel::computeClassLevel($credits);
+    }
+
     public function get_class_paragon_map(): array
     {
         return Award::GetClassParagonMap();

--- a/orkui/model/model.Player.php
+++ b/orkui/model/model.Player.php
@@ -327,6 +327,49 @@ class Model_Player extends Model
         return $this->_player()->GetHighestClassLevel($mundane_id);
     }
 
+    public function get_class_paragon_map(): array
+    {
+        return Award::GetClassParagonMap();
+    }
+
+    public function get_ladder_master_map(): array
+    {
+        return Award::GetLadderMasterMap();
+    }
+
+    public function get_knight_award_map(): array
+    {
+        return Award::GetKnightAwardMap();
+    }
+
+    /**
+     * @param array<string, mixed> $request
+     * @return list<array<string, mixed>>
+     */
+    public function get_player_milestones(array $request): array
+    {
+        $response = $this->_player()->GetPlayerMilestones($request);
+        if (($response['Status'] ?? 1) != 0) {
+            return [];
+        }
+
+        return is_array($response['Detail'] ?? null) ? $response['Detail'] : [];
+    }
+
+    /**
+     * @param array<string, mixed> $request
+     * @return list<array<string, mixed>>
+     */
+    public function get_ladder_progress(array $request): array
+    {
+        $response = $this->_player()->GetLadderProgress($request);
+        if (($response['Status'] ?? 1) != 0) {
+            return [];
+        }
+
+        return is_array($response['Detail'] ?? null) ? $response['Detail'] : [];
+    }
+
     public function dismiss_whats_new($mundane_id, $version)
     {
         return $this->_player()->DismissWhatsNew((int)$mundane_id, (string)$version);

--- a/orkui/model/model.SessionToken.php
+++ b/orkui/model/model.SessionToken.php
@@ -1,0 +1,14 @@
+<?php
+
+class Model_SessionToken extends Model
+{
+    public function validate_session_token(int $mundane_id, string $token): bool
+    {
+        return $this->_session_token()->ValidateSessionToken($mundane_id, $token);
+    }
+
+    private function _session_token(): SessionToken
+    {
+        return new SessionToken();
+    }
+}

--- a/orkui/template/revised-frontend/Playernew_index.tpl
+++ b/orkui/template/revised-frontend/Playernew_index.tpl
@@ -113,6 +113,9 @@
 	if (!isset($ClassParagonMap) || !is_array($ClassParagonMap)) {
 		$ClassParagonMap = [];
 	}
+	if (!isset($ClassLevelThresholds) || !is_array($ClassLevelThresholds)) {
+		$ClassLevelThresholds = [];
+	}
 	$pnHeldAwardIds = [];
 	if (is_array($Details['Awards'])) {
 		foreach ($Details['Awards'] as $_pa) {
@@ -170,22 +173,7 @@
 			$_daysLeft = max(1, ceil($passwordSoonSecs / 86400));
 			$_maAlerts[] = ['type'=>'warning','icon'=>'fa-key','msg'=>"Your password expires in {$_daysLeft} day" . ($_daysLeft===1?'':'s') . ".",'actionLabel'=>'Update your password.','actionOnclick'=>'pnOpenAccountModal();return false;'];
 		}
-		// Level helpers
-		function _ma_level($credits) {
-			if ($credits >= 53) return 6;
-			if ($credits >= 34) return 5;
-			if ($credits >= 21) return 4;
-			if ($credits >= 12) return 3;
-			if ($credits >= 5)  return 2;
-			return 1;
-		}
-		function _ma_progress($credits) {
-			$t = [0,5,12,21,34,53];
-			if ($credits >= 53) return 100;
-			for ($i = count($t)-1; $i >= 0; $i--)
-				if ($credits >= $t[$i]) return round(($credits-$t[$i])/($t[$i+1]-$t[$i])*100);
-			return 0;
-		}
+		// Class level thresholds live in ClassLevel::THRESHOLDS (controller → ClassLevelThresholds / PnConfig).
 	}
 ?>
 
@@ -3857,6 +3845,7 @@ var PnConfig = {
 	canEditDesign:    <?= (!empty($isOwnProfile) || !empty($ViewerIsOrkAdmin)) ? 'true' : 'false' ?>,
 	kingdomUrl:       <?= json_encode(UIR . 'Kingdom/profile/' . (int)($KingdomId ?? 0)) ?>,
 	classToParagon:   <?= json_encode($ClassParagonMap) ?>,
+	classLevelThresholds: <?= json_encode(array_values($ClassLevelThresholds ?? [])) ?>,
 	heldAwardIds:     <?= json_encode(array_keys($pnHeldAwardIds)) ?>,
 	canDeleteRec:   <?= !empty($can_delete_recommendation) ? 'true' : 'false' ?>,
 	showRecsTab:    <?= !empty($ShowRecsTab) ? 'true' : 'false' ?>,
@@ -7006,6 +6995,8 @@ $(function() {
 				});
 
 				var newMilestones = [];
+				var levelThresholds = PnConfig.classLevelThresholds || [];
+				var maxClassCredits = levelThresholds.length ? levelThresholds[levelThresholds.length - 1] : null;
 				Object.keys(classData).forEach(function(cid) {
 					var cd = classData[cid];
 					if (!cd.history.length) return;
@@ -7013,7 +7004,7 @@ $(function() {
 					var cum = cd.reconciled;
 					for (var i = 0; i < cd.history.length; i++) {
 						cum += cd.history[i].credits;
-						if (cum >= 53) {
+						if (maxClassCredits !== null && cum >= maxClassCredits) {
 							newMilestones.push({ date: cd.history[i].date, name: cd.name });
 							break;
 						}
@@ -7201,13 +7192,18 @@ $(function() {
 				});
 				if (!maClasses.length) { cpBody.innerHTML = ''; return; }
 				var maHtml = '<div class="pna-card"><div class="pna-card-title"><i class="fas fa-shield-alt"></i> Class Progress <a class="pna-card-more" href="#" onclick="pnActivateTab(\'classes\');return false;">All &rarr;</a></div><div style="font-size:11px;color:#a0aec0;margin-bottom:6px;">Your recent classes&hellip;</div>';
-				var thresholds = [0,5,12,21,34,53];
+				var levelThresholds = PnConfig.classLevelThresholds || [];
+				var thresholds = [0].concat(levelThresholds);
+				var maxCredits = levelThresholds.length ? levelThresholds[levelThresholds.length - 1] : null;
 				maClasses.forEach(function(mc) {
 					var total = parseInt(mc.Credits||0) + parseInt(mc.Reconciled||0);
-					var lvl = total>=53?6:total>=34?5:total>=21?4:total>=12?3:total>=5?2:1;
-					var pct = total>=53?100:Math.round((total/thresholds[lvl])*100);
-					var isMax = total >= 53;
-					var next = thresholds[lvl] || 53;
+					var lvl = 1;
+					for (var ti = levelThresholds.length - 1; ti >= 0; ti--) {
+						if (total >= levelThresholds[ti]) { lvl = ti + 2; break; }
+					}
+					var isMax = maxCredits !== null && total >= maxCredits;
+					var pct = isMax ? 100 : Math.round((total / (thresholds[lvl] || 1)) * 100);
+					var next = thresholds[lvl] || maxCredits;
 					var parId = classToParagon[parseInt(mc.ClassId)] || 0;
 					var hasPar = parId > 0 && !!heldAwardIds[parId];
 					maHtml += '<div class="pna-class-row">'

--- a/orkui/template/revised-frontend/Playernew_index.tpl
+++ b/orkui/template/revised-frontend/Playernew_index.tpl
@@ -28,7 +28,9 @@
 	}
 
 
-	$knightAwardIds = array(17, 18, 19, 20, 245);
+	// Knight AwardIds from domain (Award::GetKnightAwardMap via controller).
+	// Belt IMAGE URLs stay presentation-local (host/path); AwardIds come from domain.
+	$knightAwardIds = array_map('intval', array_keys(is_array($KnightAwardMap ?? null) ? $KnightAwardMap : []));
 	$_beltImgHost = '//' . $_SERVER['HTTP_HOST'] . '/assets/images/';
 	$beltImageMap = array(
 		17  => $_beltImgHost . 'belt-flame.png',
@@ -129,11 +131,10 @@
 		if (!empty($_att['ClassId'])) { $_lastClassId = (int)$_att['ClassId']; break; }
 	}
 
-	// Class → Paragon award map (used by My Amtgard + Class Levels tabs)
-	$pnClassToParagon = [
-		1=>37, 2=>38, 3=>39, 4=>40, 5=>41, 6=>241, 7=>42, 8=>43,
-		9=>44, 10=>45, 11=>46, 12=>47, 14=>242, 15=>49, 16=>50, 17=>51,
-	];
+	// Class → Paragon award map from domain (controller-assigned ClassParagonMap)
+	if (!isset($ClassParagonMap) || !is_array($ClassParagonMap)) {
+		$ClassParagonMap = [];
+	}
 	$pnHeldAwardIds = [];
 	if (is_array($Details['Awards'])) {
 		foreach ($Details['Awards'] as $_pa) {
@@ -2129,114 +2130,16 @@ html[data-theme="dark"] .dp-no-restrict-row:hover{background:rgba(255,255,255,.0
 						}
 					}
 
-					// Build ladder progress: AwardId -> {Name, Short, MaxRank, HasMaster}
-					// Static map: Order award_id => Master award_id(s)
-					$pnOrderToMaster = [
-						21  => [1],       // Order of the Rose      → Master Rose
-						22  => [2],       // Order of the Smith      → Master Smith
-						23  => [3],       // Order of the Lion       → Master Lion
-						24  => [4],       // Order of the Owl        → Master Owl
-						25  => [5],       // Order of the Dragon     → Master Dragon
-						26  => [6],       // Order of the Garber     → Master Garber
-						27  => [12],      // Order of the Warrior    → Warlord
-						28  => [7],       // Order of the Jovius     → Master Jovius
-						29  => [9],       // Order of the Mask       → Master Mask
-						30  => [8],       // Order of the Zodiac     → Master Zodiac
-						32  => [10],      // Order of the Hydra      → Master Hydra
-						33  => [11],      // Order of the Griffin    → Master Griffin
-						239 => [240],     // Order of the Crown      → Master Crown
-						243 => [244],     // Order of Battle         → Battlemaster
-					];
-					$pnOrderNames = [
-						21  => ['Order of the Rose',    'Rose'],
-						22  => ['Order of the Smith',   'Smith'],
-						23  => ['Order of the Lion',    'Lion'],
-						24  => ['Order of the Owl',     'Owl'],
-						25  => ['Order of the Dragon',  'Dragon'],
-						26  => ['Order of the Garber',  'Garber'],
-						27  => ['Order of the Warrior', 'Warrior'],
-						28  => ['Order of the Jovius',  'Jovius'],
-						29  => ['Order of the Mask',    'Mask'],
-						30  => ['Order of the Zodiac',  'Zodiac'],
-						32  => ['Order of the Hydra',   'Hydra'],
-						33  => ['Order of the Griffin', 'Griffin'],
-						239 => ['Order of the Crown',   'Crown'],
-						243 => ['Order of Battle',      'Battle'],
-					];
-					// Index all award_ids the player holds (including titles)
-					$pnHeldAwardIds = [];
-					foreach ($awardsList as $a) {
-						$aid = (int)$a['AwardId'];
-						if ($aid > 0) $pnHeldAwardIds[$aid] = true;
+					// Ladder progress tiles from domain (Player::GetLadderProgress via controller)
+					if (!isset($LadderProgress) || !is_array($LadderProgress)) {
+						$LadderProgress = [];
 					}
-					$pnLadderProgress = [];
-					foreach ($awardsList as $a) {
-						if ((int)$a['IsLadder'] !== 1) continue;
-						$aid  = (int)$a['AwardId'];
-						$rank = (int)$a['Rank'];
-						if ($aid <= 0 || $aid === 31) continue; // 31 = Walker of the Middle
-						$displayName = trimlen($a['CustomAwardName']) > 0 ? $a['CustomAwardName']
-							: (trimlen($a['KingdomAwardName']) > 0 ? $a['KingdomAwardName'] : $a['Name']);
-						// Strip "Order of the " / "Order of " prefix to save space
-						$shortName = preg_replace('/^Order of (the )?/i', '', $displayName);
-						// Check if player holds the corresponding Master title
-						$hasMaster = false;
-						if (isset($pnOrderToMaster[$aid])) {
-							foreach ($pnOrderToMaster[$aid] as $masterId) {
-								if (isset($pnHeldAwardIds[$masterId])) { $hasMaster = true; break; }
-							}
-						}
-						// Dedup key is rank only — two awards at the same rank from different
-						// parks or dates are still the same rank, not two separate levels.
-						$rankKey = $rank;
-						if (!isset($pnLadderProgress[$aid])) {
-							$pnLadderProgress[$aid] = ['Name' => $displayName, 'Short' => $shortName, 'Rank' => $rank,
-								'RankSet' => $rank > 0 ? [$rankKey => true] : [], 'UnrankedCount' => $rank === 0 ? 1 : 0, 'HasMaster' => $hasMaster];
-						} else {
-							if ($rank > $pnLadderProgress[$aid]['Rank']) {
-								$pnLadderProgress[$aid]['Rank'] = $rank;
-							}
-							if ($rank > 0) {
-								$pnLadderProgress[$aid]['RankSet'][$rankKey] = true;
-							} else {
-								$pnLadderProgress[$aid]['UnrankedCount']++;
-							}
-						}
-					}
-					// Use max(highest_rank, effective_count) to account for unreconciled historical awards.
-					// Effective count = distinct ranked entries + unranked entries (deduplicates duplicate ranks).
-					// Cap at maxRank per award (10 for most, 12 for Zodiac)
-					// Mark as approximate when effective count exceeds highest actual rank
-					foreach ($pnLadderProgress as $_lpAid => &$lp) {
-						$_lpMax = ($_lpAid === 30) ? 12 : 10;
-						$_effectiveCount = count($lp['RankSet']) + $lp['UnrankedCount'];
-						// Suppress the "approximate" marker when the player already holds the
-						// corresponding Master title — the M badge is the authoritative signal,
-						// no need to second-guess the breakdown that got them there.
-						$lp['Approx'] = ($_effectiveCount > $lp['Rank']) && empty($lp['HasMaster']);
-						$lp['Rank'] = min($_lpMax, max($lp['Rank'], $_effectiveCount));
-					}
-					unset($lp);
-					// Add a complete tile for any masterhood held with no corresponding ladder progress
-					foreach ($pnOrderToMaster as $orderId => $masterIds) {
-						if (isset($pnLadderProgress[$orderId])) continue;
-						$hasMaster = false;
-						foreach ($masterIds as $masterId) {
-							if (isset($pnHeldAwardIds[$masterId])) { $hasMaster = true; break; }
-						}
-						if (!$hasMaster) continue;
-						$maxRank = ($orderId === 30) ? 12 : 10;
-						$name  = $pnOrderNames[$orderId][0] ?? 'Unknown Order';
-						$short = $pnOrderNames[$orderId][1] ?? $name;
-						$pnLadderProgress[$orderId] = ['Name' => $name, 'Short' => $short, 'Rank' => $maxRank, 'Count' => 0, 'HasMaster' => true, 'Approx' => false];
-					}
-					uasort($pnLadderProgress, function($a, $b) { return strcmp($a['Name'], $b['Name']); });
 				?>
-				<?php if (!empty($pnLadderProgress)): ?>
+				<?php if (!empty($LadderProgress)): ?>
 					<div style="display:flex;align-items:flex-start;gap:8px;margin-bottom:16px;">
 						<div class="pn-ladder-grid" style="flex:1;min-width:0;margin-bottom:0">
-							<?php foreach ($pnLadderProgress as $aid => $lp): ?>
-								<?php $maxRank = ($aid === 30) ? 12 : 10; ?>
+							<?php foreach ($LadderProgress as $lp): ?>
+								<?php $maxRank = (int)($lp['MaxRank'] ?? 10); ?>
 								<?php $pct = min(100, round($lp['Rank'] / $maxRank * 100)); ?>
 								<div class="pn-ladder-item" title="<?= htmlspecialchars($lp['Name'] . ($lp['Approx'] ? ' (level approximated from historical data)' : '')) ?>" data-ladname="<?= htmlspecialchars($lp['Name']) ?>" style="cursor:pointer">
 									<div class="pn-ladder-header">
@@ -2568,8 +2471,7 @@ html[data-theme="dark"] .dp-no-restrict-row:hover{background:rgba(255,255,255,.0
 			<div class="pn-tab-panel" id="pn-tab-classes" style="display:none">
 				<?php
 					$classList = is_array($Details['Classes']) ? $Details['Classes'] : array();
-					// class_id → Paragon award_id
-					// $pnClassToParagon and $pnHeldAwardIds are pre-computed in the template preamble
+					// ClassParagonMap and $pnHeldAwardIds come from controller / preamble
 				?>
 				<?php if ($canManageAwards): ?>
 				<div class="pn-tab-toolbar">
@@ -2589,7 +2491,7 @@ html[data-theme="dark"] .dp-no-restrict-row:hover{background:rgba(255,255,255,.0
 							<?php foreach ($classList as $detail): ?>
 								<?php
 									$totalCredits = $detail['Credits'] + (isset($Player_index) ? $Player_index['Class_' . $detail['ClassId']] : $detail['Reconciled']);
-									$paragonAwardId = $pnClassToParagon[$detail['ClassId']] ?? null;
+									$paragonAwardId = $ClassParagonMap[$detail['ClassId']] ?? null;
 									$hasParagon = $paragonAwardId && isset($pnHeldAwardIds[$paragonAwardId]);
 								?>
 								<tr>
@@ -3912,7 +3814,7 @@ if (is_array($Details['Awards'])) {
 }
 $playerHeldAwardIds        = array_keys($playerHeldAwardIds);
 $playerHeldKingdomAwardIds = array_keys($playerHeldKingdomAwardIds);
-$ladderMasterMap           = Award::GetLadderMasterMap();
+$ladderMasterMap           = is_array($LadderMasterMap ?? null) ? $LadderMasterMap : [];
 ?>
 
 <!-- =============================================
@@ -3976,7 +3878,7 @@ var PnConfig = {
 	isOwnProfile:     <?= !empty($isOwnProfile) ? 'true' : 'false' ?>,
 	canEditDesign:    <?= (!empty($isOwnProfile) || !empty($ViewerIsOrkAdmin)) ? 'true' : 'false' ?>,
 	kingdomUrl:       <?= json_encode(UIR . 'Kingdom/profile/' . (int)($KingdomId ?? 0)) ?>,
-	classToParagon:   <?= json_encode($pnClassToParagon) ?>,
+	classToParagon:   <?= json_encode($ClassParagonMap) ?>,
 	heldAwardIds:     <?= json_encode(array_keys($pnHeldAwardIds)) ?>,
 	canDeleteRec:   <?= !empty($can_delete_recommendation) ? 'true' : 'false' ?>,
 	showRecsTab:    <?= !empty($ShowRecsTab) ? 'true' : 'false' ?>,

--- a/orkui/template/revised-frontend/Playernew_index.tpl
+++ b/orkui/template/revised-frontend/Playernew_index.tpl
@@ -89,31 +89,9 @@
 	$showLastName  = $canSeePrivate || (!$_isRestricted && $isLoggedIn && (int)($Player['ShowMundaneLast']  ?? 0));
 	$showEmail     = $canSeePrivate || (!$_isRestricted && $isLoggedIn && (int)($Player['ShowEmail']        ?? 0));
 
-	// Check if player has any reconcilable historical awards (ladder only — matches reconcile page filter)
-	$hasHistorical = false;
-	if ($canManageAwards && is_array($Details['Awards'])) {
-		foreach ($Details['Awards'] as $_ha) {
-			if (in_array($_ha['OfficerRole'], ['none', null]) && $_ha['IsTitle'] != 1 && (int)($_ha['IsLadder'] ?? 0) === 1) {
-				if ((int)$_ha['GivenById'] === 0 && (int)($_ha['EnteredById'] ?? 0) === 0) {
-					$hasHistorical = true;
-					break;
-				}
-			}
-		}
-	}
-
-	// Same check, visible to anyone viewing the profile
-	$hasHistoricalTip = false;
-	if (is_array($Details['Awards'])) {
-		foreach ($Details['Awards'] as $_ha) {
-			if (in_array($_ha['OfficerRole'], ['none', null]) && $_ha['IsTitle'] != 1 && (int)($_ha['IsLadder'] ?? 0) === 1) {
-				if ((int)$_ha['GivenById'] === 0 && (int)($_ha['EnteredById'] ?? 0) === 0) {
-					$hasHistoricalTip = true;
-					break;
-				}
-			}
-		}
-	}
+	// Historical ladder flags from domain (Controller_Player::profile via get_reconcile_suggestions)
+	$hasHistorical = !empty($HasHistorical);
+	$hasHistoricalTip = !empty($HasHistoricalTip);
 
 	// Kingdom dues period config
 	$_kconfig = Common::get_configs((int)($KingdomId ?? 0));

--- a/orkui/template/revised-frontend/Playernew_reconcile.tpl
+++ b/orkui/template/revised-frontend/Playernew_reconcile.tpl
@@ -10,70 +10,12 @@
 		exit;
 	}
 
-	// ── Partition awards ────────────────────────────────────────────────────
-	$allAwards          = is_array($Details['Awards']) ? $Details['Awards'] : [];
-	$historicalAwards   = [];
-	$realRanksByAwardId = [];
-
-	foreach ($allAwards as $a) {
-		$isAward = in_array($a['OfficerRole'], ['none', null]) && $a['IsTitle'] != 1;
-		if (!$isAward) continue;
-
-		$isHistorical = (int)(int)$a['GivenById'] === 0 && (int)($a['EnteredById'] ?? 0) === 0;
-
-		if ($isHistorical) {
-			$historicalAwards[] = $a;
-		} else {
-			$aid  = (int)$a['AwardId'];
-			$rank = (int)$a['Rank'];
-			if ($aid > 0) {
-				if (!isset($realRanksByAwardId[$aid])) $realRanksByAwardId[$aid] = [];
-				if ($rank > 0) $realRanksByAwardId[$aid][] = $rank;
-			}
-		}
-	}
-
-	// Keep only ladder awards — non-ladder (Custom Award etc.) are not reconcilable
-	$historicalAwards = array_values(array_filter($historicalAwards, function($a) {
-		return (int)($a['IsLadder'] ?? 0) === 1;
-	}));
-
-	// Sort: AwardId ASC, date ASC (missing last)
-	usort($historicalAwards, function($a, $b) {
-		if ((int)$a['AwardId'] !== (int)$b['AwardId'])
-			return (int)$a['AwardId'] - (int)$b['AwardId'];
-		$da = ($ts = strtotime($a['Date'] ?? '')) > 0 ? $ts : PHP_INT_MAX;
-		$db = ($ts = strtotime($b['Date'] ?? '')) > 0 ? $ts : PHP_INT_MAX;
-		return $da - $db;
-	});
-
-	// ── Smart rank suggestions ───────────────────────────────────────────────
-	$rankSuggestions = [];
-	$groupState      = [];
-	foreach ($historicalAwards as $a) {
-		$aid      = (int)$a['AwardId'];
-		$awardsId = (int)$a['AwardsId'];
-		$isLadder = (int)($a['IsLadder'] ?? 0);
-		if (!$isLadder) { $rankSuggestions[$awardsId] = 0; continue; }
-		if (!isset($groupState[$aid])) {
-			$real = [];
-			foreach ($realRanksByAwardId[$aid] ?? [] as $r) { if ($r > 0) $real[$r] = true; }
-			$groupState[$aid] = ['realRanks' => $real, 'usedRanks' => []];
-		}
-		$existing = (int)$a['Rank'];
-		if ($existing > 0 && !isset($groupState[$aid]['realRanks'][$existing]) && !isset($groupState[$aid]['usedRanks'][$existing])) {
-			$rankSuggestions[$awardsId] = $existing;
-			$groupState[$aid]['usedRanks'][$existing] = true;
-		} else {
-			$c = 1;
-			while (isset($groupState[$aid]['realRanks'][$c]) || isset($groupState[$aid]['usedRanks'][$c])) $c++;
-			$rankSuggestions[$awardsId] = $c;
-			$groupState[$aid]['usedRanks'][$c] = true;
-		}
-	}
-
-	$awardTypeCount = count(array_unique(array_column($historicalAwards, 'AwardId')));
-	$totalCount     = count($historicalAwards);
+	// Partition + smart-rank from domain (Controller_Player::reconcile via get_reconcile_page_data)
+	$historicalAwards   = is_array($HistoricalAwards ?? null) ? $HistoricalAwards : [];
+	$rankSuggestions    = is_array($RankSuggestions ?? null) ? $RankSuggestions : [];
+	$realRanksByAwardId = is_array($RealRanksByAwardId ?? null) ? $RealRanksByAwardId : [];
+	$awardTypeCount     = (int)($AwardTypeCount ?? 0);
+	$totalCount         = (int)($TotalCount ?? 0);
 	$playerId       = (int)($Player['MundaneId'] ?? 0);
 	$persona        = htmlspecialchars($Player['Persona'] ?? 'Player');
 	$heraldryUrl    = ($Player['HasHeraldry'] ?? 0) > 0

--- a/orkui/template/revised-frontend/script/revised.js
+++ b/orkui/template/revised-frontend/script/revised.js
@@ -726,24 +726,24 @@ $(document).ready(function() {
         }
     });
 
-    // ---- Class Level Calculation ----
+    // ---- Class Level Calculation (thresholds from ClassLevel via PnConfig) ----
     $('#pn-classes-table tbody tr').each(function() {
         var credits = Number($(this).find('.pn-credits').text());
+        var thresholds = PnConfig.classLevelThresholds || [];
         var level = 1;
-        if (credits >= 53) level = 6;
-        else if (credits >= 34) level = 5;
-        else if (credits >= 21) level = 4;
-        else if (credits >= 12) level = 3;
-        else if (credits >= 5) level = 2;
+        for (var ti = thresholds.length - 1; ti >= 0; ti--) {
+            if (credits >= thresholds[ti]) { level = ti + 2; break; }
+        }
         $(this).find('.pn-level').text(level);
 
-        var thresholds = [5, 12, 21, 34];
+        var maxCredits = thresholds.length ? thresholds[thresholds.length - 1] : null;
+        var nearThresholds = thresholds.length > 1 ? thresholds.slice(0, -1) : [];
         var badge = '';
-        if (credits >= 53) {
+        if (maxCredits !== null && credits >= maxCredits) {
             badge = 'max';
         } else {
-            for (var i = 0; i < thresholds.length; i++) {
-                var t = thresholds[i];
+            for (var i = 0; i < nearThresholds.length; i++) {
+                var t = nearThresholds[i];
                 if (credits === t) { badge = 'leveled'; break; }
                 else if (credits === t - 1 || credits === t - 2) { badge = 'soon'; break; }
             }

--- a/system/lib/ork3/class.AuthorizationGate.php
+++ b/system/lib/ork3/class.AuthorizationGate.php
@@ -30,4 +30,14 @@ class AuthorizationGate extends Ork3
             'Authorized' => $this->check($mundaneId, $type, $id, $role),
         ];
     }
+
+    /**
+     * HasAuthority / auth ORM share the global DB connection. Clear after nav
+     * auth checks so subclass controller actions start with a clean DB state.
+     */
+    public function clearSharedDb(): void
+    {
+        global $DB;
+        $DB->Clear();
+    }
 }

--- a/system/lib/ork3/class.Award.php
+++ b/system/lib/ork3/class.Award.php
@@ -12,8 +12,7 @@ class Award extends Ork3
      * Map of ladder award_id => metadata used to detect when a player has already reached
      * the top of that ladder or earned its Master-peerage companion award.
      *
-     * Keep in sync with the $pnOrderToMaster / $pnOrderNames maps in
-     * orkui/template/revised-frontend/Playernew_index.tpl (Awards tab).
+     * Sole order→master source of truth (P3-R2). UI must not fork this map.
      */
     public static function GetLadderMasterMap()
     {
@@ -33,6 +32,66 @@ class Award extends Ork3
             239 => ['MasterAwardIds' => [240], 'LadderName' => 'Order of the Crown',   'MasterName' => 'Master Crown',   'MaxRank' => 10],
             243 => ['MasterAwardIds' => [244], 'LadderName' => 'Order of Battle',      'MasterName' => 'Battlemaster',   'MaxRank' => 10],
         ];
+    }
+
+    /**
+     * class_id => Paragon award_id (Class Levels / My Amtgard badge display).
+     *
+     * @return array<int, int>
+     */
+    public static function GetClassParagonMap(): array
+    {
+        return [
+            1 => 37, 2 => 38, 3 => 39, 4 => 40, 5 => 41, 6 => 241, 7 => 42, 8 => 43,
+            9 => 44, 10 => 45, 11 => 46, 12 => 47, 14 => 242, 15 => 49, 16 => 50, 17 => 51,
+        ];
+    }
+
+    /**
+     * Knighthood award_id => short name (milestones + belt detection).
+     * Belt image URLs remain presentation-layer (template).
+     *
+     * @return array<int, string>
+     */
+    public static function GetKnightAwardMap(): array
+    {
+        return [
+            17 => 'Flame',
+            18 => 'Crown',
+            19 => 'Serpent',
+            20 => 'Sword',
+            245 => 'Battle',
+        ];
+    }
+
+    /**
+     * Flatten MasterAwardIds from GetLadderMasterMap (includes Warlord 12).
+     *
+     * @return list<int>
+     */
+    public static function GetMasterAwardIds(): array
+    {
+        $ids = [];
+        foreach (self::GetLadderMasterMap() as $info) {
+            foreach ((array)($info['MasterAwardIds'] ?? []) as $masterId) {
+                $masterId = (int)$masterId;
+                if ($masterId > 0) {
+                    $ids[$masterId] = true;
+                }
+            }
+        }
+
+        return array_map('intval', array_keys($ids));
+    }
+
+    /**
+     * Paragon award_ids (values of GetClassParagonMap).
+     *
+     * @return list<int>
+     */
+    public static function GetParagonAwardIds(): array
+    {
+        return array_values(array_unique(array_map('intval', array_values(self::GetClassParagonMap()))));
     }
 
     public function LookupAward($request)

--- a/system/lib/ork3/class.Player.php
+++ b/system/lib/ork3/class.Player.php
@@ -1082,6 +1082,368 @@ class Player extends Ork3
         return $highest;
     }
 
+    /**
+     * Profile milestone timeline (P3-R2). Prefer preloaded Awards / beltline to avoid N+1.
+     * Icons stay Font Awesome class strings in the DTO (template renders as-is).
+     *
+     * @param array{
+     *   MundaneId?: int,
+     *   PlayerSinceDate?: ?string,
+     *   Awards?: ?list,
+     *   BeltlinePeers?: ?list,
+     *   BeltlineAssociates?: ?list,
+     *   IncludeCustom?: bool
+     * } $request
+     * @return array{Status: int, Error?: string, Detail: list<array<string, mixed>>}
+     */
+    public function GetPlayerMilestones(array $request)
+    {
+        $mundaneId = (int)($request['MundaneId'] ?? 0);
+        $awards = $request['Awards'] ?? null;
+        if (!is_array($awards)) {
+            if (!valid_id($mundaneId)) {
+                return InvalidParameter();
+            }
+            $awardsResponse = $this->AwardsForPlayer(['MundaneId' => $mundaneId]);
+            $awards = is_array($awardsResponse['Awards'] ?? null) ? $awardsResponse['Awards'] : [];
+        }
+
+        $playerSince = $request['PlayerSinceDate'] ?? null;
+        if (($playerSince === null || $playerSince === '') && valid_id($mundaneId)) {
+            $playerSince = $this->get_earliest_attendance_date($mundaneId);
+        }
+
+        $peers = is_array($request['BeltlinePeers'] ?? null) ? $request['BeltlinePeers'] : [];
+        $associates = is_array($request['BeltlineAssociates'] ?? null) ? $request['BeltlineAssociates'] : [];
+        $includeCustom = array_key_exists('IncludeCustom', $request)
+            ? (bool)$request['IncludeCustom']
+            : true;
+
+        $milestones = [];
+
+        if ($playerSince && $playerSince !== '0000-00-00' && $playerSince !== '1970-01-01') {
+            $milestones[] = [
+                'type' => 'first_signin',
+                'date' => $playerSince,
+                'icon' => 'fa-door-open',
+                'description' => 'First sign-in at Amtgard',
+            ];
+        }
+
+        $knightMap = Award::GetKnightAwardMap();
+        $knightIds = array_map('intval', array_keys($knightMap));
+        $masterIds = Award::GetMasterAwardIds();
+        $paragonIds = Award::GetParagonAwardIds();
+
+        foreach ($awards as $aw) {
+            if (!is_array($aw)) {
+                continue;
+            }
+            $aid = (int)($aw['AwardId'] ?? 0);
+            $awDate = $aw['Date'] ?? '';
+            $awName = !empty($aw['CustomAwardName'])
+                ? $aw['CustomAwardName']
+                : (!empty($aw['KingdomAwardName']) ? $aw['KingdomAwardName'] : ($aw['Name'] ?? ''));
+            $officerRole = $aw['OfficerRole'] ?? 'none';
+            $isTitle = (int)($aw['IsTitle'] ?? 0);
+            $aliasPeerage = $aw['AliasPeerage'] ?? '';
+
+            if (empty($awDate) || $awDate === '0000-00-00') {
+                continue;
+            }
+
+            if (in_array($aid, $knightIds, true)) {
+                $knLabel = isset($knightMap[$aid]) ? 'Knight of the ' . $knightMap[$aid] : 'Knighted';
+                $milestones[] = [
+                    'type' => 'knight',
+                    'date' => $awDate,
+                    'icon' => 'fa-shield-alt',
+                    'description' => 'Earned ' . $knLabel,
+                ];
+            }
+
+            if (in_array($aid, $masterIds, true)) {
+                $milestones[] = [
+                    'type' => 'master',
+                    'date' => $awDate,
+                    'icon' => 'fa-star',
+                    'description' => 'Earned ' . $awName,
+                ];
+            }
+
+            if (in_array($aid, $paragonIds, true)) {
+                $milestones[] = [
+                    'type' => 'paragon',
+                    'date' => $awDate,
+                    'icon' => 'fa-gem',
+                    'description' => 'Earned ' . $awName,
+                ];
+            }
+
+            if ($isTitle === 1 && in_array($officerRole, ['none', null], true)
+                && !in_array($aid, $paragonIds, true)
+                && !in_array($aid, $knightIds, true)
+                && !in_array($aliasPeerage, ['Page', 'Lords-Page', 'Squire', 'Man-At-Arms'], true)
+            ) {
+                $milestones[] = [
+                    'type' => 'title',
+                    'date' => $awDate,
+                    'icon' => 'fa-crown',
+                    'description' => 'Earned the title ' . $awName,
+                ];
+            }
+
+            if (!in_array($officerRole, ['none', null, ''], true)) {
+                $milestones[] = [
+                    'type' => 'officer',
+                    'date' => $awDate,
+                    'icon' => 'fa-landmark',
+                    'description' => 'Served as ' . $awName,
+                ];
+            }
+        }
+
+        $peerLabels = [
+            'Squire' => 'Squire',
+            'Man-At-Arms' => 'Person-at-Arms',
+            'Lords-Page' => "Lord's Page",
+            'Page' => 'Page',
+        ];
+        foreach ($peers as $bp) {
+            if (!is_array($bp)) {
+                continue;
+            }
+            $peerDate = $bp['Date'] ?? '';
+            if (empty($peerDate) || $peerDate === '0000-00-00') {
+                continue;
+            }
+            $peerLabel = $peerLabels[$bp['Peerage'] ?? ''] ?? ($bp['Peerage'] ?? '');
+            $milestones[] = [
+                'type' => 'became_associate',
+                'date' => $peerDate,
+                'icon' => 'fa-handshake',
+                'description' => 'Became ' . $peerLabel . ' to ' . ($bp['Persona'] ?? ''),
+            ];
+        }
+        foreach ($associates as $ba) {
+            if (!is_array($ba)) {
+                continue;
+            }
+            $assocDate = $ba['Date'] ?? '';
+            if (empty($assocDate) || $assocDate === '0000-00-00') {
+                continue;
+            }
+            $assocLabel = $peerLabels[$ba['Peerage'] ?? ''] ?? ($ba['Peerage'] ?? '');
+            $milestones[] = [
+                'type' => 'took_associate',
+                'date' => $assocDate,
+                'icon' => 'fa-hand-holding-heart',
+                'description' => 'Took ' . ($ba['Persona'] ?? '') . ' as ' . $assocLabel,
+            ];
+        }
+
+        if ($includeCustom && valid_id($mundaneId)) {
+            $customMs = $this->GetCustomMilestones($mundaneId);
+            if (is_array($customMs)) {
+                foreach ($customMs as $cm) {
+                    $milestones[] = [
+                        'type' => 'custom',
+                        'date' => $cm['MilestoneDate'],
+                        'icon' => $cm['Icon'],
+                        'description' => $cm['Description'],
+                        'milestoneId' => (int)$cm['MilestoneId'],
+                    ];
+                }
+            }
+        }
+
+        $masterMsNames = [];
+        foreach ($milestones as $m) {
+            if (($m['type'] ?? '') === 'master') {
+                $masterMsNames[] = strtolower(preg_replace('/^Earned (?:Master )?/', '', $m['description']));
+            }
+        }
+        $peerageTerms = ['squire', 'man-at-arms', 'person-at-arms', "lord's page", 'page'];
+        $milestones = array_values(array_filter($milestones, function ($m) use ($masterMsNames, $peerageTerms) {
+            if (($m['type'] ?? '') !== 'title') {
+                return true;
+            }
+            $tn = strtolower(preg_replace('/^Earned the title /', '', $m['description']));
+            if (in_array($tn, $peerageTerms, true)) {
+                return false;
+            }
+            if (substr($tn, 0, 7) === 'master ') {
+                $kw = substr($tn, 7);
+                foreach ($masterMsNames as $mn) {
+                    if (strpos($mn, $kw) !== false) {
+                        return false;
+                    }
+                }
+            }
+            return true;
+        }));
+
+        $seen = [];
+        $milestones = array_values(array_filter($milestones, function ($m) use (&$seen) {
+            $key = ($m['date'] ?? '') . '|' . ($m['description'] ?? '');
+            if (isset($seen[$key])) {
+                return false;
+            }
+            $seen[$key] = true;
+            return true;
+        }));
+
+        usort($milestones, function ($a, $b) {
+            return strtotime($a['date'] ?? '') - strtotime($b['date'] ?? '');
+        });
+
+        return Success($milestones);
+    }
+
+    /**
+     * Ladder progress tiles for the Awards tab (P3-R2). Uses Award::GetLadderMasterMap only.
+     * Skips Walker of the Middle (31). Approx when effective count > Rank and no Master.
+     *
+     * @param array{MundaneId?: int, Awards?: ?list} $request
+     * @return array{Status: int, Error?: string, Detail: list<array<string, mixed>>}
+     */
+    public function GetLadderProgress(array $request)
+    {
+        $mundaneId = (int)($request['MundaneId'] ?? 0);
+        $awards = $request['Awards'] ?? null;
+        if (!is_array($awards)) {
+            if (!valid_id($mundaneId)) {
+                return InvalidParameter();
+            }
+            $awardsResponse = $this->AwardsForPlayer(['MundaneId' => $mundaneId]);
+            $awards = is_array($awardsResponse['Awards'] ?? null) ? $awardsResponse['Awards'] : [];
+        }
+
+        $ladderMap = Award::GetLadderMasterMap();
+        $heldAwardIds = [];
+        foreach ($awards as $a) {
+            if (!is_array($a)) {
+                continue;
+            }
+            $aid = (int)($a['AwardId'] ?? 0);
+            if ($aid > 0) {
+                $heldAwardIds[$aid] = true;
+            }
+        }
+
+        $progress = [];
+        foreach ($awards as $a) {
+            if (!is_array($a)) {
+                continue;
+            }
+            if ((int)($a['IsLadder'] ?? 0) !== 1) {
+                continue;
+            }
+            $aid = (int)($a['AwardId'] ?? 0);
+            $rank = (int)($a['Rank'] ?? 0);
+            if ($aid <= 0 || $aid === 31) {
+                continue; // 31 = Walker of the Middle
+            }
+
+            $custom = (string)($a['CustomAwardName'] ?? '');
+            $kingdomName = (string)($a['KingdomAwardName'] ?? '');
+            $name = (string)($a['Name'] ?? '');
+            if (function_exists('trimlen')) {
+                $displayName = trimlen($custom) > 0 ? $custom
+                    : (trimlen($kingdomName) > 0 ? $kingdomName : $name);
+            } else {
+                $displayName = $custom !== '' ? $custom : ($kingdomName !== '' ? $kingdomName : $name);
+            }
+            $shortName = preg_replace('/^Order of (the )?/i', '', $displayName);
+
+            $hasMaster = false;
+            if (isset($ladderMap[$aid])) {
+                foreach ((array)$ladderMap[$aid]['MasterAwardIds'] as $masterId) {
+                    if (isset($heldAwardIds[(int)$masterId])) {
+                        $hasMaster = true;
+                        break;
+                    }
+                }
+            }
+
+            $rankKey = $rank;
+            if (!isset($progress[$aid])) {
+                $progress[$aid] = [
+                    'Name' => $displayName,
+                    'Short' => $shortName,
+                    'Rank' => $rank,
+                    'RankSet' => $rank > 0 ? [$rankKey => true] : [],
+                    'UnrankedCount' => $rank === 0 ? 1 : 0,
+                    'HasMaster' => $hasMaster,
+                ];
+            } else {
+                if ($rank > $progress[$aid]['Rank']) {
+                    $progress[$aid]['Rank'] = $rank;
+                }
+                if ($rank > 0) {
+                    $progress[$aid]['RankSet'][$rankKey] = true;
+                } else {
+                    $progress[$aid]['UnrankedCount']++;
+                }
+            }
+        }
+
+        foreach ($progress as $lpAid => &$lp) {
+            $maxRank = (int)($ladderMap[$lpAid]['MaxRank'] ?? (($lpAid === 30) ? 12 : 10));
+            $effectiveCount = count($lp['RankSet']) + $lp['UnrankedCount'];
+            $lp['Approx'] = ($effectiveCount > $lp['Rank']) && empty($lp['HasMaster']);
+            $lp['Rank'] = min($maxRank, max($lp['Rank'], $effectiveCount));
+            $lp['MaxRank'] = $maxRank;
+            unset($lp['RankSet'], $lp['UnrankedCount']);
+        }
+        unset($lp);
+
+        foreach ($ladderMap as $orderId => $info) {
+            if (isset($progress[$orderId])) {
+                continue;
+            }
+            $hasMaster = false;
+            foreach ((array)$info['MasterAwardIds'] as $masterId) {
+                if (isset($heldAwardIds[(int)$masterId])) {
+                    $hasMaster = true;
+                    break;
+                }
+            }
+            if (!$hasMaster) {
+                continue;
+            }
+            $maxRank = (int)($info['MaxRank'] ?? 10);
+            $name = (string)($info['LadderName'] ?? 'Unknown Order');
+            $short = preg_replace('/^Order of (the )?/i', '', $name);
+            $progress[$orderId] = [
+                'Name' => $name,
+                'Short' => $short,
+                'Rank' => $maxRank,
+                'MaxRank' => $maxRank,
+                'HasMaster' => true,
+                'Approx' => false,
+            ];
+        }
+
+        $tiles = [];
+        foreach ($progress as $aid => $lp) {
+            $tiles[] = [
+                'AwardId' => (int)$aid,
+                'Name' => $lp['Name'],
+                'Short' => $lp['Short'],
+                'Rank' => (int)$lp['Rank'],
+                'MaxRank' => (int)($lp['MaxRank'] ?? (($aid === 30) ? 12 : 10)),
+                'HasMaster' => !empty($lp['HasMaster']),
+                'Approx' => !empty($lp['Approx']),
+            ];
+        }
+        usort($tiles, function ($a, $b) {
+            return strcmp($a['Name'], $b['Name']);
+        });
+
+        return Success($tiles);
+    }
+
     public function GetPlayerClasses($request)
     {
         // Cold-cache the dedupe-by-date subquery costs ~185ms for the busiest player

--- a/system/lib/ork3/class.Player.php
+++ b/system/lib/ork3/class.Player.php
@@ -1037,6 +1037,51 @@ class Player extends Ork3
         return Success($progress);
     }
 
+    /**
+     * Profile chrome highest class level via ComputeClassProgress (P3-R1 Option A).
+     * Details['Classes'] from GetPlayerProfileDetails use the same GetPlayerClasses source.
+     */
+    public function GetHighestClassLevel(int $mundaneId): int
+    {
+        $progress = $this->ComputeClassProgress(['MundaneId' => $mundaneId]);
+        if (($progress['Status'] ?? 1) != 0) {
+            return 0;
+        }
+
+        $highest = 0;
+        foreach ($progress['Detail'] ?? [] as $row) {
+            $lvl = (int)($row['Level'] ?? 0);
+            if ($lvl > $highest) {
+                $highest = $lvl;
+            }
+        }
+
+        return $highest;
+    }
+
+    /**
+     * Pure max level over class rows (Credits + Reconciled) via ClassLevel::computeClassLevel.
+     * Characterization / Option B byte-identical path over already-fetched Details['Classes'].
+     *
+     * @param array<int|string, array<string, mixed>> $classes
+     */
+    public static function HighestClassLevelFromClasses(array $classes): int
+    {
+        $highest = 0;
+        foreach ($classes as $c) {
+            if (!is_array($c)) {
+                continue;
+            }
+            $credits = (float)($c['Credits'] ?? 0) + (float)($c['Reconciled'] ?? 0);
+            $lvl = ClassLevel::computeClassLevel($credits)['Level'];
+            if ($lvl > $highest) {
+                $highest = $lvl;
+            }
+        }
+
+        return $highest;
+    }
+
     public function GetPlayerClasses($request)
     {
         // Cold-cache the dedupe-by-date subquery costs ~185ms for the busiest player

--- a/system/lib/ork3/class.Player.php
+++ b/system/lib/ork3/class.Player.php
@@ -243,6 +243,148 @@ class Player extends Ork3
         return $awardIdMap;
     }
 
+    /**
+     * Pure historical partition + smart-rank suggestions over an awards list.
+     * Prefer existing Rank if unused by real+suggested; else smallest free
+     * positive integer per AwardId group. Matches former Playernew_reconcile.tpl.
+     *
+     * @param list<array<string, mixed>> $awards
+     * @return array{
+     *   HistoricalAwards: list<array<string, mixed>>,
+     *   RankSuggestions: array<int, int>,
+     *   RealRanksByAwardId: array<int, list<int>>,
+     *   Summary: array{AwardTypeCount: int, TotalCount: int},
+     *   HasHistoricalLadder: bool
+     * }
+     */
+    public function GetReconcileSuggestions(array $awards): array
+    {
+        $historicalAwards = [];
+        $realRanksByAwardId = [];
+
+        foreach ($awards as $a) {
+            if (!is_array($a)) {
+                continue;
+            }
+            $isAward = in_array($a['OfficerRole'] ?? null, ['none', null]) && ($a['IsTitle'] ?? 0) != 1;
+            if (!$isAward) {
+                continue;
+            }
+
+            $isHistorical = (int)($a['GivenById'] ?? 0) === 0 && (int)($a['EnteredById'] ?? 0) === 0;
+
+            if ($isHistorical) {
+                $historicalAwards[] = $a;
+            } else {
+                $aid = (int)($a['AwardId'] ?? 0);
+                $rank = (int)($a['Rank'] ?? 0);
+                if ($aid > 0) {
+                    if (!isset($realRanksByAwardId[$aid])) {
+                        $realRanksByAwardId[$aid] = [];
+                    }
+                    if ($rank > 0) {
+                        $realRanksByAwardId[$aid][] = $rank;
+                    }
+                }
+            }
+        }
+
+        // Keep only ladder awards — non-ladder (Custom Award etc.) are not reconcilable
+        $historicalAwards = array_values(array_filter($historicalAwards, function ($a) {
+            return (int)($a['IsLadder'] ?? 0) === 1;
+        }));
+
+        // Sort: AwardId ASC, date ASC (missing last)
+        usort($historicalAwards, function ($a, $b) {
+            if ((int)$a['AwardId'] !== (int)$b['AwardId']) {
+                return (int)$a['AwardId'] - (int)$b['AwardId'];
+            }
+            $da = ($ts = strtotime($a['Date'] ?? '')) > 0 ? $ts : PHP_INT_MAX;
+            $db = ($ts = strtotime($b['Date'] ?? '')) > 0 ? $ts : PHP_INT_MAX;
+
+            return $da - $db;
+        });
+
+        $rankSuggestions = [];
+        $groupState = [];
+        foreach ($historicalAwards as $a) {
+            $aid = (int)$a['AwardId'];
+            $awardsId = (int)$a['AwardsId'];
+            $isLadder = (int)($a['IsLadder'] ?? 0);
+            if (!$isLadder) {
+                $rankSuggestions[$awardsId] = 0;
+                continue;
+            }
+            if (!isset($groupState[$aid])) {
+                $real = [];
+                foreach ($realRanksByAwardId[$aid] ?? [] as $r) {
+                    if ($r > 0) {
+                        $real[$r] = true;
+                    }
+                }
+                $groupState[$aid] = ['realRanks' => $real, 'usedRanks' => []];
+            }
+            $existing = (int)($a['Rank'] ?? 0);
+            if ($existing > 0
+                && !isset($groupState[$aid]['realRanks'][$existing])
+                && !isset($groupState[$aid]['usedRanks'][$existing])
+            ) {
+                $rankSuggestions[$awardsId] = $existing;
+                $groupState[$aid]['usedRanks'][$existing] = true;
+            } else {
+                $c = 1;
+                while (isset($groupState[$aid]['realRanks'][$c]) || isset($groupState[$aid]['usedRanks'][$c])) {
+                    $c++;
+                }
+                $rankSuggestions[$awardsId] = $c;
+                $groupState[$aid]['usedRanks'][$c] = true;
+            }
+        }
+
+        $awardTypeCount = count(array_unique(array_column($historicalAwards, 'AwardId')));
+        $totalCount = count($historicalAwards);
+
+        return [
+            'HistoricalAwards' => $historicalAwards,
+            'RankSuggestions' => $rankSuggestions,
+            'RealRanksByAwardId' => $realRanksByAwardId,
+            'Summary' => [
+                'AwardTypeCount' => $awardTypeCount,
+                'TotalCount' => $totalCount,
+            ],
+            'HasHistoricalLadder' => $totalCount > 0,
+        ];
+    }
+
+    /**
+     * Reconcile page DTO: suggestions + kingdom award map.
+     *
+     * @param array{
+     *   MundaneId?: int,
+     *   KingdomId?: int,
+     *   Awards?: ?list
+     * } $request
+     * @return array{Status: int, Error?: string, Detail: array<string, mixed>}
+     */
+    public function GetReconcilePageData(array $request)
+    {
+        $mundaneId = (int)($request['MundaneId'] ?? 0);
+        $kingdomId = (int)($request['KingdomId'] ?? 0);
+        $awards = $request['Awards'] ?? null;
+        if (!is_array($awards)) {
+            if (!valid_id($mundaneId)) {
+                return InvalidParameter();
+            }
+            $awardsResponse = $this->AwardsForPlayer(['MundaneId' => $mundaneId]);
+            $awards = is_array($awardsResponse['Awards'] ?? null) ? $awardsResponse['Awards'] : [];
+        }
+
+        $suggestions = $this->GetReconcileSuggestions($awards);
+        $suggestions['AwardIdToKingdomAwardId'] = $this->GetReconcileAwardMap($kingdomId);
+
+        return Success($suggestions);
+    }
+
     public function CheckUsernameAvailable($username, $excludeMundaneId = 0)
     {
         $username = trim((string) $username);

--- a/system/lib/system/class.Controller.php
+++ b/system/lib/system/class.Controller.php
@@ -51,7 +51,8 @@ class Controller
         if (!$_skipTokenCheck && isset($this->session->user_id) && isset($this->session->token)) {
             $_uid_check = (int)$this->session->user_id;
             $_tok_check = $this->session->token;
-            if (!Ork3::$Lib->sessiontoken->ValidateSessionToken($_uid_check, $_tok_check)) {
+            $this->load_model('SessionToken');
+            if (!$this->SessionToken->validate_session_token($_uid_check, $_tok_check)) {
                 $_returnRoute = trim($_GET['Route'] ?? '');
                 unset($_SESSION['is_authorized_mundane_id']);
                 session_unset();
@@ -72,7 +73,8 @@ class Controller
         $this->data['ShowWhatsNew']        = false;
         $this->data['WhatsNewRelease']     = null;
         if ($_uid > 0) {
-            $prefs = Ork3::$Lib->player->GetViewerPreferences($_uid);
+            $this->load_model('Player');
+            $prefs = $this->Player->get_viewer_preferences($_uid);
             $this->data['ViewerBasicFonts']    = (int) ($prefs['BasicFonts'] ?? 0);
             $this->data['ViewerDyslexiaFonts'] = (int) ($prefs['DyslexiaFonts'] ?? 0);
 
@@ -84,7 +86,7 @@ class Controller
                 }
             }
             if ($this->data['WhatsNewRelease'] !== null) {
-                $this->data['ShowWhatsNew'] = !Ork3::$Lib->player->GetWhatsNewSeen($_uid, WHATS_NEW_VERSION);
+                $this->data['ShowWhatsNew'] = !$this->Player->get_whats_new_seen($_uid, WHATS_NEW_VERSION);
             }
         }
 
@@ -114,8 +116,7 @@ class Controller
         }
         // HasAuthority uses the auth ORM which shares the global DB connection.
         // Clear after all auth checks so subclass methods start with a clean DB state.
-        global $DB;
-        $DB->Clear();
+        $this->Authorization->clear_db_after_auth_checks();
     }
 
     public function load_model($name)
@@ -143,7 +144,8 @@ class Controller
         // Fall back to the session-cached value only when not logged in.
         if ($this->data['LoggedIn'] && isset($this->session->user_id)) {
             $uid = (int) $this->session->user_id;
-            $home = Ork3::$Lib->player->GetHomeKingdom($uid);
+            $this->load_model('Player');
+            $home = $this->Player->get_home_kingdom($uid);
             $this->data['UserKingdomId']       = (int) ($home['KingdomId'] ?? 0);
             $this->data['UserParentKingdomId'] = (int) ($home['ParentKingdomId'] ?? 0);
         } else {

--- a/tests/Integration/AttendanceSignInTest.php
+++ b/tests/Integration/AttendanceSignInTest.php
@@ -168,6 +168,36 @@ final class AttendanceSignInTest extends TestCase
         $this->assertSame(3.0, $domainCredits);
     }
 
+    public function testGetHighestClassLevelMatchesProgressAndClasses(): void
+    {
+        $parkId = $this->fixture->firstParkId();
+        $kingdomId = $this->fixture->kingdomIdForPark($parkId);
+        $player = $this->fixture->createPlayer($parkId, 'high-lvl');
+        $classId = $this->fixture->firstClassId();
+
+        // 12 credits attendance + 0 reconciled → level 3 for that class
+        $this->fixture->insertParkAttendance($parkId, $kingdomId, $player['mundane_id'], '2096-01-05', $classId, 5.0);
+        $this->fixture->insertParkAttendance($parkId, $kingdomId, $player['mundane_id'], '2096-01-12', $classId, 5.0);
+        $this->fixture->insertParkAttendance($parkId, $kingdomId, $player['mundane_id'], '2096-01-19', $classId, 2.0);
+
+        $playerDomain = new Player();
+        $progress = $playerDomain->ComputeClassProgress(['MundaneId' => $player['mundane_id']]);
+        $this->assertSame(0, $progress['Status']);
+
+        $maxFromProgress = 0;
+        foreach ($progress['Detail'] ?? [] as $row) {
+            $maxFromProgress = max($maxFromProgress, (int) ($row['Level'] ?? 0));
+        }
+
+        $classes = $playerDomain->GetPlayerClasses(['MundaneId' => $player['mundane_id']]);
+        $fromClasses = Player::HighestClassLevelFromClasses($classes['Classes'] ?? []);
+        $fromApi = $playerDomain->GetHighestClassLevel($player['mundane_id']);
+
+        $this->assertSame(3, $maxFromProgress);
+        $this->assertSame($maxFromProgress, $fromClasses);
+        $this->assertSame($maxFromProgress, $fromApi);
+    }
+
     public function testValidateLinkTokenForQr(): void
     {
         $parkId = $this->fixture->firstParkId();

--- a/tests/Unit/AwardCatalogueMapsTest.php
+++ b/tests/Unit/AwardCatalogueMapsTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Characterization for P3-R2 Award catalogue maps (single source of truth).
+ */
+final class AwardCatalogueMapsTest extends TestCase
+{
+    public function testClassParagonMapMatchesFormerTemplateLiterals(): void
+    {
+        $expected = [
+            1 => 37, 2 => 38, 3 => 39, 4 => 40, 5 => 41, 6 => 241, 7 => 42, 8 => 43,
+            9 => 44, 10 => 45, 11 => 46, 12 => 47, 14 => 242, 15 => 49, 16 => 50, 17 => 51,
+        ];
+
+        $this->assertSame($expected, Award::GetClassParagonMap());
+    }
+
+    public function testKnightAwardMapMatchesFormerMilestoneBeltIds(): void
+    {
+        $expected = [
+            17 => 'Flame',
+            18 => 'Crown',
+            19 => 'Serpent',
+            20 => 'Sword',
+            245 => 'Battle',
+        ];
+
+        $this->assertSame($expected, Award::GetKnightAwardMap());
+    }
+
+    public function testMasterAwardIdsFlattenLadderMasterMapIncludingWarlord(): void
+    {
+        $ids = Award::GetMasterAwardIds();
+        $this->assertContains(1, $ids);
+        $this->assertContains(12, $ids); // Warlord — from Order of the Warrior
+        $this->assertContains(240, $ids);
+        $this->assertContains(244, $ids);
+        $this->assertSame($ids, array_values(array_unique($ids)));
+
+        $fromMap = [];
+        foreach (Award::GetLadderMasterMap() as $info) {
+            foreach ($info['MasterAwardIds'] as $mid) {
+                $fromMap[(int)$mid] = true;
+            }
+        }
+        $this->assertSame(array_map('intval', array_keys($fromMap)), $ids);
+    }
+
+    public function testParagonAwardIdsMatchClassParagonValues(): void
+    {
+        $expected = array_values(array_unique(array_map('intval', array_values(Award::GetClassParagonMap()))));
+        $this->assertSame($expected, Award::GetParagonAwardIds());
+    }
+
+    public function testLadderMasterMapIsSoleOrderToMasterSource(): void
+    {
+        $map = Award::GetLadderMasterMap();
+        $this->assertArrayHasKey(21, $map);
+        $this->assertSame([1], $map[21]['MasterAwardIds']);
+        $this->assertSame(12, $map[30]['MaxRank']);
+        $this->assertSame(10, $map[21]['MaxRank']);
+        $this->assertSame([12], $map[27]['MasterAwardIds']);
+    }
+}

--- a/tests/Unit/ClassLevelTest.php
+++ b/tests/Unit/ClassLevelTest.php
@@ -47,4 +47,9 @@ final class ClassLevelTest extends TestCase
         $this->assertNull(ClassLevel::computeClassLevel(53.0)['ToNext']);
         $this->assertNull(ClassLevel::computeClassLevel(100.0)['ToNext']);
     }
+
+    public function testThresholdsConstantIsCanonicalLadder(): void
+    {
+        $this->assertSame([5, 12, 21, 34, 53], ClassLevel::THRESHOLDS);
+    }
 }

--- a/tests/Unit/PlayerHighestClassLevelTest.php
+++ b/tests/Unit/PlayerHighestClassLevelTest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Characterization for P3-R1 highest-class-level helpers.
+ */
+final class PlayerHighestClassLevelTest extends TestCase
+{
+    public function testHighestClassLevelFromClassesMatchesFormerControllerLoop(): void
+    {
+        $classes = [
+            ['Credits' => 4, 'Reconciled' => 0],
+            ['Credits' => 10, 'Reconciled' => 2],
+            ['Credits' => 20, 'Reconciled' => 1],
+            ['Credits' => 0, 'Reconciled' => 53],
+        ];
+
+        $this->assertSame(6, Player::HighestClassLevelFromClasses($classes));
+    }
+
+    public function testHighestClassLevelFromClassesEmptyIsZero(): void
+    {
+        $this->assertSame(0, Player::HighestClassLevelFromClasses([]));
+    }
+
+    public function testHighestClassLevelFromClassesLevelBoundaries(): void
+    {
+        $cases = [
+            0.0 => 1,
+            4.9 => 1,
+            5.0 => 2,
+            11.9 => 2,
+            12.0 => 3,
+            20.9 => 3,
+            21.0 => 4,
+            33.9 => 4,
+            34.0 => 5,
+            52.9 => 5,
+            53.0 => 6,
+        ];
+
+        foreach ($cases as $credits => $expectedLevel) {
+            $this->assertSame(
+                $expectedLevel,
+                Player::HighestClassLevelFromClasses([
+                    ['Credits' => $credits, 'Reconciled' => 0],
+                ]),
+                'Credits ' . $credits . ' should yield highest level ' . $expectedLevel,
+            );
+        }
+    }
+
+    public function testHighestClassLevelFromClassesAddsReconciled(): void
+    {
+        $this->assertSame(
+            3,
+            Player::HighestClassLevelFromClasses([
+                ['Credits' => 10, 'Reconciled' => 2],
+            ]),
+        );
+    }
+}

--- a/tests/Unit/PlayerLadderProgressTest.php
+++ b/tests/Unit/PlayerLadderProgressTest.php
@@ -1,0 +1,158 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Characterization for P3-R2 GetLadderProgress (Approx / Master / Walker skip).
+ */
+final class PlayerLadderProgressTest extends TestCase
+{
+    private Player $player;
+
+    protected function setUp(): void
+    {
+        $this->player = new Player();
+    }
+
+    public function testSkipsWalkerOfTheMiddle(): void
+    {
+        $response = $this->player->GetLadderProgress([
+            'MundaneId' => 0,
+            'Awards' => [
+                [
+                    'AwardId' => 31,
+                    'IsLadder' => 1,
+                    'Rank' => 5,
+                    'Name' => 'Walker of the Middle',
+                ],
+                [
+                    'AwardId' => 21,
+                    'IsLadder' => 1,
+                    'Rank' => 3,
+                    'Name' => 'Order of the Rose',
+                ],
+            ],
+        ]);
+
+        $this->assertSame(0, $response['Status']);
+        $ids = array_column($response['Detail'], 'AwardId');
+        $this->assertNotContains(31, $ids);
+        $this->assertContains(21, $ids);
+    }
+
+    public function testApproxWhenUnrankedExceedsHighestRankWithoutMaster(): void
+    {
+        $response = $this->player->GetLadderProgress([
+            'MundaneId' => 0,
+            'Awards' => [
+                ['AwardId' => 21, 'IsLadder' => 1, 'Rank' => 2, 'Name' => 'Order of the Rose'],
+                ['AwardId' => 21, 'IsLadder' => 1, 'Rank' => 0, 'Name' => 'Order of the Rose'],
+                ['AwardId' => 21, 'IsLadder' => 1, 'Rank' => 0, 'Name' => 'Order of the Rose'],
+            ],
+        ]);
+
+        $tile = $this->tileByAwardId($response['Detail'], 21);
+        $this->assertTrue($tile['Approx']);
+        $this->assertFalse($tile['HasMaster']);
+        // effective = 1 ranked + 2 unranked = 3; max(2,3)=3
+        $this->assertSame(3, $tile['Rank']);
+        $this->assertSame(10, $tile['MaxRank']);
+    }
+
+    public function testApproxSuppressedWhenMasterHeld(): void
+    {
+        $response = $this->player->GetLadderProgress([
+            'MundaneId' => 0,
+            'Awards' => [
+                ['AwardId' => 21, 'IsLadder' => 1, 'Rank' => 2, 'Name' => 'Order of the Rose'],
+                ['AwardId' => 21, 'IsLadder' => 1, 'Rank' => 0, 'Name' => 'Order of the Rose'],
+                ['AwardId' => 21, 'IsLadder' => 1, 'Rank' => 0, 'Name' => 'Order of the Rose'],
+                ['AwardId' => 1, 'IsLadder' => 0, 'Rank' => 0, 'Name' => 'Master Rose', 'IsTitle' => 1],
+            ],
+        ]);
+
+        $tile = $this->tileByAwardId($response['Detail'], 21);
+        $this->assertTrue($tile['HasMaster']);
+        $this->assertFalse($tile['Approx']);
+    }
+
+    public function testSyntheticMasterTileWhenNoLadderRows(): void
+    {
+        $response = $this->player->GetLadderProgress([
+            'MundaneId' => 0,
+            'Awards' => [
+                ['AwardId' => 1, 'IsLadder' => 0, 'Rank' => 0, 'Name' => 'Master Rose', 'IsTitle' => 1],
+            ],
+        ]);
+
+        $tile = $this->tileByAwardId($response['Detail'], 21);
+        $this->assertTrue($tile['HasMaster']);
+        $this->assertFalse($tile['Approx']);
+        $this->assertSame(10, $tile['Rank']);
+        $this->assertSame(10, $tile['MaxRank']);
+        $this->assertSame('Order of the Rose', $tile['Name']);
+        $this->assertSame('Rose', $tile['Short']);
+    }
+
+    public function testZodiacMaxRankTwelve(): void
+    {
+        $response = $this->player->GetLadderProgress([
+            'MundaneId' => 0,
+            'Awards' => [
+                ['AwardId' => 30, 'IsLadder' => 1, 'Rank' => 12, 'Name' => 'Order of the Zodiac'],
+            ],
+        ]);
+
+        $tile = $this->tileByAwardId($response['Detail'], 30);
+        $this->assertSame(12, $tile['MaxRank']);
+        $this->assertSame(12, $tile['Rank']);
+    }
+
+    public function testDuplicateRanksDoNotInflateEffectiveCount(): void
+    {
+        $response = $this->player->GetLadderProgress([
+            'MundaneId' => 0,
+            'Awards' => [
+                ['AwardId' => 22, 'IsLadder' => 1, 'Rank' => 5, 'Name' => 'Order of the Smith'],
+                ['AwardId' => 22, 'IsLadder' => 1, 'Rank' => 5, 'Name' => 'Order of the Smith'],
+                ['AwardId' => 22, 'IsLadder' => 1, 'Rank' => 4, 'Name' => 'Order of the Smith'],
+            ],
+        ]);
+
+        $tile = $this->tileByAwardId($response['Detail'], 22);
+        $this->assertFalse($tile['Approx']);
+        $this->assertSame(5, $tile['Rank']);
+    }
+
+    public function testTilesSortedByName(): void
+    {
+        $response = $this->player->GetLadderProgress([
+            'MundaneId' => 0,
+            'Awards' => [
+                ['AwardId' => 25, 'IsLadder' => 1, 'Rank' => 1, 'Name' => 'Order of the Dragon'],
+                ['AwardId' => 21, 'IsLadder' => 1, 'Rank' => 1, 'Name' => 'Order of the Rose'],
+            ],
+        ]);
+
+        $names = array_column($response['Detail'], 'Name');
+        $sorted = $names;
+        sort($sorted, SORT_STRING);
+        $this->assertSame($sorted, $names);
+    }
+
+    /**
+     * @param list<array<string, mixed>> $tiles
+     * @return array<string, mixed>
+     */
+    private function tileByAwardId(array $tiles, int $awardId): array
+    {
+        foreach ($tiles as $tile) {
+            if ((int)$tile['AwardId'] === $awardId) {
+                return $tile;
+            }
+        }
+        $this->fail('Missing ladder tile for AwardId ' . $awardId);
+    }
+}

--- a/tests/Unit/PlayerMilestonesTest.php
+++ b/tests/Unit/PlayerMilestonesTest.php
@@ -1,0 +1,179 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Characterization for P3-R2 GetPlayerMilestones (dedup / sort / catalogue use).
+ */
+final class PlayerMilestonesTest extends TestCase
+{
+    private Player $player;
+
+    protected function setUp(): void
+    {
+        $this->player = new Player();
+    }
+
+    public function testFirstSigninKnightMasterParagonChronological(): void
+    {
+        $response = $this->player->GetPlayerMilestones([
+            'MundaneId' => 0,
+            'PlayerSinceDate' => '2018-01-15',
+            'Awards' => [
+                [
+                    'AwardId' => 17,
+                    'Date' => '2020-06-01',
+                    'Name' => 'Knight of the Flame',
+                    'OfficerRole' => 'none',
+                    'IsTitle' => 0,
+                ],
+                [
+                    'AwardId' => 1,
+                    'Date' => '2019-03-01',
+                    'Name' => 'Master Rose',
+                    'OfficerRole' => 'none',
+                    'IsTitle' => 0,
+                ],
+                [
+                    'AwardId' => 37,
+                    'Date' => '2021-01-01',
+                    'Name' => 'Paragon Warrior',
+                    'OfficerRole' => 'none',
+                    'IsTitle' => 1,
+                ],
+            ],
+            'BeltlinePeers' => [],
+            'BeltlineAssociates' => [],
+            'IncludeCustom' => false,
+        ]);
+
+        $this->assertSame(0, $response['Status']);
+        $rows = $response['Detail'];
+        $this->assertCount(4, $rows);
+        $this->assertSame('first_signin', $rows[0]['type']);
+        $this->assertSame('master', $rows[1]['type']);
+        $this->assertSame('knight', $rows[2]['type']);
+        $this->assertSame('paragon', $rows[3]['type']);
+        $this->assertSame('fa-shield-alt', $rows[2]['icon']);
+    }
+
+    public function testDedupesMasterTitleAgainstMasterAward(): void
+    {
+        $response = $this->player->GetPlayerMilestones([
+            'MundaneId' => 0,
+            'PlayerSinceDate' => null,
+            'Awards' => [
+                [
+                    'AwardId' => 1,
+                    'Date' => '2019-03-01',
+                    'Name' => 'Master Rose',
+                    'OfficerRole' => 'none',
+                    'IsTitle' => 0,
+                ],
+                [
+                    'AwardId' => 99,
+                    'Date' => '2019-03-01',
+                    'Name' => 'Master Rose',
+                    'CustomAwardName' => 'Master Rose',
+                    'OfficerRole' => 'none',
+                    'IsTitle' => 1,
+                    'AliasPeerage' => '',
+                ],
+            ],
+            'BeltlinePeers' => [],
+            'BeltlineAssociates' => [],
+            'IncludeCustom' => false,
+        ]);
+
+        $types = array_column($response['Detail'], 'type');
+        $this->assertContains('master', $types);
+        $this->assertNotContains('title', $types);
+    }
+
+    public function testDedupesExactDescriptionAndDate(): void
+    {
+        $response = $this->player->GetPlayerMilestones([
+            'MundaneId' => 0,
+            'PlayerSinceDate' => null,
+            'Awards' => [
+                [
+                    'AwardId' => 17,
+                    'Date' => '2020-06-01',
+                    'Name' => 'Knight of the Flame',
+                    'OfficerRole' => 'none',
+                    'IsTitle' => 0,
+                ],
+                [
+                    'AwardId' => 17,
+                    'Date' => '2020-06-01',
+                    'Name' => 'Knight of the Flame',
+                    'OfficerRole' => 'none',
+                    'IsTitle' => 0,
+                ],
+            ],
+            'BeltlinePeers' => [],
+            'BeltlineAssociates' => [],
+            'IncludeCustom' => false,
+        ]);
+
+        $this->assertCount(1, $response['Detail']);
+        $this->assertSame('knight', $response['Detail'][0]['type']);
+    }
+
+    public function testSuppressesBeltlineAliasedTitleWhenPeerMilestoneExists(): void
+    {
+        $response = $this->player->GetPlayerMilestones([
+            'MundaneId' => 0,
+            'PlayerSinceDate' => null,
+            'Awards' => [
+                [
+                    'AwardId' => 50,
+                    'Date' => '2020-01-01',
+                    'Name' => 'Squire',
+                    'OfficerRole' => 'none',
+                    'IsTitle' => 1,
+                    'AliasPeerage' => 'Squire',
+                ],
+            ],
+            'BeltlinePeers' => [
+                [
+                    'Date' => '2020-01-01',
+                    'Peerage' => 'Squire',
+                    'Persona' => 'Sir Example',
+                ],
+            ],
+            'BeltlineAssociates' => [],
+            'IncludeCustom' => false,
+        ]);
+
+        $types = array_column($response['Detail'], 'type');
+        $this->assertContains('became_associate', $types);
+        $this->assertNotContains('title', $types);
+    }
+
+    public function testWarlordMasterAwardIsMilestone(): void
+    {
+        $response = $this->player->GetPlayerMilestones([
+            'MundaneId' => 0,
+            'PlayerSinceDate' => null,
+            'Awards' => [
+                [
+                    'AwardId' => 12,
+                    'Date' => '2022-05-05',
+                    'Name' => 'Warlord',
+                    'OfficerRole' => 'none',
+                    'IsTitle' => 0,
+                ],
+            ],
+            'BeltlinePeers' => [],
+            'BeltlineAssociates' => [],
+            'IncludeCustom' => false,
+        ]);
+
+        $this->assertCount(1, $response['Detail']);
+        $this->assertSame('master', $response['Detail'][0]['type']);
+        $this->assertStringContainsString('Warlord', $response['Detail'][0]['description']);
+    }
+}

--- a/tests/Unit/PlayerReconcileSuggestionsTest.php
+++ b/tests/Unit/PlayerReconcileSuggestionsTest.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Characterization for P3-R3 GetReconcileSuggestions smart-rank + partition.
+ */
+final class PlayerReconcileSuggestionsTest extends TestCase
+{
+    private Player $player;
+
+    protected function setUp(): void
+    {
+        $this->player = new Player();
+    }
+
+    public function testPartitionsHistoricalLadderAndCollectsRealRanks(): void
+    {
+        $dto = $this->player->GetReconcileSuggestions([
+            $this->row(101, 21, 2, true, 0, 0, '2020-01-01'), // historical ladder
+            $this->row(102, 21, 5, true, 10, 10, '2021-01-01'), // real rose 5
+            $this->row(103, 99, 0, false, 0, 0, '2020-02-01'), // historical non-ladder (dropped)
+            $this->row(104, 22, 1, true, 0, 0, '2019-06-01'), // historical sword
+            $this->row(105, 17, 0, true, 0, 0, '2018-01-01', true), // title — ignored
+        ]);
+
+        $this->assertTrue($dto['HasHistoricalLadder']);
+        $this->assertSame(2, $dto['Summary']['TotalCount']);
+        $this->assertSame(2, $dto['Summary']['AwardTypeCount']);
+        $ids = array_column($dto['HistoricalAwards'], 'AwardsId');
+        $this->assertSame([101, 104], $ids);
+        $this->assertSame([5], $dto['RealRanksByAwardId'][21]);
+        $this->assertArrayNotHasKey(99, $dto['RealRanksByAwardId']);
+    }
+
+    public function testSortsByAwardIdThenDateMissingLast(): void
+    {
+        $dto = $this->player->GetReconcileSuggestions([
+            $this->row(1, 22, 0, true, 0, 0, '2022-01-01'),
+            $this->row(2, 21, 0, true, 0, 0, ''),
+            $this->row(3, 21, 0, true, 0, 0, '2020-05-01'),
+            $this->row(4, 21, 0, true, 0, 0, '2019-01-01'),
+        ]);
+
+        $ids = array_column($dto['HistoricalAwards'], 'AwardsId');
+        $this->assertSame([4, 3, 2, 1], $ids);
+    }
+
+    public function testPreferExistingRankWhenUnused(): void
+    {
+        $dto = $this->player->GetReconcileSuggestions([
+            $this->row(10, 21, 3, true, 0, 0, '2020-01-01'), // historical with rank 3
+            $this->row(11, 21, 1, true, 5, 5, '2021-01-01'), // real holds 1
+        ]);
+
+        $this->assertSame(3, $dto['RankSuggestions'][10]);
+    }
+
+    public function testSkipsExistingRankWhenHeldByReal(): void
+    {
+        $dto = $this->player->GetReconcileSuggestions([
+            $this->row(10, 21, 3, true, 0, 0, '2020-01-01'),
+            $this->row(11, 21, 3, true, 5, 5, '2021-01-01'), // real already has 3
+        ]);
+
+        // existing 3 taken by real → smallest free = 1
+        $this->assertSame(1, $dto['RankSuggestions'][10]);
+    }
+
+    public function testAllocatesSmallestFreeAcrossHistoricalGroup(): void
+    {
+        $dto = $this->player->GetReconcileSuggestions([
+            $this->row(1, 21, 0, true, 0, 0, '2018-01-01'),
+            $this->row(2, 21, 0, true, 0, 0, '2019-01-01'),
+            $this->row(3, 21, 2, true, 0, 0, '2020-01-01'), // would prefer 2, but 2 already taken
+            $this->row(4, 21, 5, true, 9, 9, '2021-01-01'), // real holds 5
+        ]);
+
+        // Chronological: 1→1, 2→2, 3 (existing 2 used)→3
+        $this->assertSame(1, $dto['RankSuggestions'][1]);
+        $this->assertSame(2, $dto['RankSuggestions'][2]);
+        $this->assertSame(3, $dto['RankSuggestions'][3]);
+    }
+
+    public function testMixedAwardGroupsIndependent(): void
+    {
+        $dto = $this->player->GetReconcileSuggestions([
+            $this->row(1, 21, 0, true, 0, 0, '2020-01-01'),
+            $this->row(2, 22, 0, true, 0, 0, '2020-01-01'),
+            $this->row(3, 21, 1, true, 8, 8, '2021-01-01'), // real rose 1
+        ]);
+
+        $this->assertSame(2, $dto['RankSuggestions'][1]); // 1 taken by real
+        $this->assertSame(1, $dto['RankSuggestions'][2]); // sword group free at 1
+    }
+
+    public function testEmptyAwardsHasNoHistorical(): void
+    {
+        $dto = $this->player->GetReconcileSuggestions([]);
+        $this->assertFalse($dto['HasHistoricalLadder']);
+        $this->assertSame(0, $dto['Summary']['TotalCount']);
+        $this->assertSame([], $dto['HistoricalAwards']);
+        $this->assertSame([], $dto['RankSuggestions']);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function row(
+        int $awardsId,
+        int $awardId,
+        int $rank,
+        bool $isLadder,
+        int $givenById,
+        int $enteredById,
+        string $date,
+        bool $isTitle = false
+    ): array {
+        return [
+            'AwardsId' => $awardsId,
+            'AwardId' => $awardId,
+            'Rank' => $rank,
+            'IsLadder' => $isLadder ? 1 : 0,
+            'GivenById' => $givenById,
+            'EnteredById' => $enteredById,
+            'Date' => $date,
+            'OfficerRole' => 'none',
+            'IsTitle' => $isTitle ? 1 : 0,
+            'Name' => 'Award ' . $awardId,
+        ];
+    }
+}


### PR DESCRIPTION
## Summary
Stacked on [#492](https://github.com/amtgard/ORK3/pull/492) (`megiddo/fuzzy-validator-v2`). Merge **#492 first**, then this PR (or retarget base to `master` after #492 lands).

- **Bootstrap / audit model hop:** Route `class.Controller` session/prefs/What’s New/home kingdom and `$DB` clear through models; replace controller `(new Dangeraudit())->audit` with `Authorization->audit`; `index.php` Health/Event via `Model_Health` / `Model_Event`. Extends static gates so Lib / inline Dangeraudit cannot creep back into the frontend hot path.
- **Player aggregates (P3-R0…R4):** First-class domain/model APIs for highest class level, milestones, award/ladder maps & progress, and reconcile smart-rank; thin `Controller_Player` and revised Player templates. Plan under `docs/megiddo/refactor/player-aggregates/`.

## Test plan
- [ ] PHPUnit green (Player / ClassLevel / reconcile coverage as applicable)
- [ ] `rg '\$DB->|Ork3::\$Lib' orkui/` and `rg 'Ork3::\$Lib' system/lib/system/class.Controller.php` clean
- [ ] `rg '\(new Dangeraudit\(\)\)' orkui/controller/` clean
- [ ] Fuzzy `player-profile` test + mirror (or re-check locally)
- [ ] Smoke Player profile + reconcile UI after merge

## Notes
- orkservice JSON registration for aggregates left optional / not required for UI thinness.
- Human Phase 3 close-out (P3-4 / P3-5 / P3-6) still open after this stack.


Made with [Cursor](https://cursor.com)