### PR TITLE
Bugfix: Update php-cs-fixer references and fix explicit path bug

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -7,6 +7,9 @@
 #   2. Auto-formats the PHP files you are committing to PSR-12 via tools/php-cs-fixer/php-cs-fixer.phar,
 #      then re-stages them. Only files that are FULLY staged are touched — a file with both
 #      staged and unstaged changes is skipped, so unstaged hunks are never swept into the commit.
+#      --path-mode=intersection makes the fixer honor the excludes in .php-cs-fixer.dist.php
+#      (vendor, tools, import, db-migrations, ...); without it, explicitly-passed paths bypass
+#      the config Finder and third-party code staged with `git add -f` gets reformatted.
 #
 # It never blocks a commit because of the formatter (missing php / fixer errors only warn).
 
@@ -72,7 +75,7 @@ TO_FIX=$(printf '%s' "$TO_FIX" | sed '/^$/d')
 
 # Run the fixer on just those files. setUnsupportedPhpVersionAllowed handles newer PHP.
 echo "$TO_FIX" | tr '\n' '\0' | \
-    xargs -0 "$PHP_BIN" "$PHAR" fix --config="$CONFIG" --quiet --using-cache=yes
+    xargs -0 "$PHP_BIN" "$PHAR" fix --config="$CONFIG" --path-mode=intersection --quiet --using-cache=yes
 FIX_STATUS=$?
 
 if [ "$FIX_STATUS" -ne 0 ]; then
@@ -81,5 +84,7 @@ if [ "$FIX_STATUS" -ne 0 ]; then
 fi
 
 # Re-stage anything the fixer rewrote (no-op for unchanged files).
-echo "$TO_FIX" | tr '\n' '\0' | xargs -0 git add --
+# -f because every path here was already staged by the user; without it, a
+# gitignored-but-force-added file (e.g. vendor/) makes git print "paths are ignored" noise.
+echo "$TO_FIX" | tr '\n' '\0' | xargs -0 git add -f --
 exit 0


### PR DESCRIPTION
## Problem

`.githooks/pre-commit` passes the staged file paths to php-cs-fixer explicitly. php-cs-fixer defaults to `--path-mode=override`, in which **explicit path arguments replace the config Finder entirely** — so every exclude declared in `.php-cs-fixer.dist.php` was silently ignored by the hook:

`vendor`, `tools`, `node_modules`, `cache`, `assets`, `import`, `db-migrations`, `system/lib/phpqrcode`

The practical effect: a third-party file staged with `git add -f` — e.g. a vendored library under `vendor/` — was reformatted to PSR-12 and committed that way, despite the config explicitly excluding it. Reproduced on current `master`:

```
$ printf '<?php\nclass VendorThing {\n\tpublic function v(){ return 1; }\n}\n' > vendor/fake/thing.php
$ git add -f vendor/fake/thing.php && git commit -m "test"
$ git show HEAD:vendor/fake/thing.php
<?php

class VendorThing
{
    public function v()
    {
        return 1;
    }
}
```

Tabs and brace style rewritten — in a directory the config excludes.

## Fix

**`--path-mode=intersection`** on the fixer invocation. Excluded files are then skipped (exit 0, no error), and non-excluded files still format normally.

**`git add -f --`** on the re-stage. Every path in that list was already staged by the user, so `-f` changes nothing about *which* files get committed; it only suppresses git's `the following paths are ignored by one of your .gitignore files` hint that otherwise prints mid-commit when a gitignored-but-force-added file is in the batch.

## Verification

End-to-end against a scratch clone with the patched hook installed — 11 cases, all passing:

| # | Case | Result |
|---|------|--------|
| A | Fully-staged PHP file | formatted, and the **formatted** version is what lands in the commit |
| B | Partially-staged file | skipped; unstaged hunks never swept in |
| C | `class.Authorization.php` staged | auto-unstaged, excluded from commit |
| D | `vendor/` file force-added | **exclusion honored** (was the bug) |
| E | `tools/` file staged | **exclusion honored** (was the bug) |
| F | Batch of only-excluded files | exit 0, commit not blocked |
| F2 | Same batch | no `paths are ignored` hint noise |
| G1 | Mixed batch — normal file | formatted |
| G2 | Mixed batch — vendored file | untouched |
| H | No `php` on PATH | warns, commit proceeds |
| I | Phar missing | warns, commit proceeds |

Cases A–C and F–I confirm the existing behavior is unchanged by this patch; D, E and F2 are the fix.

## Notes

- Hook-only change — no application code touched, no PHP files reformatted by this PR.
- The phar path references (`tools/php-cs-fixer/php-cs-fixer.phar`) were already correct across `.php-cs-fixer.dist.php`, `bin/setup-dev-hooks.sh`, `tools/README.md` and `tools/php-cs-fixer/README.md` after the recent reorganization; this PR adds a header comment in the hook documenting *why* the path-mode flag is required, so the flag doesn't get dropped as redundant later.
- Worth flagging separately: there is no CI check for PSR-12, and `core.hooksPath` is per-clone local config — so this hook is the only enforcement point, and a fresh clone that skips `npm install` / `bin/setup-dev-hooks.sh` commits unformatted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JaHaMaTU5v17Lzu7inruTx