### PR TITLE
Bugfix: Discord reports — ICS feed reachability, recap masterhoods, description autolinking, map popover

### DIFF
--- a/nginx.ork3.config
+++ b/nginx.ork3.config
@@ -36,6 +36,16 @@ server {
     real_ip_header CF-Connecting-IP;
     real_ip_recursive on;
 
+    # Calendar (ICS) subscription feeds on a clean, stable path.
+    # Deliberately kept off the ?Route= front controller so the CDN/WAF can
+    # exempt automated calendar fetchers (Google Calendar, Apple Calendar,
+    # Outlook) from the browser challenge with a simple URI-path match.
+    # Those clients cannot execute JS, so a challenge silently empties the feed.
+    location ^~ /ics/ {
+        rewrite ^/ics/kingdom/([0-9]+)\.ics$ /orkui/index.php?Route=Kingdom/ics/$1 last;
+        return 404;
+    }
+
     location / {
 	try_files $uri $uri/ =404;
     }

--- a/orkui/controller/controller.Kingdom.php
+++ b/orkui/controller/controller.Kingdom.php
@@ -475,10 +475,26 @@ class Controller_Kingdom extends Controller
 
         $this->data['PronounList']          = $this->Pronoun->fetch_pronoun_list();
         $this->data['PronounOptionsCreate'] = $this->Pronoun->fetch_pronoun_option_list(null);
-        $this->data['IcsUrl'] = UIR . 'Kingdom/ics/' . $kingdom_id;
+        $this->data['IcsUrl'] = self::ics_feed_url((int)$kingdom_id);
     }
 
     // ------------------------------------------------------------------ ICS Feed
+
+    /**
+     * Canonical public URL for a kingdom's calendar subscription feed.
+     *
+     * Served from a clean path (/ics/kingdom/{id}.ics) rather than the ?Route=
+     * front controller so the CDN/WAF can exempt automated calendar fetchers
+     * from the browser challenge with a simple URI-path match. Requires the
+     * matching rewrite in nginx.ork3.config; the ?Route= form still works for
+     * anyone already subscribed to it.
+     */
+    private static function ics_feed_url(int $kingdom_id): string
+    {
+        // HTTP_UI_REMOTE ends in 'orkui/'; the feed is served from the site root.
+        return preg_replace('#orkui/$#', '', HTTP_UI_REMOTE) . 'ics/kingdom/' . $kingdom_id . '.ics';
+    }
+
     public function ics($kingdom_id = null)
     {
         $kingdom_id = preg_replace('/[^0-9]/', '', $kingdom_id);
@@ -491,7 +507,8 @@ class Controller_Kingdom extends Controller
         $icsBody = $this->KingdomProfile->export_ics($kid, $knName);
         $safeName = preg_replace('/[^a-z0-9]/i', '-', $knName);
         header('Content-Type: text/calendar; charset=utf-8');
-        header('Content-Disposition: attachment; filename="' . $safeName . '-events.ics"');
+        // inline, not attachment: this URL is subscribed to, not downloaded.
+        header('Content-Disposition: inline; filename="' . $safeName . '-events.ics"');
         header('Cache-Control: no-cache, must-revalidate');
         echo $icsBody;
         exit();

--- a/orkui/template/revised-frontend/Eventnew_index.tpl
+++ b/orkui/template/revised-frontend/Eventnew_index.tpl
@@ -1,8 +1,64 @@
 <?php
 	require_once(DIR_LIB . 'Parsedown.php');
+
+	// Author-supplied links point off-site; losing the event page mid-read is
+	// disorienting, so every generated anchor opens in a new tab. rel guards
+	// against tabnabbing via window.opener.
+	function ev_link_new_tab(string $html): string {
+		return preg_replace('/<a\s+href=/i', '<a target="_blank" rel="noopener noreferrer" href=', $html);
+	}
+
 	function ev_markdown(string $text): string {
 		$html = (new Parsedown())->setSafeMode(true)->setBreaksEnabled(true)->text($text);
-		return preg_replace('/<img[^>]*>/i', '', $html);
+		return ev_link_new_tab(preg_replace('/<img[^>]*>/i', '', $html));
+	}
+
+	// Escape plain text and turn bare http/https URLs into new-tab links.
+	// For description fields that are NOT markdown (schedule items), so that a
+	// pasted URL is clickable instead of a wall of unusable text.
+	//
+	// Splitting on the URL first — rather than escaping up front — keeps '&' in
+	// query strings intact; escaping first would leave '&amp;' inside the match
+	// and corrupt the href. Only http/https ever matches, so 'javascript:' and
+	// friends can never become an anchor.
+	function ev_autolink(string $text): string {
+		$parts = preg_split('~(https?://[^\s<>"\'`]+)~i', (string)$text, -1, PREG_SPLIT_DELIM_CAPTURE);
+		if ($parts === false) {
+			return htmlspecialchars((string)$text);
+		}
+		$out = '';
+		foreach ($parts as $i => $part) {
+			if ($i % 2 === 0) {
+				$out .= htmlspecialchars($part);
+				continue;
+			}
+			// Trailing punctuation almost always belongs to the sentence, not the
+			// URL — "(https://example.com/x)" should not link the closing paren.
+			$tail = '';
+			while ($part !== '') {
+				$last = substr($part, -1);
+				if (strpos('.,;:!?', $last) !== false) {
+					$tail = $last . $tail;
+					$part = substr($part, 0, -1);
+					continue;
+				}
+				// Keep balanced parens (Wikipedia-style URLs); drop an unmatched closer.
+				if ($last === ')' && substr_count($part, ')') > substr_count($part, '(')) {
+					$tail = $last . $tail;
+					$part = substr($part, 0, -1);
+					continue;
+				}
+				break;
+			}
+			if ($part === '') {
+				$out .= htmlspecialchars($tail);
+				continue;
+			}
+			$out .= '<a href="' . htmlspecialchars($part, ENT_QUOTES)
+				. '" target="_blank" rel="noopener noreferrer">'
+				. htmlspecialchars($part) . '</a>' . htmlspecialchars($tail);
+		}
+		return $out;
 	}
 
 	// ---- Normalize data ----
@@ -1272,7 +1328,7 @@ html[data-theme="dark"] .ev-ds-action-btn:hover{background:rgba(72,187,120,.2)}
 							<td style="white-space:nowrap"><i class="fas fa-fw <?= $evCatCfg['icon'] ?>" style="color:<?= $evCatCfg['color'] ?>" data-tip="<?= htmlspecialchars($evCat) ?>"></i><?php if ($evSecCatCfg): ?><i class="fas fa-fw <?= $evSecCatCfg['icon'] ?>" style="color:<?= $evSecCatCfg['color'] ?>;margin-right:4px" data-tip="<?= htmlspecialchars($evSecCat) ?>"></i><?php else: ?><span style="display:inline-block;width:1.25em;margin-right:4px"></span><?php endif; ?><?= htmlspecialchars($item['Title']) ?><?php if (($evCat === 'Feast and Food' || $evSecCat === 'Feast and Food') && !empty($item['Menu'])): ?> <i class="fas fa-scroll" style="color:#e65100;font-size:10px;margin-left:4px;vertical-align:middle" data-tip="Has menu"></i><?php endif; ?></td>
 							<td><?= htmlspecialchars($item['Location']) ?></td>
 							<td><?php foreach ($item['Leads'] ?? [] as $li => $lead) { if ($li > 0) echo ', '; echo '<a href="' . UIR . 'Playernew/index/' . (int)$lead['MundaneId'] . '">' . htmlspecialchars($lead['Persona']) . '</a>'; } ?></td>
-							<td><?= htmlspecialchars($item['Description']) ?></td>
+							<td class="ev-sched-desc"><?= ev_autolink($item['Description']) ?></td>
 							<?php if ($canManageSchedule): ?>
 							<td class="ev-del-cell">
 								<button class="ev-edit-link" data-tip="Edit" onclick="evOpenScheduleEditModal(<?= (int)$item['EventScheduleId'] ?>, this)" style="background:none;border:none;cursor:pointer;color:#666;font-size:13px;padding:0 5px 0 0">
@@ -4053,6 +4109,13 @@ html[data-theme="dark"] .ev-grid-day-pill.ev-grid-day-pill-active {
 .ev-grid-popover .ev-gp-row { margin-top:4px; color:#4a5568; font-size:11px; }
 .ev-grid-popover .ev-gp-row i { width:12px; color:#a0aec0; margin-right:4px; }
 
+/* Auto-linked URLs in description fields. --ork-link is defined for both themes,
+   so this needs no separate html[data-theme="dark"] rule. Pasted URLs run long,
+   so allow them to break rather than forcing the table or popover to scroll. */
+.ev-sched-desc, .ev-grid-popover .ev-gp-desc { overflow-wrap:anywhere; }
+.ev-sched-desc a, .ev-grid-popover .ev-gp-desc a { color:var(--ork-link); text-decoration:underline; }
+.ev-sched-desc a:hover, .ev-grid-popover .ev-gp-desc a:hover { text-decoration:none; }
+
 @media (max-width: 700px) {
 	#ev-schedule-grid-container { display:none !important; }
 	#ev-schedule-container      { display:block !important; }
@@ -4403,10 +4466,30 @@ html[data-theme="dark"] .ev-grid-day-pill.ev-grid-day-pill-active {
 		var pop = document.createElement('div');
 		pop.className = 'ev-grid-popover';
 		var safe = function(s) { var d = document.createElement('div'); d.textContent = s; return d.innerHTML; };
+		// Mirror of ev_autolink() in PHP: escape the text, but turn bare http/https
+		// URLs into new-tab links. Matching on the raw string before escaping keeps
+		// '&' in query strings from being split across an '&amp;' entity.
+		var linkify = function(s) {
+			var out = '', re = /https?:\/\/[^\s<>"']+/gi, m, last = 0;
+			while ((m = re.exec(s)) !== null) {
+				var url = m[0], tail = '';
+				while (url) {
+					var ch = url.charAt(url.length - 1);
+					if ('.,;:!?'.indexOf(ch) !== -1) { tail = ch + tail; url = url.slice(0, -1); continue; }
+					if (ch === ')' && (url.split(')').length > url.split('(').length)) { tail = ch + tail; url = url.slice(0, -1); continue; }
+					break;
+				}
+				out += safe(s.slice(last, m.index));
+				if (url) { out += '<a href="' + safe(url).replace(/"/g, '&quot;') + '" target="_blank" rel="noopener noreferrer">' + safe(url) + '</a>'; }
+				out += safe(tail);
+				last = m.index + m[0].length;
+			}
+			return out + safe(s.slice(last));
+		};
 		var html = '<h5>' + safe(title) + '</h5>';
 		if (timeStr) html += '<div class="ev-gp-row"><i class="fas fa-clock"></i>' + safe(timeStr) + '</div>';
 		if (loc)     html += '<div class="ev-gp-row"><i class="fas fa-map-marker-alt"></i>' + safe(loc) + '</div>';
-		if (desc)    html += '<div class="ev-gp-row" style="margin-top:8px;line-height:1.4">' + safe(desc) + '</div>';
+		if (desc)    html += '<div class="ev-gp-row ev-gp-desc" style="margin-top:8px;line-height:1.4">' + linkify(desc) + '</div>';
 		pop.innerHTML = html;
 		document.body.appendChild(pop);
 

--- a/orkui/template/revised-frontend/script/revised.js
+++ b/orkui/template/revised-frontend/script/revised.js
@@ -2549,6 +2549,12 @@ window.knInitMap = async function() {
     }
 
     var infowindow = new google.maps.InfoWindow();
+    // Local escaper, matching the knCiEsc/pkCiEsc convention elsewhere in this file —
+    // park names are user-entered and land in InfoWindow HTML.
+    function knMapEsc(s) {
+        return String(s == null ? '' : s)
+            .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+    }
     for (var i = 0; i < knMapLocations.length; i++) {
         (function(loc) {
             var pinBg = loc.prinz ? '#2C5F8B' : '#8B1A1A';
@@ -2561,8 +2567,16 @@ window.knInitMap = async function() {
             });
             google.maps.event.addListener(marker, 'click', function() {
                 var locLine = [loc.city, loc.province].filter(Boolean).join(', ');
-                var tipHtml = '<b><a href="' + KnConfig.uir + 'Park/profile/' + loc.id + '" style="color:#2b6cb0">' + loc.name + '</a></b>'
-                    + (locLine ? '<div style="font-size:12px;color:#718096;margin-top:3px"><i class="fas fa-map-marker-alt" style="font-size:10px;margin-right:3px"></i>' + locLine + '</div>' : '');
+                // Styling lives in .kn-map-popover (revised.css) rather than inline, so the
+                // popover picks up dark mode and stays readable on the dark InfoWindow chrome.
+                var tipHtml = '<div class="kn-map-popover' + (loc.prinz ? ' kn-map-popover-prinz' : '') + '">'
+                    + '<a class="kn-map-popover-name" href="' + KnConfig.uir + 'Park/profile/' + loc.id + '">'
+                    + knMapEsc(loc.name) + '</a>'
+                    + (locLine
+                        ? '<div class="kn-map-popover-meta"><i class="fas fa-map-marker-alt"></i><span>'
+                          + knMapEsc(locLine) + '</span></div>'
+                        : '')
+                    + '</div>';
                 infowindow.setContent(tipHtml);
                 infowindow.open(map, marker);
                 knRenderMapSidebar(loc);

--- a/orkui/template/revised-frontend/style/revised.css
+++ b/orkui/template/revised-frontend/style/revised.css
@@ -10016,6 +10016,64 @@ html[data-theme="dark"] .ev-rsvp-counts               { color: var(--ork-text-mu
 html[data-theme="dark"] .ev-rsvp-count-going          { color: #68d391; }
 html[data-theme="dark"] .ev-rsvp-count-interest       { color: #f6ad55; }
 
+/* ============================================================
+ * Kingdom map — park pin popover
+ * ------------------------------------------------------------
+ * Shares the visual language of .ev-map-popover above (same type scale,
+ * same muted meta row, same dark-mode token sources) so the two maps
+ * read as one component. Kept as its own block rather than folded into
+ * the .ev-* selectors because the content differs: a park pin shows name
+ * + location only — the detail lives in the sidebar beside the map, so
+ * this popover stays an identifier, not a card.
+ * ============================================================ */
+.kn-map-popover {
+	font-family: inherit;
+	font-size: 12px;
+	line-height: 1.45;
+	min-width: 196px;
+	max-width: 264px;
+	padding: 12px 16px;
+	color: #2d3748;
+}
+.kn-map-popover-name {
+	display: block;
+	font-size: 15px;
+	font-weight: 700;
+	color: #2c5282;
+	text-decoration: none;
+	letter-spacing: -0.01em;
+	line-height: 1.25;
+	overflow-wrap: anywhere;
+	padding-right: 20px;   /* clear Google's close X */
+}
+.kn-map-popover-name:hover,
+.kn-map-popover-name:focus-visible { color: #2b6cb0; text-decoration: underline; }
+.kn-map-popover-meta {
+	display: flex;
+	align-items: baseline;
+	gap: 5px;
+	color: #718096;
+	font-size: 11.5px;
+	margin-top: 5px;
+}
+/* The pin glyph carries the colour of the marker that was just clicked —
+   crimson for a kingdom park, blue for a principality one — matching the
+   PinElement backgrounds in revised.js and the map legend. */
+.kn-map-popover-meta i { font-size: 10px; position: relative; top: 1px; color: #8B1A1A; }
+.kn-map-popover-prinz .kn-map-popover-meta i { color: #2C5F8B; }
+
+/* Google reserves header height for the close button; our content supplies its
+   own top padding, so reclaim it. Scoped via :has() so the event map popover
+   above keeps its current spacing. Degrades to the old gap if :has() is absent. */
+.gm-style .gm-style-iw-c:has(.kn-map-popover) .gm-style-iw-ch { padding-top: 0 !important; }
+
+html[data-theme="dark"] .kn-map-popover            { color: var(--ork-text, #e2e8f0); }
+html[data-theme="dark"] .kn-map-popover-name       { color: #90cdf4; }
+html[data-theme="dark"] .kn-map-popover-name:hover { color: #bee3f8; }
+html[data-theme="dark"] .kn-map-popover-meta       { color: var(--ork-text-muted, #a0aec0); }
+html[data-theme="dark"] .kn-map-popover-meta i     { color: #e06c6c; }
+html[data-theme="dark"] .kn-map-popover-prinz .kn-map-popover-meta i { color: #63a4dd; }
+
 /* ── Dark mode: Google Maps InfoWindow chrome ────────────────── */
 html[data-theme="dark"] .gm-style .gm-style-iw-c {
 	background: var(--ork-bg-secondary, #1a202c) !important;

--- a/system/lib/ork3/class.Report.php
+++ b/system/lib/ork3/class.Report.php
@@ -12,6 +12,26 @@ I have no apologies for the following code.  It works well enough.
 
 class Report extends Ork3
 {
+    /**
+     * Ladder-terminal masterhoods that ork_award.peerage still records as 'None'.
+     *
+     * Every Order ladder ends in a masterhood, and most are classified correctly
+     * (Rose, Smith, Lion, Owl, Dragon, Garber, Warlord, Master Crown, Battlemaster
+     * all carry peerage='Master'). These five do not, so filtering on peerage alone
+     * silently drops them from the weekly recap:
+     *
+     *     7 Master Jovius   8 Master Zodiac   9 Master Mask
+     *    10 Master Hydra   11 Master Griffin
+     *
+     * Reported 2026-08-08 ("Week in review missing non-ladder masterhoods").
+     *
+     * This is a recap-scoped compensation, NOT a fix for the underlying data:
+     * ork_award.peerage is deliberately left alone, so the Masters report, the
+     * Knights & Masters report and the State of Amtgard totals still omit these.
+     * Reclassifying the awards would make all of those consistent in one move.
+     */
+    private const RECAP_UNFLAGGED_MASTERHOOD_AWARD_IDS = array(7, 8, 9, 10, 11);
+
     public function __construct()
     {
         parent::__construct();
@@ -4461,10 +4481,23 @@ class Report extends Ork3
         $start = mysql_real_escape_string($win['WeekStart']);
         $end   = mysql_real_escape_string($win['WeekEnd']);
         $kid_clause = $kingdom_id ? ' AND m.kingdom_id IN (' . implode(',', array_map('intval', Ork3::$Lib->kingdom->GetStatsKingdomIds($kingdom_id))) . ')' : '';
+
+        // Resolve peerage and award id through the same alias-then-kingdomaward
+        // precedence, so both agree on which award a grant actually represents.
+        $peerage_expr  = 'COALESCE(alias.peerage, a.peerage)';
+        $award_expr    = 'COALESCE(alias.award_id, ka.award_id)';
+        $peerage_where = "$peerage_expr IN ($list)";
+        if (in_array('Master', $peerages, true)) {
+            // Pick up the masterhoods ork_award.peerage does not flag as such.
+            $unflagged     = implode(',', array_map('intval', self::RECAP_UNFLAGGED_MASTERHOOD_AWARD_IDS));
+            $peerage_where = "($peerage_where OR $award_expr IN ($unflagged))";
+            // Report them as masterhoods so the returned DTO is self-consistent.
+            $peerage_expr  = "CASE WHEN $award_expr IN ($unflagged) THEN 'Master' ELSE $peerage_expr END";
+        }
         $sql = "SELECT ma.awards_id, ma.date, ma.mundane_id, m.persona,
 					   p.park_id, p.name AS park_name,
 					   k.kingdom_id, k.name AS kingdom_name,
-					   COALESCE(alias.peerage, a.peerage) AS peerage,
+					   $peerage_expr AS peerage,
 					   COALESCE(NULLIF(ma.custom_name, ''), ka.name, alias.name, a.name) AS award_name
 				FROM " . DB_PREFIX . "awards ma
 					JOIN " . DB_PREFIX . "mundane m ON m.mundane_id = ma.mundane_id
@@ -4473,7 +4506,7 @@ class Report extends Ork3
 					LEFT JOIN " . DB_PREFIX . "award alias ON alias.award_id = ma.alias_award_id
 					LEFT JOIN " . DB_PREFIX . "park p ON p.park_id = m.park_id
 					LEFT JOIN " . DB_PREFIX . "kingdom k ON k.kingdom_id = m.kingdom_id
-				WHERE COALESCE(alias.peerage, a.peerage) IN ($list)
+				WHERE $peerage_where
 				  AND ma.revoked = 0
 				  AND ma.date >= '$start' AND ma.date <= '$end'
 				  $kid_clause


### PR DESCRIPTION
Four reports from the Discord bug channel. Each was reproduced against real data before any code was written; verification notes are under each item.

---

## ⚠️ Action required in Cloudflare — this PR does not fix report #1 on its own

**Nothing in this branch makes the Google Calendar feed work.** The feed is unreachable at the network edge, and only a Cloudflare change can fix that. The code here exists to make that change simple and durable.

### What's happening

`ork.amtgard.com` returns a **403 managed challenge to every non-browser client**. Verified against production with four different user agents — default curl, `Google-Calendar-Importer`, a real Chrome UA, and a complete browser header set (`sec-ch-ua`, `Sec-Fetch-*`, `Accept-Language`). All four:

```
GET https://ork.amtgard.com/orkui/index.php?Route=Kingdom/ics/11
→ HTTP 403 · content-type: text/html · cf-mitigated: challenge · cType: 'managed'
→ body: the "Just a moment..." interstitial
```

It is zone-wide over the app path, not specific to the ICS route — `/`, `/orkui/`, and `Kingdom/profile/11` all 403; only static `/robots.txt` returns 200.

The challenge requires executing Cloudflare's JavaScript, so **no server-side fetcher can ever pass it**. Google Calendar's "From URL" only validates that it can store the URL — it never surfaces a fetch failure, which is exactly why the calendar appears subscribed and stays permanently empty.

### The rule to add

**Cloudflare → Security → WAF → Custom rules**

| Field | Value |
|---|---|
| Expression | `starts_with(http.request.uri.path, "/ics/")` |
| Action | **Skip** → All remaining custom rules, Managed Challenge, Bot Fight Mode |

This is why the branch adds a clean `/ics/kingdom/{id}.ics` path: a WAF rule matching a URI path is trivial and stable, whereas one matching `?Route=Kingdom/ics/...` inside a query string is fragile.

### Then verify from outside a browser

```
curl -sS -o /dev/null -w '%{http_code} %{content_type}\n' \
  https://ork.amtgard.com/ics/kingdom/11.ics
```

Expected: `200 text/calendar; charset=utf-8`. If it still returns `403 text/html`, the rule is not matching.

### Two more things

**Check the WAF logs to confirm the diagnosis.** Cloudflare exempts "verified bots" from managed challenges, and I can't tell from outside whether Google's calendar fetcher is on that list for this zone. **Security → Events**, filtered to the ICS path, will show whether Google's requests are actually being challenged. My evidence is conclusive for every client I could test, but the log is proof.

**Deploy order matters.** `nginx.ork3.config` is `COPY`'d at image build time in all three Dockerfiles, so a normal image rebuild ships the rewrite and the new URL together. If PHP were deployed without an nginx rebuild, the kingdom page would advertise a URL that 404s. **Rebuild the image; don't hot-patch only the PHP.**

**Tell the reporter to re-subscribe.** Their existing subscription points at the `?Route=` URL, which still works but is *not* covered by the path-scoped rule above. Simplest fix is to remove the old subscription and use the button on the kingdom page again.

---

## 1. Google Calendar subscriptions never populate

Root cause is the Cloudflare challenge above. The ICS generator itself is fine — the same route returns `200 text/calendar` anonymously on local Docker with a well-formed payload (correct CRLF, valid `VCALENDAR`/`VEVENT`, proper `UID`/`DTSTAMP`/`DTSTART`/`DTEND`).

**Changes**
- `nginx.ork3.config` — clean feed path ahead of the front controller:
  ```nginx
  location ^~ /ics/ {
      rewrite ^/ics/kingdom/([0-9]+)\.ics$ /orkui/index.php?Route=Kingdom/ics/$1 last;
      return 404;
  }
  ```
- `controller.Kingdom.php` — `Content-Disposition: attachment` → `inline` (this URL is subscribed to, not downloaded), plus an `ics_feed_url()` helper deriving the canonical URL from `HTTP_UI_REMOTE` so it is correct in dev, dist and prod without a hardcoded host.

**Verified** by loading the config into the running container, `nginx -t`, reload, then:

| Check | Result |
|---|---|
| `/ics/kingdom/11.ics` | 200 `text/calendar`, `inline`, valid VCALENDAR |
| `?Route=Kingdom/ics/11` (legacy) | 200 — existing subscribers unaffected |
| `/ics/`, `/ics/kingdom/11`, `/ics/kingdom/abc.ics`, `.ics.bak` | 404 |
| `/ics/kingdom/../../etc/passwd` (`--path-as-is`) | 404, no traversal |
| All three UI entry points | now emit `/ics/kingdom/11.ics`; zero leftover `Kingdom/ics` links |

**Known issue, not fixed here.** `icsDt()` does `gmdate(..., strtotime($str))`. Event times are naive wall-clock, `ork_event_calendardetail` has no timezone column, and the app runs `America/Chicago` — so every event is converted to UTC *as if it were Central*. Golden Plains is Central and was correct by luck; a Pacific kingdom's events land 2 hours off for subscribers. A real fix needs per-kingdom or per-park timezone data — a schema change, deliberately left as separate work.

---

## 2. Week in Review omits non-ladder masterhoods

`_RecapPeerages()` filters on `COALESCE(alias.peerage, a.peerage) IN ('Master')`. The query is right; the data is not. Every Order ladder terminates in a masterhood, but only nine of fourteen are classified as such:

| Order (`is_ladder=1`) | Masterhood | `peerage` |
|---|---|---|
| Rose / Smith / Lion / Owl / Dragon / Garber | Master Rose … Garber (1–6) | `Master` ✅ |
| Order of the Warrior (27) | Warlord (12) | `Master` ✅ |
| Order of the Crown (239) | Master Crown (240) | `Master` ✅ |
| Order of Battle (243) | Battlemaster (244) | `Master` ✅ |
| **Jovius (28) / Zodiac (30) / Mask (29) / Hydra (32) / Griffin (33)** | **Master Jovius / Zodiac / Mask / Hydra / Griffin (7–11)** | **`None` ❌** |

Scale: **438 kingdom-award rows across 38 kingdoms** map to the five, and **226 grants** have never appeared in a recap (Griffin 105, Hydra 44, Mask 41, Jovius 33, Zodiac 3).

Weaponmaster (36) and Dragonmaster (207) were checked and **excluded** — neither terminates an Order ladder, so they read as standalone titles.

**Change** — compensation in the recap only. Award ids in a documented constant; matched via `COALESCE(alias.award_id, ka.award_id)`, mirroring the existing peerage precedence; a `CASE` reports them as `Master` so the DTO stays self-consistent. Gated on `in_array('Master', ...)` so the Knight and Paragon calls generate byte-identical SQL.

**Verified** by running the real `GetWeeklyRecap()` for the reproduction week (2026-05-18 → 05-24) and diffing full output before/after:

```
< Masterhoods (13):
> Masterhoods (16):
>    2026-05-24  Master Griffin  peerage=Master   (×3)
```

That is the entire diff — Knightings and Paragons byte-identical. `GetWeeklyRecapForKingdom()` also verified.

**Deliberately not fixed: the underlying data.** `Reports/masters`, the Knights & Masters report and its "master belts" count, and the State of Amtgard totals all still exclude these 226 masterhoods, because they read `ork_award.peerage` directly. A one-line migration on ids 7–11 — same shape as `db-migrations/2017-10-18-set-paragon-flag` — would make every surface consistent, but it moves numbers on official kingdom reports, so it belongs to whoever owns that call.

**No backfill.** The 57 stored weeks keep their existing lists. Re-running `compute-weekly-recap.php` per week would fix history but nulls `PlatformStats` for weeks whose Cloudflare data has aged out.

⚠️ `GetWeeklyRecapForKingdom` is GhettoCache'd at 86400s — **flush memcache after deploy** for the fix to show immediately on kingdom pages.

---

## 3. URLs in event and schedule descriptions are not clickable

Three render surfaces, two of which needed work:

- **Event description** already auto-linked via Parsedown, but had no `target` — links replaced the event page.
- **Schedule item description** (list view) was plain `htmlspecialchars()` — the reported bug.
- **Schedule grid popover** (JS) had the same gap.

The Feast tab renders `Menu`, not `Description`, so it is out of scope; the embeddable `ork-schedule.js` widget renders no descriptions.

**Changes** — `ev_link_new_tab()`, `ev_autolink()`, and a JS `linkify()` mirror.

Two details: the URL is matched **before** escaping, because escaping first turns `&` into `&amp;` inside query strings and corrupts the `href`. Trailing `.,;:!?` is trimmed, and `)` only when unbalanced — the reporter's own example is `(https://drive.google.com/...?usp=sharing)`, where a naive regex swallows the paren. Only `https?://` matches, so `javascript:` can never become an anchor.

**Verified** — PHP and JS agree across 9 cases (balanced parens, query strings, trailing punctuation, `<script>`, `javascript:`, an attribute-break attempt, `ftp://`), then against a real production record: a waiver link in Emerald Hills event 17977 that has been sitting unclickable. Renders correctly in list view and grid popover, dark (`#63b3ed`) and light (`#2b6cb0`), with no horizontal overflow — `overflow-wrap:anywhere` lets a 90-character URL wrap inside the cell.

---

## 4. Kingdom map popover is hard to read

The popover was built from inline-styled HTML with hardcoded light-mode colours (`#2b6cb0`, `#718096`). On the dark InfoWindow chrome the park name and address were near-illegible; a global rule strips Google's default padding on the assumption content supplies its own, which this markup didn't, so text ran to the bubble edge; and nothing reserved space for the close X, which sat on the title.

A properly designed popover component already existed — `.ev-map-popover`, built for the Event map — and the Kingdom map simply wasn't using it.

**Changes** — a `.kn-map-popover` component sharing that visual language (same type scale, same muted meta row, same dark-mode token sources), with Google's reserved header space reclaimed via `:has(.kn-map-popover)`, scoped so the Event map keeps its current spacing. The location pin glyph takes the colour of the marker clicked — crimson `#8B1A1A` kingdom, blue `#2C5F8B` principality, the same values `PinElement` and the legend use.

**Security fix included:** `loc.name` was previously interpolated into InfoWindow HTML **unescaped**. Park names are user-entered. Now escaped via a local `knMapEsc()`, following the `knCiEsc`/`pkCiEsc` convention already in `revised.js`.

**Verification caveat — please eyeball this one on a real map.** Google Maps will not render Advanced Markers on localhost (the `mapId` isn't valid there), so I could not click a real pin. I reproduced Google's InfoWindow DOM (`gm-style-iw-c` / `-ch` / `-d`) inside the live Kingdom page so the real `revised.css` applied, and drove it with markup from the shipped code path. That harness reproduced the reported defects exactly before the fix, which gives reasonable confidence it is faithful — but it does **not** reproduce Google's own width/height measurement, so the real bubble auto-sizing to the new content is unverified. `min-width: 196px` / `max-width: 264px` should keep it tight.

---

## Notes for review

- `system/lib/ork3/class.Authorization.php` carries a local dev auth bypass in my working tree and is **deliberately excluded** from this branch. Every file was staged explicitly and the staged diff reviewed hunk-by-hunk.
- `vendor/` is not installed in my environment, so **php-cs-fixer was not run**. Edits match surrounding style (4-space PSR-12 in `.php`; the 1,235 tab-leading lines in `class.Report.php` are all SQL string-literal continuations, untouched) and `php -l` / `node --check` are clean, but a fixer pass before merge would be prudent.
- `bin/check-layering.sh` does not exist on this branch — it lives only on `feature/front-door` and was never merged to master, so the layering gate silently does not run here. Worth landing separately.
