### PR TITLE
Bugfix: pass session Token to add_dues so AddDues can authorize

### DIFF
--- a/orkui/controller/controller.Admin.php
+++ b/orkui/controller/controller.Admin.php
@@ -1137,6 +1137,7 @@ class Controller_Admin extends Controller
                             break;
                         }
                         $r = $this->Player->add_dues(array(
+                                'Token' => $this->session->token,
                                 'MundaneId' => $id,
                                 'ParkId' => valid_id($this->request->Admin_player->ParkId) ? $this->request->Admin_player->ParkId : 0,
                                 'KingdomId' => valid_id($this->request->Admin_player->KingdomId) ? $this->request->Admin_player->KingdomId : 0,


### PR DESCRIPTION
## Problem

An officer reported that adding dues did nothing — clicking **Add Dues** refreshed the page and no dues appeared, with no error message.

## Cause

`Player::AddDues` resolves the acting user from the request and gates its insert on that identity:

```php
$mundane_id = Ork3::$Lib->authorization->IsAuthorized($request['Token']);
if (Ork3::$Lib->authorization->HasAuthority($mundane_id, AUTH_PARK, $request['ParkId'], AUTH_EDIT)) {
```

`Controller_Admin::player()` built the `add_dues` argument array **without a `Token`**, so `IsAuthorized()` received null and returned `0`; `HasAuthority(0, ...)` then failed its first guard (`valid_id(0)` is false). `AddDues` returned `NoAuthorization()` — Status 5 — and wrote nothing.

`adddues` was the only one of the 14 cases in that switch not passing a token. The others, including `revokedues` directly below it, already do.

## Why it looked like a silent refresh

On Status 5 the controller redirects to `Login/login/...`. The dues modal submits with `fetch()` and reloads on any successful response:

```js
fetch(DUES_URL, { method: 'POST', body: fd })
  .then(function(resp) {
      if (!resp.ok) throw new Error('Server returned ' + resp.status);
      window.location.reload();
  })
```

The redirect is followed, a 200 comes back, the page reloads — so the rejection is invisible to the user.

## Evidence

Six consecutive `302`s on `POST /orkui/index.php?Route=Admin/player/{id}/adddues` from a park Prime Minister whose park-level `create` grant is valid (`HasAuthority(..., AUTH_PARK, 1043, AUTH_EDIT)` returns true).

## Change

One line — add `'Token' => $this->session->token,` to the `add_dues` argument array, matching every sibling call in the same switch.

## Testing

Not yet verified end to end against production. The reporting officer should retry after deploy; if her dues save, this was the cause. If she still receives a 302 with the token present, the problem lies with her account or session rather than this call — but the change remains correct for consistency with the other 13 cases, since `AddDues` cannot authorize without a token.

## Follow-up worth considering

The dues modal treating any 200 as success hides server-side errors. Surfacing the controller's `$this->data['Error']`, or moving dues onto a JSON endpoint like the sign-in link flows use, would make the next failure of this kind visible instead of silent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)