### PR TITLE
Enhancement: real human-visitor counts in the Week in Review (GA4)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,4 @@ __pycache__/
 htmlcov/
 .pytest_cache/
 test-results/
+ga-service-account.json

--- a/bin/ga-probe.php
+++ b/bin/ga-probe.php
@@ -1,0 +1,35 @@
+#!/usr/bin/env php
+<?php
+
+/**
+ * Quick check of the GA4 Data API wiring, and the answer to "how many humans
+ * visit the ORK?" without opening the Analytics UI.
+ *
+ *     php bin/ga-probe.php            # last 30 days + last full calendar month
+ *     php bin/ga-probe.php 90         # last 90 days instead
+ *
+ * Needs GA4_PROPERTY_ID and GA4_SA_KEY_PATH in config.php (see
+ * Report::GaActiveUsers). Prints "unavailable" if config is missing or the
+ * API call fails — the same null-safe behavior the weekly recap has.
+ */
+
+require_once dirname(__DIR__) . '/startup.php';
+
+$days = isset($argv[1]) ? max(1, (int)$argv[1]) : 30;
+$report = Ork3::$Lib->report;
+
+$fmt = function ($n) {
+    return $n === null ? 'unavailable (missing config or API error)' : number_format($n);
+};
+
+$since = date('Y-m-d', strtotime("-{$days} days"));
+$today = date('Y-m-d');
+printf(
+    "GA4 unique human visitors (activeUsers), property %s\n",
+    defined('GA4_PROPERTY_ID') ? GA4_PROPERTY_ID : (getenv('GA4_PROPERTY_ID') ?: '(unset)')
+);
+printf("  last %d days (%s .. %s): %s\n", $days, $since, $today, $fmt($report->GaActiveUsers($since, $today)));
+
+$month_start = date('Y-m-01', strtotime('first day of last month'));
+$month_end   = date('Y-m-t', strtotime('first day of last month'));
+printf("  last calendar month (%s .. %s): %s\n", $month_start, $month_end, $fmt($report->GaActiveUsers($month_start, $month_end)));

--- a/orkui/template/default/Recap_index.tpl
+++ b/orkui/template/default/Recap_index.tpl
@@ -514,38 +514,64 @@ html[data-theme="dark"] .recap-foot a { color: #6b7280; }
 <?php endif; ?>
 
 <?php
-	// ============================ ORK platform stats (CF) ============================
+	// ============================ ORK platform stats (CF + GA) ============================
 	$ps = $recap['PlatformStats'] ?? null;
-	if (is_array($ps)) :
-		$req_str         = $format_count($ps['Requests']);
-		$cache_hits_str  = $format_count($ps['CacheHits']);
-		$origin_req_str  = $format_count(max(0, $ps['Requests'] - $ps['CacheHits']));
-		$total_gb_str    = $format_bytes($ps['Bytes']);
-		$origin_gb_str   = $format_bytes($ps['OriginBytes'] ?? 0);
-		$cached_gb_str   = $format_bytes($ps['CachedBytes'] ?? 0);
-		$us_str          = $format_count($ps['RequestsUS']);
-		$ca_str          = $format_count($ps['RequestsCA']);
-		$req_total    = max(1, $ps['Requests']);
-		$cache_pct    = round(100 * $ps['CacheHits'] / $req_total);
-		$bytes_total  = max(1, $ps['Bytes']);
-		$cached_pct   = round(100 * ($ps['CachedBytes'] ?? 0) / $bytes_total);
-
-		// WoW delta — only when the prior week ALSO has PlatformStats (i.e. both
-		// weeks are inside CF's retention horizon). Neutral phrasing, no color.
-		$prev_ps = $prev_recap['PlatformStats'] ?? null;
+	// Unique human visitors (GA4). Independent of CF stats — either can be null
+	// (different APIs, different failure modes), so the section renders if we
+	// have at least one of them.
+	$hu = isset($recap['HumanUsers']) && is_numeric($recap['HumanUsers']) ? (int)$recap['HumanUsers'] : null;
+	$hu_delta_line = '';
+	if ($hu !== null) {
+		$prev_hu = $prev_recap['HumanUsers'] ?? null;
+		if (is_numeric($prev_hu) && (int)$prev_hu > 0) {
+			$hu_pct = round(100 * ($hu - (int)$prev_hu) / (int)$prev_hu);
+			$hu_arrow = $hu_pct > 0 ? '↑' : ($hu_pct < 0 ? '↓' : '·');
+			$hu_delta_line = sprintf('%s %s%% from the previous week (%s → %s).',
+				$hu_arrow, $hu_pct >= 0 ? '+' . $hu_pct : $hu_pct,
+				$format_count((int)$prev_hu), $format_count($hu));
+		}
+	}
+	if (is_array($ps) || $hu !== null) :
 		$delta_line = '';
-		if (is_array($prev_ps) && !empty($prev_ps['Requests'])) {
-			$cur  = $ps['Requests'];
-			$prev = $prev_ps['Requests'];
-			$pct  = round(100 * ($cur - $prev) / $prev);
-			$arrow = $pct > 0 ? '↑' : ($pct < 0 ? '↓' : '·');
-			$delta_line = sprintf('%s %s%% from the previous week (%s → %s).',
-				$arrow, $pct >= 0 ? '+' . $pct : $pct,
-				$format_count($prev), $format_count($cur));
+		if (is_array($ps)) {
+			$req_str         = $format_count($ps['Requests']);
+			$cache_hits_str  = $format_count($ps['CacheHits']);
+			$origin_req_str  = $format_count(max(0, $ps['Requests'] - $ps['CacheHits']));
+			$total_gb_str    = $format_bytes($ps['Bytes']);
+			$origin_gb_str   = $format_bytes($ps['OriginBytes'] ?? 0);
+			$cached_gb_str   = $format_bytes($ps['CachedBytes'] ?? 0);
+			$us_str          = $format_count($ps['RequestsUS']);
+			$ca_str          = $format_count($ps['RequestsCA']);
+			$req_total    = max(1, $ps['Requests']);
+			$cache_pct    = round(100 * $ps['CacheHits'] / $req_total);
+			$bytes_total  = max(1, $ps['Bytes']);
+			$cached_pct   = round(100 * ($ps['CachedBytes'] ?? 0) / $bytes_total);
+
+			// WoW delta — only when the prior week ALSO has PlatformStats (i.e. both
+			// weeks are inside CF's retention horizon). Neutral phrasing, no color.
+			$prev_ps = $prev_recap['PlatformStats'] ?? null;
+			if (is_array($prev_ps) && !empty($prev_ps['Requests'])) {
+				$cur  = $ps['Requests'];
+				$prev = $prev_ps['Requests'];
+				$pct  = round(100 * ($cur - $prev) / $prev);
+				$arrow = $pct > 0 ? '↑' : ($pct < 0 ? '↓' : '·');
+				$delta_line = sprintf('%s %s%% from the previous week (%s → %s).',
+					$arrow, $pct >= 0 ? '+' . $pct : $pct,
+					$format_count($prev), $format_count($cur));
+			}
 		}
 ?>
 	<section class="recap-section">
-		<h2><span class="recap-section-icon"><i class="fas fa-globe-americas"></i></span> ORK Data <span class="recap-tip" tabindex="0"><i class="fas fa-info-circle"></i><span class="recap-tip-text">The ORK is a PHP/Database application hosted on Amazon Web Services behind Cloudflare's CDN. Cloudflare caches static assets (images, CSS, JavaScript) at edge locations near visitors — those requests never reach AWS, saving server load, bandwidth, and response time. Cloudflare also absorbs bot traffic and bad actors before they touch the origin. These numbers show how that split played out for US and Canadian traffic this week.</span></span></h2>
+		<h2><span class="recap-section-icon"><i class="fas fa-globe-americas"></i></span> ORK Data <span class="recap-tip" tabindex="0"><i class="fas fa-info-circle"></i><span class="recap-tip-text">The ORK is a PHP/Database application hosted on Amazon Web Services behind Cloudflare's CDN. Cloudflare caches static assets (images, CSS, JavaScript) at edge locations near visitors — those requests never reach AWS, saving server load, bandwidth, and response time. Cloudflare also absorbs bot traffic and bad actors before they touch the origin. These numbers show how that split played out for US and Canadian traffic this week. Visitor counts come from Google Analytics, which only counts real browsers — bots are excluded.</span></span></h2>
+<?php   if ($hu !== null) : ?>
+		<p class="recap-digest">
+			<strong><?=$format_count($hu)?></strong> people visited the ORK this week.
+		</p>
+<?php     if ($hu_delta_line) : ?>
+		<p class="recap-trend"><em>Visitors <?=$hu_delta_line?></em></p>
+<?php     endif; ?>
+<?php   endif; ?>
+<?php   if (is_array($ps)) : ?>
 		<p class="recap-digest">
 			Cloudflare delivered <strong><?=$req_str?></strong> requests
 			(<strong><?=$total_gb_str?></strong>)
@@ -563,6 +589,7 @@ html[data-theme="dark"] .recap-foot a { color: #6b7280; }
 			Cloudflare also blocked or challenged <strong><?=$format_count($ps['BlockedOrChallenged'])?></strong> malicious requests this week.
 		</p>
 <?php   endif; ?>
+<?php   endif; // is_array($ps) ?>
 	</section>
 <?php endif; ?>
 

--- a/system/lib/ork3/class.Report.php
+++ b/system/lib/ork3/class.Report.php
@@ -4208,6 +4208,7 @@ class Report extends Ork3
             'ReturningPlayers' => $this->_RecapReturningPlayers($win, 90),
             'MilestoneEvents'  => $this->_RecapMilestoneEvents($win, 25),
             'PlatformStats'    => $this->_RecapCloudflareStats($win),
+            'HumanUsers'       => $this->_RecapGaHumanUsers($win),
         );
     }
 
@@ -4317,6 +4318,125 @@ class Report extends Ork3
         return json_decode($resp, true);
     }
 
+    /**
+     * Unique human visitors for the recap week, from Google Analytics (GA4).
+     *
+     * This is the only honest "how many people use the site" number we have:
+     * GA only counts clients that execute its JS, which excludes essentially all
+     * bots. (Cloudflare's edge "uniques" counts distinct IPs and is ~99% bot
+     * traffic — see PlatformStats, which is a traffic/security metric, not a
+     * user count. GA undercounts humans somewhat instead: ad-blockers.)
+     *
+     * Auth is a Google service account (GA4 property Viewer) — the JWT-bearer
+     * flow, signed locally with openssl, no SDK. Config lives beside the CF
+     * keys: GA4_PROPERTY_ID (numeric, GA Admin > Property settings) and
+     * GA4_SA_KEY_PATH (the service account's JSON key file, NOT in git).
+     * Returns null on any failure so the recap still ships without it.
+     *
+     * @return int|null distinct activeUsers over the week, or null
+     */
+    private function _RecapGaHumanUsers($win)
+    {
+        return $this->GaActiveUsers($win['WeekStart'], $win['WeekEnd']);
+    }
+
+    /**
+     * Distinct GA4 activeUsers between two Y-m-d dates (inclusive). Public so
+     * ad-hoc callers (bin/ga-probe.php, "how many users this month?") share the
+     * exact plumbing the weekly recap uses. Null on any failure or missing config.
+     *
+     * @param string $start_date Y-m-d
+     * @param string $end_date   Y-m-d
+     * @return int|null
+     */
+    public function GaActiveUsers($start_date, $end_date)
+    {
+        $property = (defined('GA4_PROPERTY_ID') && GA4_PROPERTY_ID !== '') ? GA4_PROPERTY_ID : getenv('GA4_PROPERTY_ID');
+        $key_path = (defined('GA4_SA_KEY_PATH') && GA4_SA_KEY_PATH !== '') ? GA4_SA_KEY_PATH : getenv('GA4_SA_KEY_PATH');
+        if (empty($property) || empty($key_path) || !is_readable($key_path)) {
+            return null;
+        }
+        $token = $this->_gaAccessToken($key_path);
+        if ($token === null) {
+            return null;
+        }
+
+        $ch = curl_init('https://analyticsdata.googleapis.com/v1beta/properties/' . rawurlencode($property) . ':runReport');
+        curl_setopt_array($ch, array(
+            CURLOPT_POST           => true,
+            CURLOPT_POSTFIELDS     => json_encode(array(
+                'dateRanges' => array(array('startDate' => $start_date, 'endDate' => $end_date)),
+                'metrics'    => array(array('name' => 'activeUsers')),
+            )),
+            CURLOPT_HTTPHEADER     => array(
+                'Authorization: Bearer ' . $token,
+                'Content-Type: application/json',
+            ),
+            CURLOPT_RETURNTRANSFER => true,
+            CURLOPT_TIMEOUT        => 20,
+            CURLOPT_CONNECTTIMEOUT => 5,
+        ));
+        $resp = curl_exec($ch);
+        $http = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+        curl_close($ch);
+        if ($resp === false || $http !== 200) {
+            return null;
+        }
+        $json = json_decode($resp, true);
+        $value = $json['rows'][0]['metricValues'][0]['value'] ?? null;
+        return $value === null ? null : (int)$value;
+    }
+
+    /**
+     * OAuth2 access token for the GA service account (JWT-bearer grant).
+     * Scope is read-only analytics. Returns null on any failure.
+     */
+    private function _gaAccessToken($key_path)
+    {
+        $key = json_decode((string)file_get_contents($key_path), true);
+        if (!is_array($key) || empty($key['client_email']) || empty($key['private_key'])) {
+            return null;
+        }
+
+        $b64 = function ($data) {
+            return rtrim(strtr(base64_encode($data), '+/', '-_'), '=');
+        };
+        $now = time();
+        $unsigned = $b64(json_encode(array('alg' => 'RS256', 'typ' => 'JWT')))
+            . '.' . $b64(json_encode(array(
+                'iss'   => $key['client_email'],
+                'scope' => 'https://www.googleapis.com/auth/analytics.readonly',
+                'aud'   => 'https://oauth2.googleapis.com/token',
+                'iat'   => $now,
+                'exp'   => $now + 3600,
+            )));
+        $signature = '';
+        if (!openssl_sign($unsigned, $signature, $key['private_key'], OPENSSL_ALGO_SHA256)) {
+            return null;
+        }
+        $jwt = $unsigned . '.' . $b64($signature);
+
+        $ch = curl_init('https://oauth2.googleapis.com/token');
+        curl_setopt_array($ch, array(
+            CURLOPT_POST           => true,
+            CURLOPT_POSTFIELDS     => http_build_query(array(
+                'grant_type' => 'urn:ietf:params:oauth:grant-type:jwt-bearer',
+                'assertion'  => $jwt,
+            )),
+            CURLOPT_RETURNTRANSFER => true,
+            CURLOPT_TIMEOUT        => 20,
+            CURLOPT_CONNECTTIMEOUT => 5,
+        ));
+        $resp = curl_exec($ch);
+        $http = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+        curl_close($ch);
+        if ($resp === false || $http !== 200) {
+            return null;
+        }
+        $json = json_decode($resp, true);
+        return isset($json['access_token']) ? (string)$json['access_token'] : null;
+    }
+
     // Count of firewall events that actually stopped traffic: outright blocks plus
     // challenges (managed/JS/classic). Excludes "skip", "allow", "log", and the
     // *_solved/*_bypassed actions where the request ultimately got through.
@@ -4398,6 +4518,8 @@ class Report extends Ork3
             'MilestoneEvents'  => $this->_RecapMilestoneEvents($win, 25, $kingdom_id),
             // PlatformStats stays global — CF doesn't tell us per-kingdom traffic.
             'PlatformStats'    => $global['PlatformStats'] ?? null,
+            // Ditto HumanUsers — GA4 counts site visitors, not kingdom members.
+            'HumanUsers'       => $global['HumanUsers'] ?? null,
             'ComputedAt'       => $computed_at,
         );
         return Ork3::$Lib->ghettocache->cache($call, $key, $payload);

--- a/tests/Unit/ReportGaActiveUsersTest.php
+++ b/tests/Unit/ReportGaActiveUsersTest.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Guard behavior of Report::GaActiveUsers (GA4 human-visitor counts).
+ *
+ * The happy path needs Google's OAuth + Data API and a real service-account
+ * key, so it is exercised by bin/ga-probe.php against production credentials,
+ * not here. These tests pin the null-safety contract the weekly recap relies
+ * on: any missing or broken configuration must yield null, never a warning,
+ * an exception, or a network call.
+ */
+final class ReportGaActiveUsersTest extends TestCase
+{
+    /** @var array<string, string|false> */
+    private $savedEnv = [];
+
+    protected function setUp(): void
+    {
+        // The method falls back to env vars when the constants are undefined
+        // (they are undefined under ENVIRONMENT=TEST), so pin a clean slate.
+        foreach (['GA4_PROPERTY_ID', 'GA4_SA_KEY_PATH'] as $name) {
+            $this->savedEnv[$name] = getenv($name);
+            putenv($name);
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        foreach ($this->savedEnv as $name => $value) {
+            putenv($value === false ? $name : $name . '=' . $value);
+        }
+    }
+
+    public function testReturnsNullWithoutAnyConfiguration(): void
+    {
+        $this->assertNull(Ork3::$Lib->report->GaActiveUsers('2026-08-01', '2026-08-07'));
+    }
+
+    public function testReturnsNullWhenKeyPathIsMissing(): void
+    {
+        putenv('GA4_PROPERTY_ID=495241107');
+        $this->assertNull(Ork3::$Lib->report->GaActiveUsers('2026-08-01', '2026-08-07'));
+    }
+
+    public function testReturnsNullWhenKeyFileDoesNotExist(): void
+    {
+        putenv('GA4_PROPERTY_ID=495241107');
+        putenv('GA4_SA_KEY_PATH=/nonexistent/ga-key.json');
+        $this->assertNull(Ork3::$Lib->report->GaActiveUsers('2026-08-01', '2026-08-07'));
+    }
+
+    public function testReturnsNullWhenKeyFileIsNotJson(): void
+    {
+        $tmp = tempnam(sys_get_temp_dir(), 'ga-key-');
+        file_put_contents($tmp, 'this is not json');
+        putenv('GA4_PROPERTY_ID=495241107');
+        putenv('GA4_SA_KEY_PATH=' . $tmp);
+        try {
+            $this->assertNull(Ork3::$Lib->report->GaActiveUsers('2026-08-01', '2026-08-07'));
+        } finally {
+            unlink($tmp);
+        }
+    }
+
+    public function testReturnsNullWhenKeyFileLacksCredentialFields(): void
+    {
+        $tmp = tempnam(sys_get_temp_dir(), 'ga-key-');
+        file_put_contents($tmp, json_encode(['type' => 'service_account']));
+        putenv('GA4_PROPERTY_ID=495241107');
+        putenv('GA4_SA_KEY_PATH=' . $tmp);
+        try {
+            $this->assertNull(Ork3::$Lib->report->GaActiveUsers('2026-08-01', '2026-08-07'));
+        } finally {
+            unlink($tmp);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

"How many people actually use the ORK?" has never had an honest answer. Cloudflare's edge "unique visitors" counts distinct IPs and is ~99% automation (**1.69M IPs/month** at the edge vs **~14k humans**). Google Analytics only counts clients that execute its JS — bots are excluded by construction — and GA4 is already installed site-wide (`G-PVQCKENY0M` in `default.theme`). This wires it into the weekly recap.

## What's included

- **`Report::GaActiveUsers($start, $end)`** — GA4 Data API `runReport` for `activeUsers`, authenticated as a Google service account (Viewer on the GA4 property) via the OAuth2 JWT-bearer flow, signed locally with `openssl_sign`. No Google SDK dependency. Null-safe on any missing config or API failure — the recap ships without it, same contract as the Cloudflare stats.
- **`HumanUsers` in the weekly recap payload** (global compute + per-kingdom passthrough, like `PlatformStats`). The Week in Review's *ORK Data* section now leads with "**N** people visited the ORK this week," with a week-over-week trend once two consecutive weeks carry the number. The CF paragraphs render independently, so either source can be down without hiding the other.
- **`bin/ga-probe.php`** — CLI for ad-hoc questions: last 30 days + last calendar month (`php bin/ga-probe.php`, or `php bin/ga-probe.php 90`).
- **5 unit tests** pinning the null-safety guards (missing config, missing/unreadable/garbage/incomplete key file → `null`, never a warning or a network call). No credentials needed to run the suite; the happy path is deliberately an operational probe, mirroring how the CF stats are covered.

## Configuration (prod)

```php
define('GA4_PROPERTY_ID', '495241107');
define('GA4_SA_KEY_PATH', '/var/www/ORK3/ga-service-account.json');
```

The service-account JSON key is **not in git** (`.gitignore`'d) and needs `www-data`-readable, `600` perms. The service account (`ork-recap@ork-analytics.iam.gserviceaccount.com`) has Viewer on the GA4 property — read-only analytics, no other access. Env-var fallbacks exist for both settings.

## Verified

Against the real property, three ways:

| Window | activeUsers |
|---|---|
| Last 30 days (Jul 20 – Aug 19) | 14,747 |
| July 2026 (full month) | 12,995 |
| Recap week Aug 10–16 | 2,835 |

End-to-end through `compute-weekly-recap.php` → `ork_weekly_recap` → Week in Review render. Full suite 364 tests green; php-cs-fixer clean.

## Notes

- Historical recap rows simply lack the key → the paragraph doesn't render for old weeks (no backfill; GA can answer historical windows ad-hoc via the probe if ever needed).
- GA undercounts humans somewhat (ad-blockers); it's still the honest number. The CF figures remain in the recap as traffic/security metrics, which is what they actually are.

🤖 Generated with [Claude Code](https://claude.com/claude-code)