### PR TITLE
Enhancement: Platform Trends page — visitors, players, and the bot wall over time

### DIFF
--- a/orkui/controller/controller.Recap.php
+++ b/orkui/controller/controller.Recap.php
@@ -16,128 +16,150 @@
  * global recap's computed_at so a fresh cron run naturally orphans the cache.
  */
 
-class Controller_Recap extends Controller {
+class Controller_Recap extends Controller
+{
+    public function __construct($call = null, $method = null)
+    {
+        parent::__construct($call, $method);
+        $this->load_model('Recap');
 
-	public function __construct($call = null, $method = null) {
-		parent::__construct($call, $method);
-		$this->load_model('Recap');
+        // Login required for both the page and the JSON endpoint. For json,
+        // respond with a 401 + JSON body instead of an HTML redirect so callers
+        // (e.g. the planned WebXR dashboard) can detect auth failure cleanly.
+        if (!isset($this->session->user_id)) {
+            if ($this->method === 'json' || $this->method === 'json_kingdom') {
+                header('Content-Type: application/json');
+                http_response_code(401);
+                echo json_encode(array('error' => 'login_required'));
+                exit;
+            }
+            header('Location: ' . UIR . 'Login');
+            exit;
+        }
+    }
 
-		// Login required for both the page and the JSON endpoint. For json,
-		// respond with a 401 + JSON body instead of an HTML redirect so callers
-		// (e.g. the planned WebXR dashboard) can detect auth failure cleanly.
-		if (!isset($this->session->user_id)) {
-			if ($this->method === 'json' || $this->method === 'json_kingdom') {
-				header('Content-Type: application/json');
-				http_response_code(401);
-				echo json_encode(array('error' => 'login_required'));
-				exit;
-			}
-			header('Location: ' . UIR . 'Login');
-			exit;
-		}
-	}
+    public function index($week_start = null)
+    {
+        $this->_render_page(0, $week_start);
+    }
 
-	public function index($week_start = null) {
-		$this->_render_page(0, $week_start);
-	}
+    public function kingdom($p = null)
+    {
+        list($kingdom_id, $week_start) = $this->_parse_kingdom_path($p);
+        if ($kingdom_id <= 0) {
+            header('Location: ' . UIR . 'Recap');
+            exit;
+        }
+        $this->_render_page($kingdom_id, $week_start);
+    }
 
-	public function kingdom($p = null) {
-		list($kingdom_id, $week_start) = $this->_parse_kingdom_path($p);
-		if ($kingdom_id <= 0) {
-			header('Location: ' . UIR . 'Recap');
-			exit;
-		}
-		$this->_render_page($kingdom_id, $week_start);
-	}
+    public function json($week_start = null)
+    {
+        $this->_render_json(0, $week_start);
+    }
 
-	public function json($week_start = null) {
-		$this->_render_json(0, $week_start);
-	}
+    // Trends view: the recap's headline numbers over time, plus the
+    // all-history weekly active-players curve. Same audience as the recap
+    // itself (the constructor's login gate applies); the heavy lifting is
+    // ghettocached upstream, so page loads are two cheap cache reads.
+    public function trends()
+    {
+        $this->data['page_title']     = 'Amtgard Platform Trends';
+        $this->data['trend_series']   = $this->Recap->trend_series();
+        $this->data['players_series'] = $this->Recap->weekly_active_players();
+    }
 
-	public function json_kingdom($p = null) {
-		list($kingdom_id, $week_start) = $this->_parse_kingdom_path($p);
-		if ($kingdom_id <= 0) {
-			header('Content-Type: application/json');
-			http_response_code(400);
-			echo json_encode(array('error' => 'invalid_kingdom_id'));
-			exit;
-		}
-		$this->_render_json($kingdom_id, $week_start);
-	}
+    public function json_kingdom($p = null)
+    {
+        list($kingdom_id, $week_start) = $this->_parse_kingdom_path($p);
+        if ($kingdom_id <= 0) {
+            header('Content-Type: application/json');
+            http_response_code(400);
+            echo json_encode(array('error' => 'invalid_kingdom_id'));
+            exit;
+        }
+        $this->_render_json($kingdom_id, $week_start);
+    }
 
-	// Shared page render. $kingdom_id = 0 means global view.
-	private function _render_page($kingdom_id, $week_start) {
-		// Force the template so kingdom() doesn't try to resolve Recap_kingdom.tpl
-		// based on the method name.
-		$this->template = 'Recap_index.tpl';
-		$week_start  = $this->_normalize_week_start($week_start);
-		$kingdom_id  = (int)$kingdom_id;
-		$recap       = $kingdom_id > 0
-			? $this->Recap->get_for_kingdom($kingdom_id, $week_start)
-			: $this->Recap->get($week_start);
-		$weeks       = $this->Recap->recent_weeks(60);
+    // Shared page render. $kingdom_id = 0 means global view.
+    private function _render_page($kingdom_id, $week_start)
+    {
+        // Force the template so kingdom() doesn't try to resolve Recap_kingdom.tpl
+        // based on the method name.
+        $this->template = 'Recap_index.tpl';
+        $week_start  = $this->_normalize_week_start($week_start);
+        $kingdom_id  = (int)$kingdom_id;
+        $recap       = $kingdom_id > 0
+            ? $this->Recap->get_for_kingdom($kingdom_id, $week_start)
+            : $this->Recap->get($week_start);
+        $weeks       = $this->Recap->recent_weeks(60);
 
-		$idx       = array_search($week_start, $weeks, true);
-		$prev_week = ($idx !== false && isset($weeks[$idx + 1])) ? $weeks[$idx + 1] : null;
-		$next_week = ($idx !== false && $idx > 0)               ? $weeks[$idx - 1] : null;
+        $idx       = array_search($week_start, $weeks, true);
+        $prev_week = ($idx !== false && isset($weeks[$idx + 1])) ? $weeks[$idx + 1] : null;
+        $next_week = ($idx !== false && $idx > 0) ? $weeks[$idx - 1] : null;
 
-		$prev_recap = null;
-		if ($prev_week) {
-			$prev_recap = $kingdom_id > 0
-				? $this->Recap->get_for_kingdom($kingdom_id, $prev_week)
-				: $this->Recap->get($prev_week);
-		}
+        $prev_recap = null;
+        if ($prev_week) {
+            $prev_recap = $kingdom_id > 0
+                ? $this->Recap->get_for_kingdom($kingdom_id, $prev_week)
+                : $this->Recap->get($prev_week);
+        }
 
-		$kingdom_name = '';
-		if ($kingdom_id > 0) {
-			$this->load_model('Kingdom');
-			$kingdom_name = $this->Kingdom->get_kingdom_name($kingdom_id);
-		}
+        $kingdom_name = '';
+        if ($kingdom_id > 0) {
+            $this->load_model('Kingdom');
+            $kingdom_name = $this->Kingdom->get_kingdom_name($kingdom_id);
+        }
 
-		$this->data['page_title']    = $kingdom_id > 0
-			? 'Amtgard Week in Review (' . $kingdom_name . ') — Week of ' . ($recap['WeekStart'] ?? $week_start)
-			: 'Amtgard Week in Review — Week of ' . ($recap['WeekStart'] ?? $week_start);
-		$this->data['recap']         = $recap;
-		$this->data['week_start']    = $week_start;
-		$this->data['prev_week']     = $prev_week;
-		$this->data['next_week']     = $next_week;
-		$this->data['recent_weeks']  = $weeks;
-		$this->data['prev_recap']    = $prev_recap;
-		$this->data['scope_kingdom_id']   = $kingdom_id;
-		$this->data['scope_kingdom_name'] = $kingdom_name;
-		$this->data['kingdom_list']  = $this->Recap->kingdom_list();
-	}
+        $this->data['page_title']    = $kingdom_id > 0
+            ? 'Amtgard Week in Review (' . $kingdom_name . ') — Week of ' . ($recap['WeekStart'] ?? $week_start)
+            : 'Amtgard Week in Review — Week of ' . ($recap['WeekStart'] ?? $week_start);
+        $this->data['recap']         = $recap;
+        $this->data['week_start']    = $week_start;
+        $this->data['prev_week']     = $prev_week;
+        $this->data['next_week']     = $next_week;
+        $this->data['recent_weeks']  = $weeks;
+        $this->data['prev_recap']    = $prev_recap;
+        $this->data['scope_kingdom_id']   = $kingdom_id;
+        $this->data['scope_kingdom_name'] = $kingdom_name;
+        $this->data['kingdom_list']  = $this->Recap->kingdom_list();
+    }
 
-	// Shared JSON render. $kingdom_id = 0 means global.
-	private function _render_json($kingdom_id, $week_start) {
-		$week_start = $this->_normalize_week_start($week_start);
-		$recap = $kingdom_id > 0
-			? $this->Recap->get_for_kingdom($kingdom_id, $week_start)
-			: $this->Recap->get($week_start);
-		header('Content-Type: application/json');
-		header('Cache-Control: public, max-age=300');
-		echo json_encode($recap ?? array(
-			'WeekStart' => $week_start,
-			'KingdomId' => $kingdom_id > 0 ? (int)$kingdom_id : null,
-			'Status'    => 'not_computed',
-		));
-		exit;
-	}
+    // Shared JSON render. $kingdom_id = 0 means global.
+    private function _render_json($kingdom_id, $week_start)
+    {
+        $week_start = $this->_normalize_week_start($week_start);
+        $recap = $kingdom_id > 0
+            ? $this->Recap->get_for_kingdom($kingdom_id, $week_start)
+            : $this->Recap->get($week_start);
+        header('Content-Type: application/json');
+        header('Cache-Control: public, max-age=300');
+        echo json_encode($recap ?? array(
+            'WeekStart' => $week_start,
+            'KingdomId' => $kingdom_id > 0 ? (int)$kingdom_id : null,
+            'Status'    => 'not_computed',
+        ));
+        exit;
+    }
 
-	// Parse "{id}" or "{id}/{week_start}" path tail.
-	private function _parse_kingdom_path($p) {
-		if (empty($p)) return array(0, null);
-		$parts = explode('/', $p);
-		$kid = (int)preg_replace('/[^0-9]/', '', $parts[0]);
-		$ws  = isset($parts[1]) && preg_match('/^\d{4}-\d{2}-\d{2}$/', $parts[1]) ? $parts[1] : null;
-		return array($kid, $ws);
-	}
+    // Parse "{id}" or "{id}/{week_start}" path tail.
+    private function _parse_kingdom_path($p)
+    {
+        if (empty($p)) {
+            return array(0, null);
+        }
+        $parts = explode('/', $p);
+        $kid = (int)preg_replace('/[^0-9]/', '', $parts[0]);
+        $ws  = isset($parts[1]) && preg_match('/^\d{4}-\d{2}-\d{2}$/', $parts[1]) ? $parts[1] : null;
+        return array($kid, $ws);
+    }
 
-	// Validate Y-m-d or default to last full week's Monday.
-	private function _normalize_week_start($week_start) {
-		if (!empty($week_start) && preg_match('/^\d{4}-\d{2}-\d{2}$/', $week_start)) {
-			return $week_start;
-		}
-		return date('Y-m-d', strtotime('-7 days', strtotime('monday this week')));
-	}
+    // Validate Y-m-d or default to last full week's Monday.
+    private function _normalize_week_start($week_start)
+    {
+        if (!empty($week_start) && preg_match('/^\d{4}-\d{2}-\d{2}$/', $week_start)) {
+            return $week_start;
+        }
+        return date('Y-m-d', strtotime('-7 days', strtotime('monday this week')));
+    }
 }

--- a/orkui/model/model.Recap.php
+++ b/orkui/model/model.Recap.php
@@ -1,36 +1,59 @@
 <?php
 
-class Model_Recap extends Model {
+class Model_Recap extends Model
+{
+    public function __construct()
+    {
+        parent::__construct();
+        $this->Report = new APIModel('Report');
+    }
 
-	function __construct() {
-		parent::__construct();
-		$this->Report = new APIModel('Report');
-	}
+    // Read a cached weekly recap. Returns the decoded payload or null if no row exists.
+    public function get($week_start = null)
+    {
+        $request = array();
+        if (!empty($week_start)) {
+            $request['WeekStart'] = $week_start;
+        }
+        return $this->Report->ReadWeeklyRecap($request);
+    }
 
-	// Read a cached weekly recap. Returns the decoded payload or null if no row exists.
-	function get($week_start = null) {
-		$request = array();
-		if (!empty($week_start)) $request['WeekStart'] = $week_start;
-		return $this->Report->ReadWeeklyRecap($request);
-	}
+    // Available week_starts in the recap table, newest first.
+    public function recent_weeks($limit = 26)
+    {
+        $r = $this->Report->ListRecapWeeks($limit);
+        return is_array($r) ? $r : array();
+    }
 
-	// Available week_starts in the recap table, newest first.
-	function recent_weeks($limit = 26) {
-		$r = $this->Report->ListRecapWeeks($limit);
-		return is_array($r) ? $r : array();
-	}
+    // Kingdom-scoped recap. Returns the decoded payload or null if the global
+    // recap for that week hasn't been computed yet.
+    public function get_for_kingdom($kingdom_id, $week_start = null)
+    {
+        $request = array('KingdomId' => (int)$kingdom_id);
+        if (!empty($week_start)) {
+            $request['WeekStart'] = $week_start;
+        }
+        return $this->Report->GetWeeklyRecapForKingdom($request);
+    }
 
-	// Kingdom-scoped recap. Returns the decoded payload or null if the global
-	// recap for that week hasn't been computed yet.
-	function get_for_kingdom($kingdom_id, $week_start = null) {
-		$request = array('KingdomId' => (int)$kingdom_id);
-		if (!empty($week_start)) $request['WeekStart'] = $week_start;
-		return $this->Report->GetWeeklyRecapForKingdom($request);
-	}
+    // Active kingdoms list for the dropdown picker.
+    public function kingdom_list()
+    {
+        $r = $this->Report->ListRecapKingdoms();
+        return is_array($r) ? $r : array();
+    }
 
-	// Active kingdoms list for the dropdown picker.
-	function kingdom_list() {
-		$r = $this->Report->ListRecapKingdoms();
-		return is_array($r) ? $r : array();
-	}
+    // Weekly headline numbers from every stored recap, for the trends charts.
+    public function trend_series()
+    {
+        $r = $this->Report->GetRecapTrendSeries();
+        return is_array($r) ? $r : array();
+    }
+
+    // Distinct attending players per week across all history (24h-cached upstream).
+    public function weekly_active_players()
+    {
+        $r = $this->Report->GetWeeklyActivePlayersSeries();
+        return is_array($r) ? $r : array();
+    }
 }

--- a/orkui/template/default/Recap_index.tpl
+++ b/orkui/template/default/Recap_index.tpl
@@ -595,7 +595,8 @@ html[data-theme="dark"] .recap-foot a { color: #6b7280; }
 
 	<div class="recap-foot">
 		Computed <?=htmlspecialchars($recap['ComputedAt'] ?? '')?> ·
-		<a href="<?=UIR ?><?=$url_json?><?=urlencode($recap['WeekStart'])?>">JSON</a>
+		<a href="<?=UIR ?><?=$url_json?><?=urlencode($recap['WeekStart'])?>">JSON</a> ·
+		<a href="<?=UIR ?>Recap/trends">Trends</a>
 	</div>
 
 <?php endif; // $has_recap ?>

--- a/orkui/template/default/Recap_trends.tpl
+++ b/orkui/template/default/Recap_trends.tpl
@@ -1,0 +1,236 @@
+<?php
+/* Amtgard Platform Trends — public, read-only charts over the accumulated
+ * weekly recap data plus the all-history attendance curve.
+ *
+ * $trend_series   : rows of WeekStart/Visitors/Requests/Blocked/CacheHits/Bytes
+ *                   (nulls where a source wasn't available — charts show gaps).
+ * $players_series : rows of WeekStart/Players across all recorded history.
+ */
+
+$_ts  = is_array($trend_series)   ? $trend_series   : array();
+$_ps  = is_array($players_series) ? $players_series : array();
+
+// Highcharts datetime series: [ms, value|null]. INTERIOR gaps stay gaps — the
+// honest rendering for "we don't trust / don't have data for this week" — but
+// leading/trailing all-null stretches are trimmed so a source that only exists
+// for part of the archive doesn't pad its chart with empty axis.
+$_trim = function ($points) {
+	$first = null; $last = null;
+	foreach ($points as $i => $p) {
+		if ($p[1] !== null) { if ($first === null) $first = $i; $last = $i; }
+	}
+	return $first === null ? array() : array_slice($points, $first, $last - $first + 1);
+};
+
+$_visitors = array();
+$_requests = array();
+$_blocked  = array();
+foreach ($_ts as $_row) {
+	$_ms = strtotime($_row['WeekStart']);
+	if ($_ms === false) continue;
+	$_ms *= 1000;
+	$_visitors[] = array($_ms, $_row['Visitors']);
+	$_requests[] = array($_ms, $_row['Requests']);
+	$_blocked[]  = array($_ms, $_row['Blocked']);
+}
+$_visitors = $_trim($_visitors);
+$_requests = $_trim($_requests);
+$_blocked  = $_trim($_blocked);
+
+$_players = array();
+foreach ($_ps as $_row) {
+	// Guard against unparseable week buckets from garbage historical dates.
+	$_ms = strtotime((string)$_row['WeekStart']);
+	if ($_ms === false || $_ms < strtotime('2004-12-01')) continue;
+	$_players[] = array($_ms * 1000, $_row['Players']);
+}
+
+$_fmt = function ($n) {
+	if ($n === null) return '—';
+	if ($n >= 1000000) return round($n / 1000000, 1) . 'M';
+	if ($n >= 1000)    return round($n / 1000, 1) . 'K';
+	return (string)$n;
+};
+?>
+<style>
+.recap-root { max-width: 900px; margin: 1.5em auto 3em; padding: 0 1em;
+	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+	color: #222; line-height: 1.5; }
+.recap-root h1, .recap-root h2 { background: transparent; border: none;
+	text-shadow: none; padding: 0; border-radius: 0; }
+.recap-hero { text-align: center; padding: 1.5em 0 1.8em; margin-bottom: 1.5em;
+	border-bottom: 2px solid #f0e5d0; }
+.recap-hero-eyebrow { color: #c89b3f; font-size: 0.78em; letter-spacing: 0.22em;
+	text-transform: uppercase; font-weight: 700; margin-bottom: 0.4em; }
+.recap-hero-eyebrow .fas { margin-right: 0.4em; }
+.recap-hero h1 { font-size: 1.65em; margin: 0; font-weight: 600; color: #2a2a2a; }
+.recap-hero-sub { color: #999; font-size: 0.82em; margin-top: 0.7em; font-style: italic; }
+.recap-section { background: #fafaf7; border: 1px solid #ececec;
+	border-radius: 10px; padding: 1.1em 1.4em 1em; margin-bottom: 1em; }
+.recap-section h2 { font-size: 1.08em; margin: 0 0 0.6em 0; color: #2a2a2a;
+	font-weight: 600; display: flex; align-items: center; gap: 0.55em; }
+.recap-section h2 .recap-section-icon { width: 1.6em; height: 1.6em; display: inline-flex;
+	align-items: center; justify-content: center; border-radius: 50%; background: #f0e5d0;
+	color: #a07d2a; font-size: 0.78em; flex-shrink: 0; }
+.recap-digest { margin: 0.2em 0 0.6em; color: #3a3a3a; line-height: 1.55; }
+.recap-muted { color: #888; font-size: 0.9em; }
+.trends-chart { width: 100%; height: 280px; }
+.recap-section details { margin-top: 0.7em; padding-top: 0.4em; border-top: 1px dashed #e0d9c2; }
+.recap-section details summary { cursor: pointer; color: #888; font-size: 0.88em;
+	padding: 0.2em 0; user-select: none; list-style: none; }
+.recap-section details summary::-webkit-details-marker { display: none; }
+.recap-section details summary::before { content: '▸ '; color: #c89b3f; font-size: 0.9em; }
+.recap-section details[open] summary::before { content: '▾ '; }
+.trends-table { width: 100%; border-collapse: collapse; font-size: 0.85em; margin-top: 0.5em; }
+.trends-table th, .trends-table td { text-align: right; padding: 3px 8px; border-bottom: 1px solid #eee9dc; }
+.trends-table th:first-child, .trends-table td:first-child { text-align: left; }
+.trends-table th { color: #888; font-weight: 600; }
+.recap-foot { text-align: center; color: #aaa; font-size: 0.8em; margin-top: 1.5em; }
+.recap-foot a { color: #1a4c8c; text-decoration: none; }
+.recap-foot a:hover { text-decoration: underline; }
+
+html[data-theme="dark"] .recap-root { color: #cbd5e0; }
+html[data-theme="dark"] .recap-hero { border-bottom-color: #3a3325; }
+html[data-theme="dark"] .recap-hero h1 { color: #e2e8f0; }
+html[data-theme="dark"] .recap-section { background: #1e2533; border-color: #2d3748; }
+html[data-theme="dark"] .recap-section h2 { color: #e2e8f0; }
+html[data-theme="dark"] .recap-section h2 .recap-section-icon { background: #3a3325; color: #c89b3f; }
+html[data-theme="dark"] .recap-digest { color: #cbd5e0; }
+html[data-theme="dark"] .recap-section details { border-top-color: #3a4356; }
+html[data-theme="dark"] .trends-table th, html[data-theme="dark"] .trends-table td { border-bottom-color: #2d3748; }
+</style>
+
+<div class="recap-root">
+	<div class="recap-hero">
+		<div class="recap-hero-eyebrow"><i class="fas fa-chart-line"></i>Amtgard ORK</div>
+		<h1>Platform Trends</h1>
+		<div class="recap-hero-sub">
+			How many people use the ORK and play the game, week over week.
+			Gaps mean a source wasn't available (or wasn't trusted) that week.
+		</div>
+	</div>
+
+	<section class="recap-section">
+		<h2><span class="recap-section-icon"><i class="fas fa-users"></i></span> People visiting the ORK</h2>
+		<p class="recap-digest recap-muted">
+			Unique weekly visitors measured by Google Analytics — real browsers only; bots are excluded.
+		</p>
+		<div id="trends-visitors" class="trends-chart"></div>
+		<details><summary>Data table</summary>
+			<table class="trends-table"><tr><th>Week</th><th>Visitors</th></tr>
+<?php foreach (array_reverse($_ts) as $_row) : if ($_row['Visitors'] === null) continue; ?>
+				<tr><td><?=htmlspecialchars($_row['WeekStart'])?></td><td><?=number_format($_row['Visitors'])?></td></tr>
+<?php endforeach; ?>
+			</table>
+		</details>
+	</section>
+
+	<section class="recap-section">
+		<h2><span class="recap-section-icon"><i class="fas fa-fist-raised"></i></span> Players on the field</h2>
+		<p class="recap-digest recap-muted">
+			Distinct players credited with attendance each week, across all recorded ORK history.
+		</p>
+		<div id="trends-players" class="trends-chart"></div>
+		<details><summary>Data table (recent year)</summary>
+			<table class="trends-table"><tr><th>Week</th><th>Players</th></tr>
+<?php foreach (array_slice(array_reverse($_ps), 0, 52) as $_row) : ?>
+				<tr><td><?=htmlspecialchars($_row['WeekStart'])?></td><td><?=number_format($_row['Players'])?></td></tr>
+<?php endforeach; ?>
+			</table>
+		</details>
+	</section>
+
+	<section class="recap-section">
+		<h2><span class="recap-section-icon"><i class="fas fa-globe-americas"></i></span> Traffic and the bot wall</h2>
+		<p class="recap-digest recap-muted">
+			Weekly requests Cloudflare delivered for the ORK (US + Canada), and the requests it
+			blocked or challenged as malicious before they reached the site.
+		</p>
+		<div id="trends-requests" class="trends-chart"></div>
+		<details><summary>Data table</summary>
+			<table class="trends-table"><tr><th>Week</th><th>Delivered</th><th>Blocked</th></tr>
+<?php foreach (array_reverse($_ts) as $_row) : if ($_row['Requests'] === null) continue; ?>
+				<tr><td><?=htmlspecialchars($_row['WeekStart'])?></td><td><?=$_fmt($_row['Requests'])?></td><td><?=$_fmt($_row['Blocked'])?></td></tr>
+<?php endforeach; ?>
+			</table>
+		</details>
+	</section>
+
+	<div class="recap-foot">
+		Built from the <a href="<?=UIR?>Recap">Week in Review</a> archive · updates daily
+	</div>
+</div>
+
+<script>
+jQuery(document).ready(function() {
+	if (typeof Highcharts === 'undefined') return;
+
+	var VISITORS = <?=json_encode($_visitors)?>;
+	var PLAYERS  = <?=json_encode($_players)?>;
+	var REQUESTS = <?=json_encode($_requests)?>;
+	var BLOCKED  = <?=json_encode($_blocked)?>;
+
+	function palette() {
+		var dk = document.documentElement.getAttribute('data-theme') === 'dark';
+		return {
+			dk:      dk,
+			blue:    dk ? '#3987e5' : '#2a78d6',
+			orange:  dk ? '#d95926' : '#eb6834',
+			text:    dk ? '#cbd5e0' : '#333',
+			muted:   dk ? '#a0aec0' : '#666',
+			grid:    dk ? '#2d3748' : '#e6e6e6',
+			line:    dk ? '#4a5568' : '#ccd6eb',
+			tipBg:   dk ? '#1a2035' : '#fff',
+			tipText: dk ? '#f1f5f9' : '#333'
+		};
+	}
+
+	function baseOptions(renderTo, p) {
+		return {
+			chart: { renderTo: renderTo, type: 'line', backgroundColor: 'transparent',
+				style: { fontFamily: 'inherit' }, zoomType: 'x' },
+			title: { text: null },
+			credits: { enabled: false },
+			xAxis: { type: 'datetime',
+				labels: { style: { fontSize: '11px', color: p.muted } },
+				lineColor: p.line, tickColor: p.line,
+				crosshair: { color: p.grid } },
+			yAxis: { title: { text: null }, min: 0,
+				labels: { style: { color: p.muted } }, gridLineColor: p.grid },
+			tooltip: { shared: true, xDateFormat: 'Week of %b %e, %Y',
+				backgroundColor: p.tipBg, borderColor: p.line,
+				style: { color: p.tipText, fontWeight: 'normal' } },
+			plotOptions: { line: { lineWidth: 2, marker: { enabled: false, radius: 4,
+				states: { hover: { enabled: true } } } } }
+		};
+	}
+
+	var charts = [];
+	function build() {
+		while (charts.length) { charts.pop().destroy(); }
+		var p = palette();
+
+		var o1 = baseOptions('trends-visitors', p);
+		o1.legend = { enabled: false };
+		o1.series = [{ name: 'Visitors', data: VISITORS, color: p.blue }];
+		charts.push(new Highcharts.Chart(o1));
+
+		var o2 = baseOptions('trends-players', p);
+		o2.legend = { enabled: false };
+		o2.series = [{ name: 'Players', data: PLAYERS, color: p.blue }];
+		charts.push(new Highcharts.Chart(o2));
+
+		var o3 = baseOptions('trends-requests', p);
+		o3.legend = { enabled: true, itemStyle: { color: p.text, fontWeight: 'normal' },
+			itemHoverStyle: { color: p.text } };
+		o3.series = [
+			{ name: 'Delivered', data: REQUESTS, color: p.blue },
+			{ name: 'Blocked or challenged', data: BLOCKED, color: p.orange }
+		];
+		charts.push(new Highcharts.Chart(o3));
+	}
+
+	build();
+	new MutationObserver(build).observe(document.documentElement, { attributeFilter: ['data-theme'] });
+});
+</script>

--- a/system/lib/ork3/class.Report.php
+++ b/system/lib/ork3/class.Report.php
@@ -4232,6 +4232,87 @@ class Report extends Ork3
         return $payload;
     }
 
+    /**
+     * Weekly platform trend series for the public Recap/trends page: one entry
+     * per stored recap week with just the headline numbers, extracted from
+     * payload_json in SQL — the full payloads also carry peerage/event lists
+     * that a trends page has no business shipping.
+     *
+     * Values are null for weeks where a source wasn't available (GA not yet
+     * installed, CF beyond retention, deliberately blanked bot-wave weeks) —
+     * the chart renders those as gaps, which is the honest presentation.
+     *
+     * Cached 1h: the underlying table changes once a day (the 6am cron).
+     */
+    public function GetRecapTrendSeries()
+    {
+        $key = Ork3::$Lib->ghettocache->key(array('recap-trend-series'));
+        if (($cache = Ork3::$Lib->ghettocache->get(__CLASS__ . '.' . __FUNCTION__, $key, 3600)) !== false) {
+            return $cache;
+        }
+        $sql = "SELECT week_start,
+					   JSON_EXTRACT(payload_json, '$.HumanUsers')                        AS visitors,
+					   JSON_EXTRACT(payload_json, '$.PlatformStats.Requests')            AS requests,
+					   JSON_EXTRACT(payload_json, '$.PlatformStats.BlockedOrChallenged') AS blocked,
+					   JSON_EXTRACT(payload_json, '$.PlatformStats.CacheHits')           AS cache_hits,
+					   JSON_EXTRACT(payload_json, '$.PlatformStats.Bytes')               AS bytes
+				FROM " . DB_PREFIX . "weekly_recap
+				ORDER BY week_start";
+        $r = $this->db->query($sql);
+        $out = array();
+        if ($r !== false && $r->size() > 0) {
+            while ($r->next()) {
+                // JSON_EXTRACT yields the string 'null' for JSON null and PHP
+                // null for a missing key; is_numeric() folds both to null here.
+                $out[] = array(
+                    'WeekStart' => $r->week_start,
+                    'Visitors'  => is_numeric($r->visitors) ? (int)$r->visitors : null,
+                    'Requests'  => is_numeric($r->requests) ? (int)$r->requests : null,
+                    'Blocked'   => is_numeric($r->blocked) ? (int)$r->blocked : null,
+                    'CacheHits' => is_numeric($r->cache_hits) ? (int)$r->cache_hits : null,
+                    'Bytes'     => is_numeric($r->bytes) ? (float)$r->bytes : null,
+                );
+            }
+        }
+        return Ork3::$Lib->ghettocache->cache(__CLASS__ . '.' . __FUNCTION__, $key, $out);
+    }
+
+    /**
+     * Distinct players credited with attendance per week (Monday-anchored,
+     * matching the recap window), across all recorded history — the long
+     * participation curve of the game itself, independent of web analytics.
+     *
+     * This is the expensive one (full aggregation over ork_attendance, ~2s),
+     * so it carries a 24h ghettocache: attendance only ever moves the current
+     * week, and a day of staleness on a decades-long chart is invisible.
+     */
+    public function GetWeeklyActivePlayersSeries()
+    {
+        $key = Ork3::$Lib->ghettocache->key(array('weekly-active-players'));
+        if (($cache = Ork3::$Lib->ghettocache->get(__CLASS__ . '.' . __FUNCTION__, $key, 86400)) !== false) {
+            return $cache;
+        }
+        // Date guards drop the stray garbage rows (far-future/ancient dates)
+        // that two decades of hand-entered data inevitably contain.
+        $sql = "SELECT DATE_SUB(date, INTERVAL WEEKDAY(date) DAY) AS wk,
+					   COUNT(DISTINCT mundane_id) AS players
+				FROM " . DB_PREFIX . "attendance
+				WHERE date >= '2005-01-01' AND date <= CURDATE()
+				GROUP BY wk
+				ORDER BY wk";
+        $r = $this->db->query($sql);
+        $out = array();
+        if ($r !== false && $r->size() > 0) {
+            while ($r->next()) {
+                $out[] = array(
+                    'WeekStart' => $r->wk,
+                    'Players'   => (int)$r->players,
+                );
+            }
+        }
+        return Ork3::$Lib->ghettocache->cache(__CLASS__ . '.' . __FUNCTION__, $key, $out);
+    }
+
     // Fetches NA-only Cloudflare traffic totals for the week. Returns null on any
     // failure (missing credentials, HTTP error, malformed response, timeout) so the
     // rest of the recap still ships. CF retains ~30-90 days of analytics depending

--- a/tools/fuzzy-validator/manifests/pages.json5
+++ b/tools/fuzzy-validator/manifests/pages.json5
@@ -1599,6 +1599,15 @@
       "notes": "Registry expansion \u2014 template Recap/kingdom"
     },
     {
+      "id": "recap-trends",
+      "url": "./index.php?Route=Recap/trends",
+      "auth": "login",
+      "waitAfterMs": 1500,
+      "readySelector": "#trends-visitors, body",
+      "driftClass": "natural",
+      "notes": "Platform Trends charts (Highcharts canvases move with weekly data \u2014 expect pixel fuzz zones over the three chart divs)."
+    },
+    {
       "id": "recap-kingdom-2",
       "url": "./index.php?Route=Recap/kingdom/1",
       "auth": "login",


### PR DESCRIPTION
## Summary

A charts page answering the standing question **"how many people use the ORK?"** over time, built entirely from data we already accumulate — no new crons, no schema changes, no new dependencies.

**`Recap/trends`** (linked from the Week in Review footer, same login gate as the rest of the recap):

1. **People visiting the ORK** — weekly unique human visitors (GA4 `HumanUsers` from the recap archive). Weeks where the source was absent or distrusted render as **gaps**, not zeros — including the deliberately-blanked Oct–Nov 2025 bot-wave weeks.
2. **Players on the field** — distinct players credited with attendance per week, across all recorded history (Dec 2004 →). The participation curve of the game itself, independent of web analytics.
3. **Traffic and the bot wall** — Cloudflare delivered vs blocked/challenged requests, week over week.

## Mechanics

- `Report::GetRecapTrendSeries()` — headline numbers `JSON_EXTRACT`ed in SQL from `ork_weekly_recap` (the full payloads, which carry peerage lists etc., never leave the server). **Ghettocached 1h.**
- `Report::GetWeeklyActivePlayersSeries()` — the heavy one: ~2s aggregation over all of `ork_attendance`. **Ghettocached 24h**; a day of staleness on a 20-year chart is invisible. Garbage historical dates guarded out.
- Steady-state page load = two cache reads.
- Charts use the bundled Highcharts with the house pattern (transparent background, theme-aware colors, full rebuild on `data-theme` flips). Palette follows a validated categorical order (blue/orange, CVD-checked in both modes). Leading/trailing all-null stretches are trimmed per series so a source that only exists for part of the archive (CF ≈ 14 weeks, GA ≈ Jun 2025→) doesn't pad its chart with empty axis; interior gaps stay gaps.
- Each chart has a collapsible data table.
- Fuzzy-validator registry entry included (`recap-trends`, natural drift — the canvases move weekly).

## Verified

- Rendered and eyeballed in light and dark themes against mirror data (playwright screenshots): three charts, gaps where expected, legend/axes legible in both modes.
- Series sanity: visitors max ~8.1K (bot weeks blanked), players 1,130 weekly points from 2004-12-27 peaking ~4.4K, CF series trimmed to its real 14-week span.
- 367/367 tests pass; php-cs-fixer clean (it also reformatted the two touched recap files to house style — that's the bulk of the deletions in the diff).

🤖 Generated with [Claude Code](https://claude.com/claude-code)