### PR TITLE
Bugfix: double scrollbar on every long page

### DIFF
--- a/orkui/template/default/style/orkui.css
+++ b/orkui/template/default/style/orkui.css
@@ -729,7 +729,6 @@ button.ui-button::-moz-focus-inner { border: 0; padding: 0; } /* reset extra pad
    Application Base — body, html, h1-h6, links, #theme_container
    ========================================================================== */
 html, body {
-    height: 100%;
     /* Guard against horizontal overflow from any descendant. Without this, an
        element wider than the viewport makes the page scroll sideways, and on
        Android Chrome a position:fixed; width:100% bar (#newmenu) then spans the
@@ -739,6 +738,17 @@ html, body {
        fixed nav pinned to the device width on every platform. */
     overflow-x: hidden;
     max-width: 100%;
+}
+html {
+    height: 100%;
+}
+body {
+    /* min-height, NOT height: overflow-x:hidden above forces overflow-y from
+       visible to auto, so a body capped at 100% becomes its own scroll
+       container and the page shows two scrollbars (body's plus the html
+       element's). Letting the body grow with its content keeps the single
+       viewport scrollbar. */
+    min-height: 100%;
 }
 body {
     /*


### PR DESCRIPTION
**Reported** (Discord, screenshot of a player About page): two scrollbars on the right edge.

**Root cause:** `orkui.css` sets `html, body { height: 100%; overflow-x: hidden }`. Per CSS, hiding overflow on one axis forces the other axis from `visible` to `auto` — so the viewport-height-capped body became its own scroll container with its own scrollbar, and the html element grew a second one for the body's margins. Site-wide on every page taller than the viewport.

The `height: 100%` has been there since 2024 and was harmless alone; the bug was born when the Android fixed-nav clamp added `overflow-x: hidden` (`0f76394d`, 2026-05-21). It went unnoticed for three months because macOS overlay scrollbars hide it — classic Windows scrollbars (the reporter's platform) show both bars.

**Fix:** `body` uses `min-height: 100%` instead of `height: 100%`, so it grows with its content and only the viewport scrolls. `html` keeps `height: 100%` (so the body's percentage min-height resolves) and the horizontal clamp is untouched — the Android fixed-nav fix this rule exists for still works.

**Verified** (Playwright, prod-mirror data): the reported player About page plus home, kingdom, and event pages — body no longer scrollable, single viewport scrollbar, no horizontal scroll, layout unchanged in light and dark themes. Only jQuery-UI widget internals use `height:100%` elsewhere, all inside their own positioned containers, unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)