### PR TITLE
Staging ORK stack on the shared applications instance

### DIFF
--- a/config.dev.php
+++ b/config.dev.php
@@ -9,14 +9,21 @@ ini_set('display_errors', '1');
 // HTTP
 define('ORK_DIST_NAME', '');
 
-define('HTTP_SERVICE', 'http://' . $_SERVER['HTTP_HOST'] . '/orkservice/');
-define('HTTP_UI', 'http://' . $_SERVER['HTTP_HOST'] . '/orkui/');
-define('HTTP_UI_REMOTE', 'http://' . $_SERVER['HTTP_HOST'] . '/orkui/');
+// Scheme-aware so the same dev config serves plain-http localhost AND the
+// TLS-terminated staging host (Cloudflare/nginx set X-Forwarded-Proto);
+// hardcoded http:// there would put http links, og:url and canonicals on
+// an https page.
+$_scheme = (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off')
+    || (($_SERVER['HTTP_X_FORWARDED_PROTO'] ?? '') === 'https') ? 'https' : 'http';
+
+define('HTTP_SERVICE', $_scheme . '://' . $_SERVER['HTTP_HOST'] . '/orkservice/');
+define('HTTP_UI', $_scheme . '://' . $_SERVER['HTTP_HOST'] . '/orkui/');
+define('HTTP_UI_REMOTE', $_scheme . '://' . $_SERVER['HTTP_HOST'] . '/orkui/');
 define('HTTP_TEMPLATE', HTTP_UI . 'template/');
-define('HTTP_ASSETS', 'http://' . $_SERVER['HTTP_HOST'] . '/assets/');
-define('HTTP_WAIVERS', 'http://' . $_SERVER['HTTP_HOST'] . '/assets/waivers/');
-define('HTTP_HERALDRY', 'http://' . $_SERVER['HTTP_HOST'] . '/assets/heraldry/');
-define('HTTP_PLAYER_IMAGE', 'http://' . $_SERVER['HTTP_HOST'] . '/assets/players/');
+define('HTTP_ASSETS', $_scheme . '://' . $_SERVER['HTTP_HOST'] . '/assets/');
+define('HTTP_WAIVERS', $_scheme . '://' . $_SERVER['HTTP_HOST'] . '/assets/waivers/');
+define('HTTP_HERALDRY', $_scheme . '://' . $_SERVER['HTTP_HOST'] . '/assets/heraldry/');
+define('HTTP_PLAYER_IMAGE', $_scheme . '://' . $_SERVER['HTTP_HOST'] . '/assets/players/');
 define('HTTP_PLAYER_HERALDRY', HTTP_HERALDRY . 'player/');
 define('HTTP_PARK_HERALDRY', HTTP_HERALDRY . 'park/');
 define('HTTP_KINGDOM_HERALDRY', HTTP_HERALDRY . 'kingdom/');
@@ -90,17 +97,20 @@ if (is_readable($ork3DbProfileFile)) {
 
 $ork3DbProfile = getenv('ORK3_DB_PROFILE') ?: 'prod';
 
+// Env-overridable so the same config serves a local checkout (defaults
+// match docker-compose.php8.yml) and the staging stack (real password,
+// ork3-stage-* container names — see docker-compose.staging.yml).
 define('DB_DRIVER', 'mysql');
-define('DB_USERNAME', 'ork');
-define('DB_PASSWORD', 'secret');
+define('DB_USERNAME', getenv('ORK3_DB_USER') ?: 'ork');
+define('DB_PASSWORD', getenv('ORK3_DB_PASSWORD') ?: 'secret');
 define('DB_PREFIX', 'ork_');
 
 if ($ork3DbProfile === 'dev') {
     define('DB_HOSTNAME', 'ork3-php8-test-db');
     define('DB_DATABASE', 'ork_test');
 } else {
-    define('DB_HOSTNAME', 'ork3-php8-db');
-    define('DB_DATABASE', 'ork');
+    define('DB_HOSTNAME', getenv('ORK3_DB_HOST') ?: 'ork3-php8-db');
+    define('DB_DATABASE', getenv('ORK3_DB_DATABASE') ?: 'ork');
 }
 define('CACHE_HOST', 'ork-dev');
 define('CUSTOM_CSS', HTTP_TEMPLATE . 'default/style/custom.css');

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -1,0 +1,52 @@
+# Staging ORK stack for the shared AWS "applications" instance.
+#
+# Deliberately dev-shaped (ENVIRONMENT=DEV -> config.dev.php): bind-mounted
+# repo so deploys are `git pull` + restart-when-needed, seed data restored by
+# hand, migrations applied by hand — the same ritual as a local checkout.
+#
+# Isolation rules for the shared box (wiki/play/go/idp also live there):
+#   - every name (containers, volumes, network) is ork3-stage-* — nothing
+#     collides with, or is ever `docker compose down`-ed out from under,
+#     another app's stack;
+#   - ports bind to 127.0.0.1 only: the app is reachable solely through the
+#     host nginx vhost (which Cloudflare Access gates), the DB solely from a
+#     shell on the instance. Nothing here listens on the public interface.
+#
+# Bring-up:  docker compose -f docker-compose.staging.yml up -d --build
+# (needs a .stage.env next to it; see staging/README.md)
+
+services:
+  ork3app:
+    build:
+      context: ./
+      dockerfile: Dockerfile.nginx-php8
+    ports:
+      - '127.0.0.1:41080:80'
+    working_dir: /var/www
+    volumes:
+      - .:/var/www/ork.amtgard.com
+    env_file: .stage.env
+    environment:
+      - ENVIRONMENT=DEV
+    restart: unless-stopped
+    container_name: ork3-stage-app
+    networks:
+      - ork3-stage-net
+  ork3db:
+    image: mariadb:11
+    command: --sql-mode=''
+    restart: unless-stopped
+    env_file: .stage.env
+    ports:
+      - '127.0.0.1:41306:3306'
+    volumes:
+      - ork3-stage-db-data:/var/lib/mysql
+    container_name: ork3-stage-db
+    networks:
+      - ork3-stage-net
+
+volumes:
+  ork3-stage-db-data: {}
+
+networks:
+  ork3-stage-net:

--- a/heartbeat.sh
+++ b/heartbeat.sh
@@ -1,4 +1,17 @@
-#/bin/sh
+#!/bin/sh
+
+# Pass deployment-specific container env through to php-fpm. The sysv
+# `service` wrapper below scrubs the environment before starting the fpm
+# master, so the pool's clear_env=no has nothing to inherit (ENVIRONMENT
+# only reaches PHP because the image bakes env[ENVIRONMENT] into the pool
+# config). This script IS started with the container env, so materialize
+# the vars into the pool config here. No-op when none are set (local dev);
+# idempotent across container restarts (delete-then-append).
+POOL=/etc/php/8.1/fpm/pool.d/www.conf
+sed -i '/^env\[ORK3_/d; /^env\[CF_/d' "$POOL"
+for v in ORK3_DB_HOST ORK3_DB_USER ORK3_DB_PASSWORD ORK3_DB_DATABASE ORK3_DB_PROFILE CF_API_TOKEN CF_ZONE_ID; do
+	val=$(printenv "$v") && echo "env[$v] = \"$val\"" >> "$POOL"
+done
 
 /usr/sbin/service nginx start
 /usr/sbin/service php8.1-fpm start

--- a/orkui/template/default/default.theme
+++ b/orkui/template/default/default.theme
@@ -11,7 +11,18 @@
 		'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
 		})(window,document,'script','dataLayer','GTM-5HZHGSLT');</script>
 		<!-- End Google Tag Manager -->
-		<title><?php echo (strlen($page_title)>0?"ORK 3: ":"ORK 3").ucwords($page_title); ?></title>
+<?php
+// Non-prod indicator (title prefix + banner below the nav). PROD renders
+// nothing; the staging host gets STAGING, everything else DEV/TEST — so a
+// prod tab and a staging tab are never mistaken for each other.
+$ork_env_label = '';
+if (getenv('ENVIRONMENT') !== 'PROD') {
+	$ork_env_label = (($_SERVER['HTTP_HOST'] ?? '') === 'staging.amtgard.com')
+		? 'STAGING'
+		: (getenv('ENVIRONMENT') === 'TEST' ? 'TEST' : 'DEV');
+}
+?>
+		<title><?php echo ($ork_env_label !== '' ? "[{$ork_env_label}] " : '').(strlen($page_title)>0?"ORK 3: ":"ORK 3").ucwords($page_title); ?></title>
 		<link rel="icon" type="image/png" sizes="32x32" href="<?= HTTP_ASSETS ?>images/favicon-32x32.png">
 		<link rel="icon" type="image/png" sizes="16x16" href="<?= HTTP_ASSETS ?>images/favicon-16x16.png">
 		<link rel="apple-touch-icon" sizes="180x180" href="<?= HTTP_ASSETS ?>images/favicon-180x180.png">
@@ -163,6 +174,11 @@ $downtime_note  = 'Potential Downtime for an upgrade';
 // -----------------------------------------------------------------------
 ?>
 		<div id='theme_container'>
+<?php if ($ork_env_label !== ''): ?>
+		<div id="ork-env-banner" style="background:<?= $ork_env_label === 'STAGING' ? '#6d28d9' : '#0f766e' ?>;color:#fff;text-align:center;padding:5px 12px;font-size:0.78rem;font-weight:700;letter-spacing:0.06em;">
+			<i class="fas fa-flask" style="margin-right:6px;opacity:0.85"></i><?= $ork_env_label ?> &mdash; test copy of the ORK; nothing here affects the real site
+		</div>
+<?php endif; ?>
 <?php if (!empty($downtime_start)): ?>
 		<div id="nav-maintenance-mobile" style="display:none;background:#92400e;color:#fff;text-align:center;padding:6px 12px;font-size:0.8rem;font-weight:600;cursor:pointer;" onclick="(function(){var d=document.getElementById('nm-mobile-detail');d.style.display=d.style.display==='none'?'block':'none';})()" >
 			<i class="fas fa-tools" style="margin-right:5px"></i>Scheduled Maintenance &nbsp;<i class="fas fa-info-circle" style="opacity:0.8"></i>

--- a/staging/README.md
+++ b/staging/README.md
@@ -3,9 +3,9 @@
 A dev-flavored ORK (`ENVIRONMENT=DEV` → `config.dev.php`) on the shared AWS
 `applications` box (t4g.medium arm64, Ubuntu 22.04 — same Graviton arch as the
 prod ORK host), living beside the wiki/play/go/idp stacks without touching
-them. Public name: **https://ork-staging.amtgard.com** (single-level subdomain
-on purpose — Cloudflare's universal cert doesn't cover two-level names like
-staging.ork.amtgard.com).
+them. Public name: **https://staging.amtgard.com** (single-level on purpose —
+Cloudflare's universal cert doesn't cover two-level names; the warning
+triangle on idp.dev.amtgard.com in the CF dash is that exact problem).
 
 **Operating rules** (Ken, 2026-08-24):
 - Nothing automated ever touches the staging DB — Ken restores seed backups
@@ -55,23 +55,31 @@ interface.
 sudo docker exec -i ork3-stage-db sh -c 'mariadb -u ork -p"$MARIADB_PASSWORD" ork' < seed-backup.sql
 ```
 
-### 3. Cloudflare (dash.cloudflare.com, amtgard.com zone)
+### 3. DNS + Cloudflare (matching the go/play/wiki pattern)
 
-1. **DNS**: A record `ork-staging` → 18.191.144.189, **proxied** (orange).
-2. **SSL/TLS mode** for the zone should already be Full — staging origin gets
-   its own certbot cert in step 4, so Full (strict) also works.
-3. **Zero Trust → Access → Applications → Add application** (self-hosted):
-   - Application domain: `ork-staging.amtgard.com`
+1. **Route 53** (`apps.amtgard.com` hosted zone, AWS console): A record
+   `staging.apps.amtgard.com` → 18.191.144.189 — the direct name, like the
+   siblings' `go.apps` / `play.apps`.
+2. **Cloudflare DNS** (amtgard.com zone): CNAME `staging` →
+   `staging.apps.amtgard.com`, **proxied** (orange) — exactly like the `go` /
+   `play` / `wiki` rows.
+3. **Origin cert**: SSL/TLS → Origin Server → Create Certificate, hostname
+   `staging.amtgard.com`, 15-year validity. Paste cert + key into
+   `/etc/ssl/ork-staging/` on the instance (see the vhost's install
+   comments). No certbot: its renewals would hit the Access wall.
+4. **Zero Trust → Access → Applications → Add application** (self-hosted):
+   - Application domain: `staging.amtgard.com`
    - Policy: Allow → Include → Emails → Ken + whoever else
    - Session duration: 1 week is comfortable.
-   Everyone else — humans and crawlers alike — is stopped at the edge and the
-   origin never sees them. No robots/noindex worry on top: unauthenticated
-   fetches can't reach the pages at all.
+   Everyone else — humans and crawlers alike — is stopped at the edge; the
+   origin never sees them, so no robots/noindex worry on top. The direct
+   Route 53 name is never proxied to the app: the vhost 301s it to the front
+   door.
 
-### 4. Host nginx vhost + cert (on the instance)
+### 4. Host nginx vhost (on the instance)
 
-Follow the install comments in `staging/nginx-ork-staging.conf` (cp, symlink,
-`nginx -t`, reload, then `certbot --nginx -d ork-staging.amtgard.com`).
+Follow the install comments in `staging/nginx-ork-staging.conf` (cert files,
+cp, symlink, `nginx -t`, reload).
 
 ## Routine operation
 

--- a/staging/README.md
+++ b/staging/README.md
@@ -1,0 +1,98 @@
+# Staging ORK on the "applications" instance
+
+A dev-flavored ORK (`ENVIRONMENT=DEV` → `config.dev.php`) on the shared AWS
+`applications` box (t4g.medium arm64, Ubuntu 22.04 — same Graviton arch as the
+prod ORK host), living beside the wiki/play/go/idp stacks without touching
+them. Public name: **https://ork-staging.amtgard.com** (single-level subdomain
+on purpose — Cloudflare's universal cert doesn't cover two-level names like
+staging.ork.amtgard.com).
+
+**Operating rules** (Ken, 2026-08-24):
+- Nothing automated ever touches the staging DB — Ken restores seed backups
+  by hand, exactly like a local install; the staging schema may deliberately
+  diverge (testing migrations before prod runs them).
+- Deploys are the local ritual: `git pull`, apply DB changes by hand when
+  needed, restart the app container when needed.
+- The instance is shared production for other apps: every server-side step
+  below is run deliberately (and `nginx -t` before any reload), never scripted
+  blind.
+
+## One-time bring-up
+
+### 1. On the instance (ssh apps-aws)
+
+```bash
+sudo git clone https://github.com/amtgard/ORK3.git /var/www/ork-staging   # or your fork/remote of choice
+cd /var/www/ork-staging
+git checkout master        # staging tracks master unless testing a branch
+
+# Secrets file (never committed). MARIADB_* configure the db container;
+# ORK3_DB_* point the app at it (config.dev.php reads them, falling back to
+# the local-dev defaults when unset).
+cat > .stage.env <<'EOF'
+MARIADB_DATABASE=ork
+MARIADB_USER=ork
+MARIADB_PASSWORD=<generate one>
+MARIADB_ROOT_PASSWORD=<generate another>
+ORK3_DB_HOST=ork3-stage-db
+ORK3_DB_USER=ork
+ORK3_DB_PASSWORD=<same as MARIADB_PASSWORD>
+EOF
+chmod 600 .stage.env
+
+sudo docker compose -f docker-compose.staging.yml up -d --build
+curl -s -o /dev/null -w '%{http_code}\n' http://127.0.0.1:41080/orkui/index.php?Route=   # expect 200/302
+```
+
+Port map (chosen clear of the neighbors' 21080/31080/32080/33080/37080-1):
+app `127.0.0.1:41080`, MariaDB `127.0.0.1:41306`. Nothing binds the public
+interface.
+
+### 2. Seed the database (by hand, like local)
+
+```bash
+# from the instance; backup file however you get it there (scp via apps-aws)
+sudo docker exec -i ork3-stage-db sh -c 'mariadb -u ork -p"$MARIADB_PASSWORD" ork' < seed-backup.sql
+```
+
+### 3. Cloudflare (dash.cloudflare.com, amtgard.com zone)
+
+1. **DNS**: A record `ork-staging` → 18.191.144.189, **proxied** (orange).
+2. **SSL/TLS mode** for the zone should already be Full — staging origin gets
+   its own certbot cert in step 4, so Full (strict) also works.
+3. **Zero Trust → Access → Applications → Add application** (self-hosted):
+   - Application domain: `ork-staging.amtgard.com`
+   - Policy: Allow → Include → Emails → Ken + whoever else
+   - Session duration: 1 week is comfortable.
+   Everyone else — humans and crawlers alike — is stopped at the edge and the
+   origin never sees them. No robots/noindex worry on top: unauthenticated
+   fetches can't reach the pages at all.
+
+### 4. Host nginx vhost + cert (on the instance)
+
+Follow the install comments in `staging/nginx-ork-staging.conf` (cp, symlink,
+`nginx -t`, reload, then `certbot --nginx -d ork-staging.amtgard.com`).
+
+## Routine operation
+
+```bash
+ssh apps-aws
+cd /var/www/ork-staging
+sudo git pull                                              # deploy
+sudo docker compose -f docker-compose.staging.yml restart ork3app   # when needed
+sudo docker exec -it ork3-stage-db sh -c 'mariadb -u ork -p"$MARIADB_PASSWORD" ork'  # SQL console
+sudo docker logs --tail 50 ork3-stage-app                  # app logs
+```
+
+Memcached lives inside the app container (same as prod): a container restart
+clears cache; a bare `git pull` does not (long-TTL ghettocache can serve
+pre-pull content — same trap as prod).
+
+## Deliberate differences from prod
+
+- Dev config: errors displayed, no CF analytics keys, empty API keys, cache
+  prefix `ork-dev`.
+- Seed data, restored manually; schema may be ahead of prod.
+- No sitemap submission, no crawler WAF skips, no OG cards reachable —
+  Access gates everything (link previews inside Discord will NOT unfurl for
+  staging links; that's the gate working).

--- a/staging/README.md
+++ b/staging/README.md
@@ -52,8 +52,28 @@ interface.
 
 ```bash
 # from the instance; backup file however you get it there (scp via apps-aws)
-sudo docker exec -i ork3-stage-db sh -c 'mariadb -u ork -p"$MARIADB_PASSWORD" ork' < seed-backup.sql
+awk 'BEGIN{print "SET autocommit=0;"} {print} NR%100000==0{print "COMMIT;"} END{print "COMMIT;"}' seed-backup.sql \
+  | sudo docker exec -i ork3-stage-db sh -c 'mariadb -u ork -p"$MARIADB_PASSWORD" ork'
 ```
+
+The awk wrapper matters: prod backups are single-row-INSERT dumps, so piping
+one straight into `mariadb` commits (and fsyncs) every row — a prod-size seed
+took ~28× longer that way (measured 2026-08-24: ~26 KB/s vs ~726 KB/s, an
+overnight import vs ~40 minutes). Batching 100k rows per COMMIT is the fix;
+the cap keeps any one transaction from bloating the undo log on the 4 GB box.
+On a dump that already uses multi-row INSERTs the wrapper is harmless.
+
+Optional extra headroom for the duration of an import (both revert on
+container restart; nothing pins them):
+
+```bash
+sudo docker exec -it ork3-stage-db sh -c 'mariadb -u root -p"$MARIADB_ROOT_PASSWORD" \
+  -e "SET GLOBAL innodb_flush_log_at_trx_commit = 2; SET GLOBAL innodb_buffer_pool_size = 1073741824"'
+```
+
+(The stock 128 MB buffer pool thrashes on `ork_attendance` secondary-index
+updates once the dataset outgrows it; 1 GB fits the working set and leaves
+plenty for the box's other tenants.)
 
 ### 3. DNS + Cloudflare (matching the go/play/wiki pattern)
 

--- a/staging/README.md
+++ b/staging/README.md
@@ -22,8 +22,8 @@ triangle on idp.dev.amtgard.com in the CF dash is that exact problem).
 ### 1. On the instance (ssh apps-aws)
 
 ```bash
-sudo git clone https://github.com/amtgard/ORK3.git /var/www/ork-staging   # or your fork/remote of choice
-cd /var/www/ork-staging
+git clone https://github.com/amtgard/ORK3.git /var/www/staging.amtgard.com   # or your fork/remote of choice
+cd /var/www/staging.amtgard.com
 git checkout master        # staging tracks master unless testing a branch
 
 # Secrets file (never committed). MARIADB_* configure the db container;
@@ -85,8 +85,8 @@ cp, symlink, `nginx -t`, reload).
 
 ```bash
 ssh apps-aws
-cd /var/www/ork-staging
-sudo git pull                                              # deploy
+cd /var/www/staging.amtgard.com
+git pull                                              # deploy
 sudo docker compose -f docker-compose.staging.yml restart ork3app   # when needed
 sudo docker exec -it ork3-stage-db sh -c 'mariadb -u ork -p"$MARIADB_PASSWORD" ork'  # SQL console
 sudo docker logs --tail 50 ork3-stage-app                  # app logs

--- a/staging/nginx-ork-staging.conf
+++ b/staging/nginx-ork-staging.conf
@@ -1,22 +1,37 @@
 # Host-nginx vhost for the staging ORK on the shared "applications" instance.
-# Same pattern as the wiki/play/go/idp vhosts: name-based routing on 80/443,
-# proxy to a localhost port owned by this app's docker stack (41080).
+# Same name-based routing as the wiki/play/go/idp vhosts, proxying to the
+# staging stack's localhost port (41080).
+#
+# DNS pattern (matches the siblings): Route 53 `apps.amtgard.com` zone holds
+# the direct name staging.apps.amtgard.com -> instance; Cloudflare holds
+# staging.amtgard.com as a PROXIED CNAME to it, with Cloudflare Access
+# (email allowlist) in front. Visitors only ever use staging.amtgard.com.
+#
+# TLS: a Cloudflare Origin CA cert (SSL/TLS -> Origin Server -> Create
+# Certificate; 15-year validity, no renewals) — NOT certbot, whose HTTP-01
+# renewals would hit the Access wall and fail every ~60 days. Origin CA is
+# only trusted by Cloudflare's proxy, which is the only client this vhost
+# will ever see on 443.
 #
 # Install (as reviewed steps, never blind):
-#   sudo cp staging/nginx-ork-staging.conf /etc/nginx/sites-available/ork-staging.amtgard.com
-#   sudo ln -s ../sites-available/ork-staging.amtgard.com /etc/nginx/sites-enabled/
+#   sudo mkdir -p /etc/ssl/ork-staging
+#   # paste the Origin CA cert + key from the CF dashboard:
+#   sudoedit /etc/ssl/ork-staging/cert.pem
+#   sudoedit /etc/ssl/ork-staging/key.pem && sudo chmod 600 /etc/ssl/ork-staging/key.pem
+#   sudo cp staging/nginx-ork-staging.conf /etc/nginx/sites-available/staging.amtgard.com
+#   sudo ln -s ../sites-available/staging.amtgard.com /etc/nginx/sites-enabled/
 #   sudo nginx -t          # MUST pass before any reload on this shared box
 #   sudo systemctl reload nginx
-#   sudo certbot --nginx -d ork-staging.amtgard.com   # adds the 443 block
-#
-# Access control is Cloudflare Access on the hostname (email allowlist), so
-# this vhost stays plain. The stack's ports bind to 127.0.0.1, so this proxy
-# is the only route in from outside the instance.
 
+# The real entrance: Cloudflare proxy -> here. Access has already vetted the
+# visitor by the time a request arrives.
 server {
-    listen 80;
-    listen [::]:80;
-    server_name ork-staging.amtgard.com;
+    listen 443 ssl;
+    listen [::]:443 ssl;
+    server_name staging.amtgard.com;
+
+    ssl_certificate     /etc/ssl/ork-staging/cert.pem;
+    ssl_certificate_key /etc/ssl/ork-staging/key.pem;
 
     # Player photos/heraldry uploads can be chunky.
     client_max_body_size 20m;
@@ -29,4 +44,13 @@ server {
         # config.dev.php builds link/og/canonical URLs from this.
         proxy_set_header X-Forwarded-Proto $scheme;
     }
+}
+
+# The direct Route 53 name and plain http: never serve the app here — that
+# would bypass Cloudflare Access. Send everything to the front door.
+server {
+    listen 80;
+    listen [::]:80;
+    server_name staging.amtgard.com staging.apps.amtgard.com;
+    return 301 https://staging.amtgard.com$request_uri;
 }

--- a/staging/nginx-ork-staging.conf
+++ b/staging/nginx-ork-staging.conf
@@ -1,0 +1,32 @@
+# Host-nginx vhost for the staging ORK on the shared "applications" instance.
+# Same pattern as the wiki/play/go/idp vhosts: name-based routing on 80/443,
+# proxy to a localhost port owned by this app's docker stack (41080).
+#
+# Install (as reviewed steps, never blind):
+#   sudo cp staging/nginx-ork-staging.conf /etc/nginx/sites-available/ork-staging.amtgard.com
+#   sudo ln -s ../sites-available/ork-staging.amtgard.com /etc/nginx/sites-enabled/
+#   sudo nginx -t          # MUST pass before any reload on this shared box
+#   sudo systemctl reload nginx
+#   sudo certbot --nginx -d ork-staging.amtgard.com   # adds the 443 block
+#
+# Access control is Cloudflare Access on the hostname (email allowlist), so
+# this vhost stays plain. The stack's ports bind to 127.0.0.1, so this proxy
+# is the only route in from outside the instance.
+
+server {
+    listen 80;
+    listen [::]:80;
+    server_name ork-staging.amtgard.com;
+
+    # Player photos/heraldry uploads can be chunky.
+    client_max_body_size 20m;
+
+    location / {
+        proxy_pass http://127.0.0.1:41080;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        # config.dev.php builds link/og/canonical URLs from this.
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}

--- a/staging/nginx-ork-staging.conf
+++ b/staging/nginx-ork-staging.conf
@@ -36,6 +36,12 @@ server {
     # Player photos/heraldry uploads can be chunky.
     client_max_body_size 20m;
 
+    # The dev image serves an empty page at the docroot; land bare-domain
+    # visits on the ORK like prod does.
+    location = / {
+        return 302 /orkui/index.php?Route=;
+    }
+
     location / {
         proxy_pass http://127.0.0.1:41080;
         proxy_set_header Host $host;


### PR DESCRIPTION
Stands up **https://staging.amtgard.com** — a dev-flavored ORK with a prod-size seed — on the shared AWS applications instance, plus the docs and UI affordances that make it safe to use.

## What's in here

- **Compose stack** (`docker-compose.staging.yml`): `ork3-stage-app` (127.0.0.1:41080) + `ork3-stage-db` (127.0.0.1:41306), loopback-only, secrets via untracked `.stage.env`.
- **Host nginx vhost** (`staging/nginx-ork-staging.conf`): 443→41080 with a Cloudflare Origin CA cert (no certbot — LE renewals would die at the Access wall); bare-domain requests redirect to the ORK entry path.
- **DNS/edge**: Route 53 `staging.apps` A record + proxied CF CNAME, Cloudflare Access gate (email allowlist + PIN) in front of everything.
- **`config.dev.php`**: reads `ORK3_DB_*` env (falls back to local-dev defaults); container env passthrough to php-fpm (sysv `service` scrubs env — heartbeat materializes it into the pool config).
- **Non-prod indicator**: purple STAGING / teal DEV banner under the nav plus a `[STAGING]`/`[DEV]` tab-title prefix whenever `ENVIRONMENT != PROD`; prod renders nothing.
- **README** (`staging/README.md`): full bring-up runbook, operating rules, and the fast seed-import recipe (single-row-INSERT prod dumps need COMMIT batching — measured 28× difference).

## Deployed state

The instance is already running this branch (built 2026-08-24): DB seeded from that morning's prod backup (82 tables, 3.6M attendance rows), heraldry/player assets synced, site verified through the Access gate. After merge, the instance checkout flips back to tracking master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)